### PR TITLE
Centralize JsonSerializerOptions configuration

### DIFF
--- a/src/DraftSpec.Formatters.Abstractions/JsonFormatter.cs
+++ b/src/DraftSpec.Formatters.Abstractions/JsonFormatter.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace DraftSpec.Formatters;
 
@@ -8,19 +7,12 @@ namespace DraftSpec.Formatters;
 /// </summary>
 public class JsonFormatter : IFormatter
 {
-    private static readonly JsonSerializerOptions DefaultOptions = new()
-    {
-        WriteIndented = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-    };
-
     private readonly JsonSerializerOptions _options;
 
     /// <summary>
     /// Create a JsonFormatter with default options (indented, camelCase).
     /// </summary>
-    public JsonFormatter() : this(DefaultOptions)
+    public JsonFormatter() : this(JsonOptionsProvider.Default)
     {
     }
 
@@ -30,7 +22,7 @@ public class JsonFormatter : IFormatter
     /// <param name="options">Custom JSON serializer options</param>
     public JsonFormatter(JsonSerializerOptions options)
     {
-        _options = options ?? DefaultOptions;
+        _options = options ?? JsonOptionsProvider.Default;
     }
 
     public string FileExtension => ".json";

--- a/src/DraftSpec.Formatters.Abstractions/JsonOptionsProvider.cs
+++ b/src/DraftSpec.Formatters.Abstractions/JsonOptionsProvider.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DraftSpec.Formatters;
+
+/// <summary>
+/// Centralized JSON serializer options to ensure consistent serialization across all components.
+/// </summary>
+public static class JsonOptionsProvider
+{
+    /// <summary>
+    /// Default options for JSON serialization (indented output, camelCase, ignores null values).
+    /// Use for human-readable output like reports and formatted responses.
+    /// </summary>
+    public static JsonSerializerOptions Default { get; } = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    /// <summary>
+    /// Options for JSON deserialization with security limits.
+    /// Use when parsing untrusted JSON input to prevent DoS attacks.
+    /// </summary>
+    public static JsonSerializerOptions Secure { get; } = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        MaxDepth = 64
+    };
+
+    /// <summary>
+    /// Compact options for JSON serialization (no indentation, camelCase).
+    /// Use for machine-to-machine communication where size matters.
+    /// </summary>
+    public static JsonSerializerOptions Compact { get; } = new()
+    {
+        WriteIndented = false,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}

--- a/src/DraftSpec.Formatters.Abstractions/SpecReport.cs
+++ b/src/DraftSpec.Formatters.Abstractions/SpecReport.cs
@@ -34,13 +34,8 @@ public class SpecReport
             throw new InvalidOperationException(
                 $"Report too large: {json.Length:N0} bytes exceeds maximum of {MaxJsonSize:N0} bytes");
 
-        var options = new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            // Security: Limit nesting depth to prevent stack overflow
-            MaxDepth = 64
-        };
-        return JsonSerializer.Deserialize<SpecReport>(json, options)
+        // Security: Use secure options with MaxDepth limit to prevent stack overflow
+        return JsonSerializer.Deserialize<SpecReport>(json, JsonOptionsProvider.Secure)
                ?? throw new InvalidOperationException("Failed to parse JSON report");
     }
 
@@ -49,13 +44,7 @@ public class SpecReport
     /// </summary>
     public string ToJson()
     {
-        var options = new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-        };
-        return JsonSerializer.Serialize(this, options);
+        return JsonSerializer.Serialize(this, JsonOptionsProvider.Default);
     }
 }
 

--- a/src/DraftSpec.Mcp/Models/RunSpecResult.cs
+++ b/src/DraftSpec.Mcp/Models/RunSpecResult.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using DraftSpec.Formatters;
 
 namespace DraftSpec.Mcp.Models;
 
@@ -62,12 +63,7 @@ public class SpecReport
 
         try
         {
-            var options = new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                MaxDepth = 64
-            };
-            return JsonSerializer.Deserialize<SpecReport>(json, options);
+            return JsonSerializer.Deserialize<SpecReport>(json, JsonOptionsProvider.Secure);
         }
         catch
         {

--- a/src/DraftSpec.Mcp/Tools/SpecTools.cs
+++ b/src/DraftSpec.Mcp/Tools/SpecTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using DraftSpec.Formatters;
 using ModelContextProtocol.Server;
 using DraftSpec.Mcp.Models;
 using DraftSpec.Mcp.Services;
@@ -12,11 +13,6 @@ namespace DraftSpec.Mcp.Tools;
 [McpServerToolType]
 public static class SpecTools
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        WriteIndented = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
 
     /// <summary>
     /// Run a DraftSpec test specification and return the results.
@@ -40,7 +36,7 @@ public static class SpecTools
             TimeSpan.FromSeconds(timeoutSeconds),
             cancellationToken);
 
-        return JsonSerializer.Serialize(result, JsonOptions);
+        return JsonSerializer.Serialize(result, JsonOptionsProvider.Default);
     }
 
     /// <summary>

--- a/src/DraftSpec/Internal/SpecExecutor.cs
+++ b/src/DraftSpec/Internal/SpecExecutor.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using DraftSpec.Configuration;
 using DraftSpec.Formatters;
 
@@ -11,12 +10,6 @@ namespace DraftSpec.Internal;
 /// </summary>
 internal static class SpecExecutor
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        WriteIndented = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-    };
 
     /// <summary>
     /// Execute specs and return the report.
@@ -63,7 +56,7 @@ internal static class SpecExecutor
             // In file reporter mode, show console formatted output for user feedback
             FormatToConsole(configuration, report);
         else if (json)
-            Console.WriteLine(JsonSerializer.Serialize(report, JsonOptions));
+            Console.WriteLine(JsonSerializer.Serialize(report, JsonOptionsProvider.Default));
         else
             FormatToConsole(configuration, report);
 


### PR DESCRIPTION
## Summary
Create `JsonOptionsProvider` with three standard configurations to ensure consistent JSON serialization across all components.

### Options provided:
- **Default**: `WriteIndented=true`, camelCase, `WhenWritingNull` - for human-readable output
- **Secure**: camelCase, `MaxDepth=64` - for parsing untrusted JSON input
- **Compact**: `WriteIndented=false`, camelCase, `WhenWritingNull` - for machine-to-machine communication

### Files updated:
| File | Before | After |
|------|--------|-------|
| `JsonFormatter.cs` | Inline options | `JsonOptionsProvider.Default` |
| `SpecReport.cs` | 2 inline definitions | `Default` (ToJson), `Secure` (FromJson) |
| `SpecExecutor.cs` | Inline options | `JsonOptionsProvider.Default` |
| `SpecTools.cs` | Inline options | `JsonOptionsProvider.Default` |
| `RunSpecResult.cs` | Inline options | `JsonOptionsProvider.Secure` |

## Test plan
- [x] All 574 tests pass
- [x] Build succeeds

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)