### PR TITLE
Add CODECOV_TOKEN to Codecov upload step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/coverage.cobertura.xml
           fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
## Summary
Codecov v4 requires an upload token - tokenless uploads are no longer supported.

## Setup Required
1. Go to [codecov.io](https://codecov.io) and add the `juvistr/draftspec` repository
2. Copy the upload token from Codecov settings
3. Add it as a GitHub secret: Settings → Secrets and variables → Actions → New repository secret → Name: `CODECOV_TOKEN`

Once the secret is configured, the badge will start showing coverage data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)