### PR TITLE
Fix O(n²) hook chain building in SpecContext

### DIFF
--- a/src/DraftSpec/SpecContext.cs
+++ b/src/DraftSpec/SpecContext.cs
@@ -102,14 +102,19 @@ public class SpecContext
     {
         if (_beforeEachChain == null)
         {
-            _beforeEachChain = [];
+            // Build in child-to-parent order (O(1) per Add), then reverse once (O(n))
+            // This is O(n) total instead of O(n²) from Insert(0, ...) per item
+            var chain = new List<Func<Task>>();
             var current = this;
             while (current != null)
             {
                 if (current.BeforeEach != null)
-                    _beforeEachChain.Insert(0, current.BeforeEach);
+                    chain.Add(current.BeforeEach);
                 current = current.Parent;
             }
+
+            chain.Reverse();
+            _beforeEachChain = chain;
         }
 
         return _beforeEachChain;


### PR DESCRIPTION
## Summary
Change `GetBeforeEachChain()` from `Insert(0, ...)` to `Add()` + `Reverse()`.

**Before:** O(n²) - `Insert(0, ...)` is O(n) per call, n calls = O(n²)
**After:** O(n) - `Add()` is O(1), one `Reverse()` is O(n)

For 100 levels of nesting:
- Before: ~10,000 operations
- After: ~200 operations

## Changes
- `SpecContext.GetBeforeEachChain()` - build list forward, then reverse
- Added performance test for 100 levels of nesting
- Added test verifying parent-to-child execution order preserved

## Test plan
- [x] All 572 tests pass
- [x] New test verifies 100-level chain builds in <10ms
- [x] Hook execution order (parent→child) preserved

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)