### PR TITLE
Fix Environment.ExitCode test race condition

### DIFF
--- a/tests/DraftSpec.Tests/Dsl/StaticDslTests.cs
+++ b/tests/DraftSpec.Tests/Dsl/StaticDslTests.cs
@@ -266,6 +266,7 @@ public class StaticDslTests
     #region Environment.ExitCode
 
     [Test]
+    [NotInParallel(nameof(Environment.ExitCode))]
     public async Task Run_AllPassed_ExitCodeZero()
     {
         // Save original
@@ -283,6 +284,7 @@ public class StaticDslTests
     }
 
     [Test]
+    [NotInParallel(nameof(Environment.ExitCode))]
     public async Task Run_AnyFailed_ExitCodeOne()
     {
         // Save original
@@ -300,6 +302,7 @@ public class StaticDslTests
     }
 
     [Test]
+    [NotInParallel(nameof(Environment.ExitCode))]
     public async Task Run_OnlyPending_ExitCodeZero()
     {
         // Save original


### PR DESCRIPTION
## Summary
Add `[NotInParallel]` attribute to tests that modify `Environment.ExitCode` to prevent race conditions when tests run concurrently.

The tests were failing on CI because TUnit runs tests in parallel by default, and the three exit code tests were racing to read/write the global `Environment.ExitCode`.

## Test plan
- [x] All 574 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)