### PR TITLE
Fix MinVer tag detection in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for MinVer
-          ref: ${{ github.event.release.tag_name || github.ref }}  # Checkout the release tag
+          fetch-tags: true  # Ensure tags are fetched for MinVer
+
+      - name: Checkout release tag
+        if: github.event_name == 'release'
+        run: |
+          git checkout ${{ github.event.release.tag_name }}
+          echo "Checked out tag: $(git describe --tags --exact-match 2>/dev/null || echo 'no tag')"
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
## Summary

- Add `fetch-tags: true` to ensure tags are fetched by checkout action
- Explicitly checkout release tag so MinVer can detect it naturally
- MinVer now works as intended instead of being bypassed with version override

## Problem

Packages were being published with commit-based versions (0.1.0-alpha.0.86) instead of the release tag version (0.1.0-alpha.2). MinVer wasn't detecting the tag because `actions/checkout` with a `ref` parameter doesn't properly expose the tag context.

## Test plan

- [ ] Create release v0.1.0-alpha.3
- [ ] Verify packages are published with correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)