### PR TITLE
Add scaffold_specs MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,44 @@ dotnet run --project src/DraftSpec.Mcp
 > **Security Note:** The MCP server executes arbitrary code from spec content via `dotnet run`. Only use in trusted
 > environments or within sandboxed containers with restricted permissions.
 
-Agents can generate and run specs with zero ceremony—just send `describe`/`it` blocks, get structured JSON results back.
-No boilerplate needed.
+**Tools:**
+
+| Tool | Description |
+|------|-------------|
+| `run_spec` | Execute spec code and return structured JSON results |
+| `scaffold_specs` | Generate pending specs from a structured description |
+
+**scaffold_specs** - Generate spec scaffolds for BDD (behavior-first) or characterisation (code-first) workflows:
+
+```json
+{
+  "description": "UserService",
+  "contexts": [
+    { "description": "Create", "specs": ["creates user", "hashes password"] },
+    { "description": "GetById", "specs": ["returns user when found", "returns null when not found"] }
+  ]
+}
+```
+
+Output:
+```csharp
+describe("UserService", () =>
+{
+    describe("Create", () =>
+    {
+        it("creates user");
+        it("hashes password");
+    });
+
+    describe("GetById", () =>
+    {
+        it("returns user when found");
+        it("returns null when not found");
+    });
+});
+```
+
+Agents can scaffold specs, then fill in assertions using `run_spec` to verify.
 
 ### Middleware & Plugins
 

--- a/src/DraftSpec.Mcp/Models/ScaffoldNode.cs
+++ b/src/DraftSpec.Mcp/Models/ScaffoldNode.cs
@@ -1,0 +1,23 @@
+namespace DraftSpec.Mcp.Models;
+
+/// <summary>
+/// Recursive structure representing a describe block with specs and nested contexts.
+/// Used by the scaffold_specs tool to generate DraftSpec code.
+/// </summary>
+public class ScaffoldNode
+{
+    /// <summary>
+    /// Description for the describe block.
+    /// </summary>
+    public string Description { get; set; } = "";
+
+    /// <summary>
+    /// List of spec descriptions (it blocks) at this level.
+    /// </summary>
+    public List<string> Specs { get; set; } = [];
+
+    /// <summary>
+    /// Nested describe blocks.
+    /// </summary>
+    public List<ScaffoldNode> Contexts { get; set; } = [];
+}

--- a/src/DraftSpec.Mcp/Services/Scaffolder.cs
+++ b/src/DraftSpec.Mcp/Services/Scaffolder.cs
@@ -1,0 +1,70 @@
+using System.Text;
+using DraftSpec.Mcp.Models;
+
+namespace DraftSpec.Mcp.Services;
+
+/// <summary>
+/// Generates DraftSpec code from a structured scaffold definition.
+/// </summary>
+public static class Scaffolder
+{
+    private const string Indent = "    ";
+
+    /// <summary>
+    /// Generate DraftSpec code from a scaffold node structure.
+    /// </summary>
+    /// <param name="node">The root scaffold node.</param>
+    /// <returns>Generated DraftSpec code with pending specs.</returns>
+    public static string Generate(ScaffoldNode node)
+    {
+        var sb = new StringBuilder();
+        GenerateNode(sb, node, 0);
+        return sb.ToString();
+    }
+
+    private static void GenerateNode(StringBuilder sb, ScaffoldNode node, int depth)
+    {
+        var indent = GetIndent(depth);
+        var description = EscapeString(node.Description);
+
+        sb.AppendLine($"{indent}describe(\"{description}\", () =>");
+        sb.AppendLine($"{indent}{{");
+
+        // Generate specs at this level
+        foreach (var spec in node.Specs)
+        {
+            var specDescription = EscapeString(spec);
+            sb.AppendLine($"{indent}{Indent}it(\"{specDescription}\");");
+        }
+
+        // Add blank line between specs and nested contexts if both exist
+        if (node.Specs.Count > 0 && node.Contexts.Count > 0)
+        {
+            sb.AppendLine();
+        }
+
+        // Generate nested contexts
+        for (var i = 0; i < node.Contexts.Count; i++)
+        {
+            if (i > 0)
+            {
+                sb.AppendLine();
+            }
+            GenerateNode(sb, node.Contexts[i], depth + 1);
+        }
+
+        sb.AppendLine($"{indent}}});");
+    }
+
+    private static string GetIndent(int depth)
+    {
+        return string.Concat(Enumerable.Repeat(Indent, depth));
+    }
+
+    private static string EscapeString(string value)
+    {
+        return value
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"");
+    }
+}

--- a/src/DraftSpec.Mcp/Tools/SpecTools.cs
+++ b/src/DraftSpec.Mcp/Tools/SpecTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text.Json;
 using ModelContextProtocol.Server;
+using DraftSpec.Mcp.Models;
 using DraftSpec.Mcp.Services;
 
 namespace DraftSpec.Mcp.Tools;
@@ -40,5 +41,18 @@ public static class SpecTools
             cancellationToken);
 
         return JsonSerializer.Serialize(result, JsonOptions);
+    }
+
+    /// <summary>
+    /// Generate DraftSpec code from a structured description.
+    /// </summary>
+    [McpServerTool(Name = "scaffold_specs")]
+    [Description("Generate DraftSpec code from a structured description. " +
+                 "Outputs pending specs ready for the agent to fill in assertions.")]
+    public static string ScaffoldSpecs(
+        [Description("Recursive structure of describe blocks and specs")]
+        ScaffoldNode structure)
+    {
+        return Scaffolder.Generate(structure);
     }
 }

--- a/tests/DraftSpec.Tests/DraftSpec.Tests.csproj
+++ b/tests/DraftSpec.Tests/DraftSpec.Tests.csproj
@@ -18,6 +18,7 @@
         <ProjectReference Include="..\..\src\DraftSpec.Cli\DraftSpec.Cli.csproj"/>
         <ProjectReference Include="..\..\src\DraftSpec.Formatters.Abstractions\DraftSpec.Formatters.Abstractions.csproj"/>
         <ProjectReference Include="..\..\src\DraftSpec.Formatters.Console\DraftSpec.Formatters.Console.csproj"/>
+        <ProjectReference Include="..\..\src\DraftSpec.Mcp\DraftSpec.Mcp.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/tests/DraftSpec.Tests/Mcp/ScaffolderTests.cs
+++ b/tests/DraftSpec.Tests/Mcp/ScaffolderTests.cs
@@ -1,0 +1,176 @@
+using DraftSpec.Mcp.Models;
+using DraftSpec.Mcp.Services;
+
+namespace DraftSpec.Tests.Mcp;
+
+/// <summary>
+/// Tests for the Scaffolder service that generates DraftSpec code from structured input.
+/// </summary>
+public class ScaffolderTests
+{
+    #region Simple Structure
+
+    [Test]
+    public async Task Generate_WithSpecs_GeneratesDescribeWithSpecs()
+    {
+        var input = new ScaffoldNode
+        {
+            Description = "Calculator",
+            Specs = ["adds numbers", "subtracts numbers"]
+        };
+
+        var output = Scaffolder.Generate(input);
+
+        await Assert.That(output).Contains("describe(\"Calculator\"");
+        await Assert.That(output).Contains("it(\"adds numbers\")");
+        await Assert.That(output).Contains("it(\"subtracts numbers\")");
+    }
+
+    [Test]
+    public async Task Generate_WithSpecs_GeneratesPendingSpecs()
+    {
+        var input = new ScaffoldNode
+        {
+            Description = "Calculator",
+            Specs = ["adds numbers"]
+        };
+
+        var output = Scaffolder.Generate(input);
+
+        await Assert.That(output).Contains("it(\"adds numbers\");");
+    }
+
+    #endregion
+
+    #region Nested Contexts
+
+    [Test]
+    public async Task Generate_WithNestedContext_GeneratesNestedDescribeBlocks()
+    {
+        var input = new ScaffoldNode
+        {
+            Description = "UserService",
+            Contexts =
+            [
+                new ScaffoldNode
+                {
+                    Description = "Create",
+                    Specs = ["creates user"]
+                }
+            ]
+        };
+
+        var output = Scaffolder.Generate(input);
+
+        await Assert.That(output).Contains("describe(\"UserService\"");
+        await Assert.That(output).Contains("describe(\"Create\"");
+        await Assert.That(output).Contains("it(\"creates user\")");
+    }
+
+    [Test]
+    public async Task Generate_WithMultipleLevels_HandlesDeepNesting()
+    {
+        var input = new ScaffoldNode
+        {
+            Description = "UserService",
+            Contexts =
+            [
+                new ScaffoldNode
+                {
+                    Description = "Create",
+                    Contexts =
+                    [
+                        new ScaffoldNode
+                        {
+                            Description = "with valid input",
+                            Specs = ["succeeds"]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var output = Scaffolder.Generate(input);
+
+        await Assert.That(output).Contains("describe(\"with valid input\"");
+    }
+
+    [Test]
+    public async Task Generate_WithSpecsAndContexts_HandlesBothAtSameLevel()
+    {
+        var input = new ScaffoldNode
+        {
+            Description = "Calculator",
+            Specs = ["initializes to zero"],
+            Contexts =
+            [
+                new ScaffoldNode { Description = "add", Specs = ["adds positive numbers"] }
+            ]
+        };
+
+        var output = Scaffolder.Generate(input);
+
+        await Assert.That(output).Contains("it(\"initializes to zero\")");
+        await Assert.That(output).Contains("describe(\"add\"");
+    }
+
+    #endregion
+
+    #region Formatting
+
+    [Test]
+    public async Task Generate_WithNesting_IndentsCorrectly()
+    {
+        var input = new ScaffoldNode
+        {
+            Description = "Outer",
+            Contexts = [new ScaffoldNode { Description = "Inner", Specs = ["works"] }]
+        };
+
+        var output = Scaffolder.Generate(input);
+        var lines = output.Split('\n');
+
+        var outerLine = lines.First(l => l.Contains("\"Outer\""));
+        var innerLine = lines.First(l => l.Contains("\"Inner\""));
+
+        var outerIndent = outerLine.TakeWhile(char.IsWhiteSpace).Count();
+        var innerIndent = innerLine.TakeWhile(char.IsWhiteSpace).Count();
+
+        await Assert.That(innerIndent).IsGreaterThan(outerIndent);
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Test]
+    public async Task Generate_WithEmptySpecs_GeneratesEmptyDescribe()
+    {
+        var input = new ScaffoldNode
+        {
+            Description = "Empty",
+            Specs = []
+        };
+
+        var output = Scaffolder.Generate(input);
+
+        await Assert.That(output).Contains("describe(\"Empty\"");
+    }
+
+    [Test]
+    public async Task Generate_WithQuotesInDescription_EscapesQuotes()
+    {
+        var input = new ScaffoldNode
+        {
+            Description = "handles \"quoted\" strings",
+            Specs = []
+        };
+
+        var output = Scaffolder.Generate(input);
+
+        await Assert.That(output).Contains("\\\"quoted\\\"");
+        await Assert.That(output).DoesNotContain("\"\"quoted\"\"");
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

New MCP tool that generates DraftSpec code from a structured description, enabling both BDD (behavior-first) and characterisation (code-first) workflows.

**Example input:**
```json
{
  "description": "UserService",
  "contexts": [
    { "description": "Create", "specs": ["creates user", "hashes password"] }
  ]
}
```

**Example output:**
```csharp
describe("UserService", () =>
{
    describe("Create", () =>
    {
        it("creates user");
        it("hashes password");
    });
});
```

## Features

- Recursive nested describe blocks
- Pending `it()` specs (no body) ready for assertions
- 4-space indentation
- Quote escaping in descriptions
- Mixed specs + contexts at same level

## Changes

| File | Description |
|------|-------------|
| `src/DraftSpec.Mcp/Models/ScaffoldNode.cs` | Recursive structure model |
| `src/DraftSpec.Mcp/Services/Scaffolder.cs` | Code generation logic |
| `src/DraftSpec.Mcp/Tools/SpecTools.cs` | Wire up MCP tool |
| `tests/DraftSpec.Tests/Mcp/ScaffolderTests.cs` | 8 comprehensive tests |
| `README.md` | Document MCP tools |

## Test plan

- [x] All 523 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)