### PR TITLE
Fix Scaffolder string escaping to prevent code injection

### DIFF
--- a/src/DraftSpec.Mcp/Services/Scaffolder.cs
+++ b/src/DraftSpec.Mcp/Services/Scaffolder.cs
@@ -63,8 +63,14 @@ public static class Scaffolder
 
     private static string EscapeString(string value)
     {
+        // Escape all C# string escape sequences to prevent code injection
+        // Order matters: backslash must be escaped first
         return value
             .Replace("\\", "\\\\")
-            .Replace("\"", "\\\"");
+            .Replace("\"", "\\\"")
+            .Replace("\n", "\\n")
+            .Replace("\r", "\\r")
+            .Replace("\t", "\\t")
+            .Replace("\0", "\\0");
     }
 }


### PR DESCRIPTION
## Summary
- Escape all C# string escape sequences (`\n`, `\r`, `\t`, `\0`) in `Scaffolder.EscapeString()`
- Prevents malicious input from breaking out of string literals in generated code
- Added comprehensive tests for escape sequences and injection prevention

## Test plan
- [x] Existing tests pass
- [x] New tests verify escape sequences are properly escaped
- [x] Injection attempt test verifies generated code structure remains valid

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)