### PR TITLE
Add ScaffoldNode depth limit to prevent stack overflow

### DIFF
--- a/src/DraftSpec.Mcp/Services/Scaffolder.cs
+++ b/src/DraftSpec.Mcp/Services/Scaffolder.cs
@@ -11,6 +11,11 @@ public static class Scaffolder
     private const string Indent = "    ";
 
     /// <summary>
+    /// Maximum nesting depth allowed to prevent stack overflow from malicious input.
+    /// </summary>
+    public const int MaxDepth = 32;
+
+    /// <summary>
     /// Generate DraftSpec code from a scaffold node structure.
     /// </summary>
     /// <param name="node">The root scaffold node.</param>
@@ -24,6 +29,11 @@ public static class Scaffolder
 
     private static void GenerateNode(StringBuilder sb, ScaffoldNode node, int depth)
     {
+        if (depth > MaxDepth)
+            throw new InvalidOperationException(
+                $"Scaffold nesting depth exceeds maximum of {MaxDepth}. " +
+                "This limit prevents stack overflow from deeply nested structures.");
+
         var indent = GetIndent(depth);
         var description = EscapeString(node.Description);
 


### PR DESCRIPTION
## Summary
Add depth limit check in `Scaffolder.GenerateNode()` to prevent stack overflow from deeply nested scaffold structures.

**Changes:**
- Add `MaxDepth` constant (32 levels)
- Throw `InvalidOperationException` with helpful message when exceeded
- Added 2 tests: one for limit enforcement, one for boundary behavior

## Why 32?
- Covers any realistic test structure
- Well below typical stack limits
- Consistent with similar limits in other code generators

## Test plan
- [x] All 574 tests pass
- [x] Test verifies exception at MaxDepth + 1
- [x] Test verifies success at exactly MaxDepth

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)