### PR TITLE
Add session persistence for multi-turn agent workflows (#6)

### DIFF
--- a/src/DraftSpec.Mcp/Program.cs
+++ b/src/DraftSpec.Mcp/Program.cs
@@ -11,6 +11,7 @@ builder.Logging.AddConsole(options => { options.LogToStandardErrorThreshold = Lo
 
 // Register services
 builder.Services.AddSingleton<TempFileManager>();
+builder.Services.AddSingleton<SessionManager>();
 builder.Services.AddSingleton<SpecExecutionService>();
 
 // Configure MCP server with stdio transport

--- a/src/DraftSpec.Mcp/Services/Session.cs
+++ b/src/DraftSpec.Mcp/Services/Session.cs
@@ -1,0 +1,148 @@
+namespace DraftSpec.Mcp.Services;
+
+/// <summary>
+/// Represents a persistent session for multi-turn spec execution workflows.
+/// Sessions maintain accumulated spec content and shared state across multiple run_spec calls.
+/// </summary>
+public class Session : IDisposable
+{
+    private readonly object _lock = new();
+    private bool _disposed;
+
+    /// <summary>
+    /// Unique identifier for this session.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// When the session was created.
+    /// </summary>
+    public DateTime CreatedAt { get; }
+
+    /// <summary>
+    /// When the session was last accessed.
+    /// </summary>
+    public DateTime LastAccessedAt { get; private set; }
+
+    /// <summary>
+    /// Session timeout duration. Session expires if not accessed within this period.
+    /// </summary>
+    public TimeSpan Timeout { get; }
+
+    /// <summary>
+    /// Accumulated spec content from previous runs in this session.
+    /// This content is prepended to each new spec run.
+    /// </summary>
+    public string AccumulatedContent { get; private set; } = "";
+
+    /// <summary>
+    /// Session-specific temporary directory for spec files.
+    /// </summary>
+    public string TempDirectory { get; }
+
+    /// <summary>
+    /// Whether this session has expired.
+    /// </summary>
+    public bool IsExpired => DateTime.UtcNow - LastAccessedAt > Timeout;
+
+    /// <summary>
+    /// Create a new session.
+    /// </summary>
+    /// <param name="id">Session ID</param>
+    /// <param name="timeout">Session timeout</param>
+    /// <param name="tempDirectory">Temp directory for this session</param>
+    public Session(string id, TimeSpan timeout, string tempDirectory)
+    {
+        Id = id;
+        Timeout = timeout;
+        TempDirectory = tempDirectory;
+        CreatedAt = DateTime.UtcNow;
+        LastAccessedAt = DateTime.UtcNow;
+
+        // Ensure temp directory exists
+        Directory.CreateDirectory(tempDirectory);
+    }
+
+    /// <summary>
+    /// Touch the session to update last accessed time.
+    /// </summary>
+    public void Touch()
+    {
+        lock (_lock)
+        {
+            LastAccessedAt = DateTime.UtcNow;
+        }
+    }
+
+    /// <summary>
+    /// Append content to the accumulated spec content.
+    /// </summary>
+    /// <param name="content">Content to append</param>
+    public void AppendContent(string content)
+    {
+        lock (_lock)
+        {
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                if (!string.IsNullOrEmpty(AccumulatedContent))
+                {
+                    AccumulatedContent += Environment.NewLine + Environment.NewLine;
+                }
+                AccumulatedContent += content;
+            }
+            LastAccessedAt = DateTime.UtcNow;
+        }
+    }
+
+    /// <summary>
+    /// Get the full spec content including accumulated content.
+    /// </summary>
+    /// <param name="newContent">New content to run</param>
+    /// <returns>Combined content</returns>
+    public string GetFullContent(string newContent)
+    {
+        lock (_lock)
+        {
+            LastAccessedAt = DateTime.UtcNow;
+            if (string.IsNullOrEmpty(AccumulatedContent))
+            {
+                return newContent;
+            }
+            return AccumulatedContent + Environment.NewLine + Environment.NewLine + newContent;
+        }
+    }
+
+    /// <summary>
+    /// Clear accumulated content.
+    /// </summary>
+    public void ClearContent()
+    {
+        lock (_lock)
+        {
+            AccumulatedContent = "";
+            LastAccessedAt = DateTime.UtcNow;
+        }
+    }
+
+    /// <summary>
+    /// Dispose the session and clean up resources.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        // Clean up temp directory
+        try
+        {
+            if (Directory.Exists(TempDirectory))
+            {
+                Directory.Delete(TempDirectory, recursive: true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup errors
+        }
+    }
+}

--- a/src/DraftSpec.Mcp/Services/SessionManager.cs
+++ b/src/DraftSpec.Mcp/Services/SessionManager.cs
@@ -1,0 +1,211 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace DraftSpec.Mcp.Services;
+
+/// <summary>
+/// Manages sessions for multi-turn spec execution workflows.
+/// Handles session creation, retrieval, expiration, and cleanup.
+/// </summary>
+public class SessionManager : IDisposable
+{
+    private readonly ConcurrentDictionary<string, Session> _sessions = new();
+    private readonly ILogger<SessionManager> _logger;
+    private readonly string _baseTempDirectory;
+    private readonly Timer _cleanupTimer;
+    private readonly TimeSpan _defaultTimeout;
+    private readonly TimeSpan _cleanupInterval;
+    private bool _disposed;
+
+    /// <summary>
+    /// Default session timeout (30 minutes).
+    /// </summary>
+    public static readonly TimeSpan DefaultSessionTimeout = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Default cleanup interval (5 minutes).
+    /// </summary>
+    public static readonly TimeSpan DefaultCleanupInterval = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Create a new SessionManager.
+    /// </summary>
+    /// <param name="logger">Logger instance</param>
+    /// <param name="baseTempDirectory">Base directory for session temp files (optional)</param>
+    /// <param name="defaultTimeout">Default session timeout (optional)</param>
+    /// <param name="cleanupInterval">Interval for cleanup checks (optional)</param>
+    public SessionManager(
+        ILogger<SessionManager> logger,
+        string? baseTempDirectory = null,
+        TimeSpan? defaultTimeout = null,
+        TimeSpan? cleanupInterval = null)
+    {
+        _logger = logger;
+        _baseTempDirectory = baseTempDirectory ?? Path.Combine(Path.GetTempPath(), "draftspec-sessions");
+        _defaultTimeout = defaultTimeout ?? DefaultSessionTimeout;
+        _cleanupInterval = cleanupInterval ?? DefaultCleanupInterval;
+
+        // Ensure base directory exists
+        Directory.CreateDirectory(_baseTempDirectory);
+
+        // Start cleanup timer
+        _cleanupTimer = new Timer(CleanupExpiredSessions, null, _cleanupInterval, _cleanupInterval);
+    }
+
+    /// <summary>
+    /// Number of active sessions.
+    /// </summary>
+    public int ActiveSessionCount => _sessions.Count;
+
+    /// <summary>
+    /// Create a new session with optional custom timeout.
+    /// </summary>
+    /// <param name="timeoutMinutes">Session timeout in minutes (optional, uses default if not specified)</param>
+    /// <returns>The created session</returns>
+    public Session CreateSession(int? timeoutMinutes = null)
+    {
+        var id = GenerateSessionId();
+        var timeout = timeoutMinutes.HasValue
+            ? TimeSpan.FromMinutes(timeoutMinutes.Value)
+            : _defaultTimeout;
+        var tempDir = Path.Combine(_baseTempDirectory, id);
+
+        var session = new Session(id, timeout, tempDir);
+        _sessions[id] = session;
+
+        _logger.LogInformation("Created session {SessionId} with timeout {Timeout}m", id, timeout.TotalMinutes);
+        return session;
+    }
+
+    /// <summary>
+    /// Get a session by ID.
+    /// </summary>
+    /// <param name="sessionId">Session ID</param>
+    /// <returns>The session if found and not expired, null otherwise</returns>
+    public Session? GetSession(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            return null;
+
+        if (!_sessions.TryGetValue(sessionId, out var session))
+            return null;
+
+        if (session.IsExpired)
+        {
+            _logger.LogInformation("Session {SessionId} has expired", sessionId);
+            DisposeSession(sessionId);
+            return null;
+        }
+
+        session.Touch();
+        return session;
+    }
+
+    /// <summary>
+    /// Dispose a session and clean up its resources.
+    /// </summary>
+    /// <param name="sessionId">Session ID</param>
+    /// <returns>True if session was found and disposed</returns>
+    public bool DisposeSession(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            return false;
+
+        if (_sessions.TryRemove(sessionId, out var session))
+        {
+            session.Dispose();
+            _logger.LogInformation("Disposed session {SessionId}", sessionId);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Get information about all active sessions.
+    /// </summary>
+    /// <returns>List of session info</returns>
+    public IReadOnlyList<SessionInfo> GetAllSessions()
+    {
+        return _sessions.Values
+            .Where(s => !s.IsExpired)
+            .Select(s => new SessionInfo
+            {
+                Id = s.Id,
+                CreatedAt = s.CreatedAt,
+                LastAccessedAt = s.LastAccessedAt,
+                TimeoutMinutes = (int)s.Timeout.TotalMinutes,
+                HasAccumulatedContent = !string.IsNullOrEmpty(s.AccumulatedContent),
+                IsExpired = s.IsExpired
+            })
+            .ToList();
+    }
+
+    private void CleanupExpiredSessions(object? state)
+    {
+        var expiredIds = _sessions
+            .Where(kvp => kvp.Value.IsExpired)
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        foreach (var id in expiredIds)
+        {
+            DisposeSession(id);
+        }
+
+        if (expiredIds.Count > 0)
+        {
+            _logger.LogInformation("Cleaned up {Count} expired sessions", expiredIds.Count);
+        }
+    }
+
+    private static string GenerateSessionId()
+    {
+        // Generate a short, readable session ID
+        return $"session-{DateTime.UtcNow:yyyyMMdd-HHmmss}-{Guid.NewGuid().ToString()[..8]}";
+    }
+
+    /// <summary>
+    /// Dispose the session manager and all sessions.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _cleanupTimer.Dispose();
+
+        foreach (var session in _sessions.Values)
+        {
+            session.Dispose();
+        }
+        _sessions.Clear();
+
+        // Try to clean up base directory
+        try
+        {
+            if (Directory.Exists(_baseTempDirectory) &&
+                !Directory.EnumerateFileSystemEntries(_baseTempDirectory).Any())
+            {
+                Directory.Delete(_baseTempDirectory);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup errors
+        }
+    }
+}
+
+/// <summary>
+/// Information about a session for API responses.
+/// </summary>
+public record SessionInfo
+{
+    public required string Id { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public DateTime LastAccessedAt { get; init; }
+    public int TimeoutMinutes { get; init; }
+    public bool HasAccumulatedContent { get; init; }
+    public bool IsExpired { get; init; }
+}

--- a/src/DraftSpec.Mcp/Tools/SessionTools.cs
+++ b/src/DraftSpec.Mcp/Tools/SessionTools.cs
@@ -1,0 +1,93 @@
+using System.ComponentModel;
+using System.Text.Json;
+using DraftSpec.Formatters;
+using DraftSpec.Mcp.Services;
+using ModelContextProtocol.Server;
+
+namespace DraftSpec.Mcp.Tools;
+
+/// <summary>
+/// MCP tools for session management in multi-turn workflows.
+/// </summary>
+[McpServerToolType]
+public static class SessionTools
+{
+    /// <summary>
+    /// Create a new session for accumulating specs across multiple tool calls.
+    /// </summary>
+    [McpServerTool(Name = "create_session")]
+    [Description("Create a new session for multi-turn spec development. " +
+                 "Sessions accumulate spec content across calls, enabling iterative development. " +
+                 "Use session_id with run_spec to build specs incrementally.")]
+    public static string CreateSession(
+        SessionManager sessionManager,
+        [Description("Session timeout in minutes (default: 30, max: 120). Session expires after inactivity.")]
+        int? timeoutMinutes = null)
+    {
+        if (timeoutMinutes.HasValue)
+        {
+            timeoutMinutes = Math.Clamp(timeoutMinutes.Value, 1, 120);
+        }
+
+        var session = sessionManager.CreateSession(timeoutMinutes);
+
+        var result = new
+        {
+            sessionId = session.Id,
+            timeoutMinutes = (int)session.Timeout.TotalMinutes,
+            expiresAt = session.LastAccessedAt.Add(session.Timeout),
+            message = "Session created. Use this session_id with run_spec to accumulate specs."
+        };
+
+        return JsonSerializer.Serialize(result, JsonOptionsProvider.Default);
+    }
+
+    /// <summary>
+    /// End a session and clean up resources.
+    /// </summary>
+    [McpServerTool(Name = "dispose_session")]
+    [Description("End a session and clean up its resources. " +
+                 "Use when done with iterative spec development.")]
+    public static string DisposeSession(
+        SessionManager sessionManager,
+        [Description("The session ID to dispose")]
+        string sessionId)
+    {
+        var disposed = sessionManager.DisposeSession(sessionId);
+
+        var result = new
+        {
+            success = disposed,
+            message = disposed
+                ? $"Session {sessionId} has been disposed."
+                : $"Session {sessionId} not found (may have expired)."
+        };
+
+        return JsonSerializer.Serialize(result, JsonOptionsProvider.Default);
+    }
+
+    /// <summary>
+    /// List all active sessions.
+    /// </summary>
+    [McpServerTool(Name = "list_sessions")]
+    [Description("List all active sessions with their status and accumulated content info.")]
+    public static string ListSessions(SessionManager sessionManager)
+    {
+        var sessions = sessionManager.GetAllSessions();
+
+        var result = new
+        {
+            count = sessions.Count,
+            sessions = sessions.Select(s => new
+            {
+                sessionId = s.Id,
+                createdAt = s.CreatedAt,
+                lastAccessedAt = s.LastAccessedAt,
+                timeoutMinutes = s.TimeoutMinutes,
+                hasAccumulatedContent = s.HasAccumulatedContent
+            })
+        };
+
+        return JsonSerializer.Serialize(result, JsonOptionsProvider.Default);
+    }
+}

--- a/tests/DraftSpec.Tests/Mcp/SessionManagerTests.cs
+++ b/tests/DraftSpec.Tests/Mcp/SessionManagerTests.cs
@@ -1,0 +1,255 @@
+using DraftSpec.Mcp.Services;
+using Microsoft.Extensions.Logging;
+
+namespace DraftSpec.Tests.Mcp;
+
+/// <summary>
+/// Tests for SessionManager class.
+/// </summary>
+public class SessionManagerTests
+{
+    private readonly ILogger<SessionManager> _logger = new NullLogger<SessionManager>();
+    private readonly string _baseTempDir;
+
+    /// <summary>
+    /// Simple no-op logger for testing.
+    /// </summary>
+    private class NullLogger<T> : ILogger<T>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => false;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) { }
+    }
+
+    public SessionManagerTests()
+    {
+        _baseTempDir = Path.Combine(Path.GetTempPath(), $"session-manager-tests-{Guid.NewGuid()}");
+    }
+
+    [After(Test)]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_baseTempDir))
+        {
+            try { Directory.Delete(_baseTempDir, recursive: true); }
+            catch { /* ignore */ }
+        }
+    }
+
+    [Test]
+    public async Task CreateSession_ReturnsNewSession()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir);
+
+        var session = manager.CreateSession();
+
+        await Assert.That(session).IsNotNull();
+        await Assert.That(session.Id).IsNotEmpty();
+    }
+
+    [Test]
+    public async Task CreateSession_UsesDefaultTimeout()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir);
+
+        var session = manager.CreateSession();
+
+        await Assert.That(session.Timeout).IsEqualTo(SessionManager.DefaultSessionTimeout);
+    }
+
+    [Test]
+    public async Task CreateSession_UsesCustomTimeout()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir);
+
+        var session = manager.CreateSession(timeoutMinutes: 60);
+
+        await Assert.That(session.Timeout).IsEqualTo(TimeSpan.FromMinutes(60));
+    }
+
+    [Test]
+    public async Task CreateSession_IncrementsActiveCount()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir);
+
+        await Assert.That(manager.ActiveSessionCount).IsEqualTo(0);
+
+        manager.CreateSession();
+        await Assert.That(manager.ActiveSessionCount).IsEqualTo(1);
+
+        manager.CreateSession();
+        await Assert.That(manager.ActiveSessionCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task GetSession_ReturnsSessionById()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir);
+        var created = manager.CreateSession();
+
+        var retrieved = manager.GetSession(created.Id);
+
+        await Assert.That(retrieved).IsNotNull();
+        await Assert.That(retrieved!.Id).IsEqualTo(created.Id);
+    }
+
+    [Test]
+    public async Task GetSession_ReturnsNullForUnknownId()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir);
+
+        var session = manager.GetSession("unknown-session-id");
+
+        await Assert.That(session).IsNull();
+    }
+
+    [Test]
+    public async Task GetSession_ReturnsNullForEmptyId()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir);
+
+        var nullId = manager.GetSession(null!);
+        var emptyId = manager.GetSession("");
+
+        await Assert.That(nullId).IsNull();
+        await Assert.That(emptyId).IsNull();
+    }
+
+    [Test]
+    public async Task GetSession_ReturnsNullForExpiredSession()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir,
+            defaultTimeout: TimeSpan.FromMilliseconds(1));
+
+        var created = manager.CreateSession();
+        await Task.Delay(50);
+
+        var retrieved = manager.GetSession(created.Id);
+
+        await Assert.That(retrieved).IsNull();
+    }
+
+    [Test]
+    public async Task GetSession_TouchesSession()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir);
+        var session = manager.CreateSession();
+        var originalLastAccessed = session.LastAccessedAt;
+
+        await Task.Delay(10);
+        manager.GetSession(session.Id);
+
+        await Assert.That(session.LastAccessedAt).IsGreaterThan(originalLastAccessed);
+    }
+
+    [Test]
+    public async Task DisposeSession_RemovesSession()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir);
+        var session = manager.CreateSession();
+
+        var disposed = manager.DisposeSession(session.Id);
+
+        await Assert.That(disposed).IsTrue();
+        await Assert.That(manager.ActiveSessionCount).IsEqualTo(0);
+        await Assert.That(manager.GetSession(session.Id)).IsNull();
+    }
+
+    [Test]
+    public async Task DisposeSession_ReturnsFalseForUnknownId()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir);
+
+        var disposed = manager.DisposeSession("unknown-id");
+
+        await Assert.That(disposed).IsFalse();
+    }
+
+    [Test]
+    public async Task DisposeSession_ReturnsFalseForEmptyId()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir);
+
+        var nullId = manager.DisposeSession(null!);
+        var emptyId = manager.DisposeSession("");
+
+        await Assert.That(nullId).IsFalse();
+        await Assert.That(emptyId).IsFalse();
+    }
+
+    [Test]
+    public async Task GetAllSessions_ReturnsActiveSessionInfo()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir);
+        var session1 = manager.CreateSession(timeoutMinutes: 30);
+        var session2 = manager.CreateSession(timeoutMinutes: 60);
+        session1.AppendContent("some content");
+
+        var sessions = manager.GetAllSessions();
+
+        await Assert.That(sessions.Count).IsEqualTo(2);
+
+        var info1 = sessions.Single(s => s.Id == session1.Id);
+        await Assert.That(info1.TimeoutMinutes).IsEqualTo(30);
+        await Assert.That(info1.HasAccumulatedContent).IsTrue();
+        await Assert.That(info1.IsExpired).IsFalse();
+
+        var info2 = sessions.Single(s => s.Id == session2.Id);
+        await Assert.That(info2.TimeoutMinutes).IsEqualTo(60);
+        await Assert.That(info2.HasAccumulatedContent).IsFalse();
+    }
+
+    [Test]
+    public async Task GetAllSessions_ExcludesExpiredSessions()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir,
+            defaultTimeout: TimeSpan.FromMilliseconds(1));
+
+        manager.CreateSession();
+        await Task.Delay(50);
+
+        var sessions = manager.GetAllSessions();
+
+        await Assert.That(sessions.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CleanupTimer_RemovesExpiredSessions()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir,
+            defaultTimeout: TimeSpan.FromMilliseconds(10),
+            cleanupInterval: TimeSpan.FromMilliseconds(50));
+
+        manager.CreateSession();
+        await Assert.That(manager.ActiveSessionCount).IsEqualTo(1);
+
+        // Wait for cleanup timer
+        await Task.Delay(200);
+
+        await Assert.That(manager.ActiveSessionCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Dispose_CleansUpAllSessions()
+    {
+        var manager = new SessionManager(_logger, _baseTempDir);
+        manager.CreateSession();
+        manager.CreateSession();
+
+        manager.Dispose();
+
+        // Should not throw even after disposal
+        await Assert.That(manager.ActiveSessionCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SessionIdFormat_IsReadable()
+    {
+        using var manager = new SessionManager(_logger, _baseTempDir);
+
+        var session = manager.CreateSession();
+
+        await Assert.That(session.Id).StartsWith("session-");
+        await Assert.That(session.Id.Length).IsGreaterThan(20);
+    }
+}

--- a/tests/DraftSpec.Tests/Mcp/SessionTests.cs
+++ b/tests/DraftSpec.Tests/Mcp/SessionTests.cs
@@ -1,0 +1,174 @@
+using DraftSpec.Mcp.Services;
+
+namespace DraftSpec.Tests.Mcp;
+
+/// <summary>
+/// Tests for Session class.
+/// </summary>
+public class SessionTests
+{
+    [Test]
+    public async Task Constructor_SetsPropertiesCorrectly()
+    {
+        var id = "test-session-123";
+        var timeout = TimeSpan.FromMinutes(15);
+        var tempDir = Path.Combine(Path.GetTempPath(), "test-session");
+
+        using var session = new Session(id, timeout, tempDir);
+
+        await Assert.That(session.Id).IsEqualTo(id);
+        await Assert.That(session.Timeout).IsEqualTo(timeout);
+        await Assert.That(session.TempDirectory).IsEqualTo(tempDir);
+        await Assert.That(session.AccumulatedContent).IsEqualTo("");
+        await Assert.That(session.IsExpired).IsFalse();
+    }
+
+    [Test]
+    public async Task Constructor_CreatesTempDirectory()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"session-test-{Guid.NewGuid()}");
+
+        try
+        {
+            using var session = new Session("test", TimeSpan.FromMinutes(30), tempDir);
+
+            await Assert.That(Directory.Exists(tempDir)).IsTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task AppendContent_AddsContent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"session-test-{Guid.NewGuid()}");
+        using var session = new Session("test", TimeSpan.FromMinutes(30), tempDir);
+
+        session.AppendContent("describe(\"Test\", () => {});");
+
+        await Assert.That(session.AccumulatedContent).IsEqualTo("describe(\"Test\", () => {});");
+    }
+
+    [Test]
+    public async Task AppendContent_AccumulatesMultipleContent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"session-test-{Guid.NewGuid()}");
+        using var session = new Session("test", TimeSpan.FromMinutes(30), tempDir);
+
+        session.AppendContent("describe(\"First\", () => {});");
+        session.AppendContent("describe(\"Second\", () => {});");
+
+        await Assert.That(session.AccumulatedContent).Contains("First");
+        await Assert.That(session.AccumulatedContent).Contains("Second");
+    }
+
+    [Test]
+    public async Task AppendContent_IgnoresEmptyContent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"session-test-{Guid.NewGuid()}");
+        using var session = new Session("test", TimeSpan.FromMinutes(30), tempDir);
+
+        session.AppendContent("describe(\"Test\", () => {});");
+        session.AppendContent("");
+        session.AppendContent("  ");
+
+        await Assert.That(session.AccumulatedContent).IsEqualTo("describe(\"Test\", () => {});");
+    }
+
+    [Test]
+    public async Task GetFullContent_ReturnsNewContentWhenNoAccumulated()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"session-test-{Guid.NewGuid()}");
+        using var session = new Session("test", TimeSpan.FromMinutes(30), tempDir);
+
+        var result = session.GetFullContent("new content");
+
+        await Assert.That(result).IsEqualTo("new content");
+    }
+
+    [Test]
+    public async Task GetFullContent_CombinesAccumulatedWithNew()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"session-test-{Guid.NewGuid()}");
+        using var session = new Session("test", TimeSpan.FromMinutes(30), tempDir);
+
+        session.AppendContent("accumulated content");
+        var result = session.GetFullContent("new content");
+
+        await Assert.That(result).Contains("accumulated content");
+        await Assert.That(result).Contains("new content");
+    }
+
+    [Test]
+    public async Task ClearContent_RemovesAccumulatedContent()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"session-test-{Guid.NewGuid()}");
+        using var session = new Session("test", TimeSpan.FromMinutes(30), tempDir);
+
+        session.AppendContent("some content");
+        session.ClearContent();
+
+        await Assert.That(session.AccumulatedContent).IsEqualTo("");
+    }
+
+    [Test]
+    public async Task Touch_UpdatesLastAccessedAt()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"session-test-{Guid.NewGuid()}");
+        using var session = new Session("test", TimeSpan.FromMinutes(30), tempDir);
+
+        var originalLastAccessed = session.LastAccessedAt;
+        await Task.Delay(10);
+        session.Touch();
+
+        await Assert.That(session.LastAccessedAt).IsGreaterThan(originalLastAccessed);
+    }
+
+    [Test]
+    public async Task IsExpired_ReturnsFalseForActiveSession()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"session-test-{Guid.NewGuid()}");
+        using var session = new Session("test", TimeSpan.FromMinutes(30), tempDir);
+
+        await Assert.That(session.IsExpired).IsFalse();
+    }
+
+    [Test]
+    public async Task IsExpired_ReturnsTrueAfterTimeout()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"session-test-{Guid.NewGuid()}");
+        using var session = new Session("test", TimeSpan.FromMilliseconds(1), tempDir);
+
+        await Task.Delay(50);
+
+        await Assert.That(session.IsExpired).IsTrue();
+    }
+
+    [Test]
+    public async Task Dispose_CleansTempDirectory()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"session-test-{Guid.NewGuid()}");
+        var session = new Session("test", TimeSpan.FromMinutes(30), tempDir);
+
+        await Assert.That(Directory.Exists(tempDir)).IsTrue();
+
+        session.Dispose();
+
+        await Assert.That(Directory.Exists(tempDir)).IsFalse();
+    }
+
+    [Test]
+    public async Task Dispose_CanBeCalledMultipleTimes()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"session-test-{Guid.NewGuid()}");
+        var session = new Session("test", TimeSpan.FromMinutes(30), tempDir);
+
+        session.Dispose();
+        session.Dispose(); // Should not throw
+
+        await Assert.That(true).IsTrue(); // Just verifying no exception
+    }
+}


### PR DESCRIPTION
## Summary
- Adds session management to MCP server for iterative spec development
- Enables accumulating specs across multiple `run_spec` calls within a session
- Sessions auto-expire after configurable timeout (default 30 min)

**New MCP Tools:**
- `create_session` - Creates a new session
- `dispose_session` - Ends a session  
- `list_sessions` - Shows active sessions

**Enhanced `run_spec`:**
- Optional `sessionId` parameter to accumulate specs
- When provided, previous specs are prepended to new content

## Test plan
- [x] 685 tests pass (30 new session tests)
- [x] Session creation, retrieval, and disposal
- [x] Content accumulation across calls
- [x] Session timeout and expiration
- [x] Cleanup timer removes expired sessions

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)