### PR TITLE
Add code coverage collection to CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,28 @@ jobs:
       - name: Build
         run: dotnet build --no-restore -c Release
 
-      - name: Run tests
-        run: dotnet run --project tests/DraftSpec.Tests --no-build -c Release
+      - name: Run tests with coverage
+        run: |
+          dotnet run --project tests/DraftSpec.Tests -c Release -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml
+
+      - name: Generate coverage report
+        run: |
+          dotnet tool install -g dotnet-reportgenerator-globaltool
+          reportgenerator -reports:tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/coverage.cobertura.xml -targetdir:./coverage-report -reporttypes:Html
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/coverage.cobertura.xml
+          fail_ci_if_error: false
+          verbose: true
+
+      - name: Upload coverage report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: ./coverage-report
+          retention-days: 7
 
       - name: Pack
         run: dotnet pack --no-build -c Release

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # DraftSpec
 
+[![CI](https://github.com/juvistr/draftspec/actions/workflows/ci.yml/badge.svg)](https://github.com/juvistr/draftspec/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/juvistr/draftspec/graph/badge.svg)](https://codecov.io/gh/juvistr/draftspec)
+
 > ⚠️ **Alpha** - Experimental, expect breaking changes
 
 RSpec-inspired testing for .NET.

--- a/tests/DraftSpec.Tests/DraftSpec.Tests.csproj
+++ b/tests/DraftSpec.Tests/DraftSpec.Tests.csproj
@@ -10,6 +10,11 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <!-- MTP-compatible code coverage (coverlet.collector is VSTest-only) -->
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.*" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="TUnit" Version="1.*"/>
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Add `Microsoft.Testing.Extensions.CodeCoverage` package for TUnit coverage (coverlet.collector is VSTest-only and incompatible with Microsoft.Testing.Platform)
- Update CI workflow to collect coverage with `--coverage --coverage-output-format cobertura` flags
- Generate HTML report with ReportGenerator and upload as artifact
- Upload coverage data to Codecov
- Add CI and Codecov badges to README

## Technical Notes
TUnit uses Microsoft.Testing.Platform (MTP) which is incompatible with VSTest-based coverlet.collector. The MTP-native `Microsoft.Testing.Extensions.CodeCoverage` package provides the `--coverage` flag for collecting coverage data.

Fixes #26

## Test plan
- [x] Tests pass locally with coverage enabled (574 tests, 54.7% line coverage)
- [ ] CI workflow runs successfully with coverage collection
- [ ] Coverage report uploaded to Codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)