### PR TITLE
Add spec diff tool for regression detection (#9)

### DIFF
--- a/src/DraftSpec.Mcp/Models/SpecDiffModels.cs
+++ b/src/DraftSpec.Mcp/Models/SpecDiffModels.cs
@@ -1,0 +1,111 @@
+using System.Text.Json.Serialization;
+
+namespace DraftSpec.Mcp.Models;
+
+/// <summary>
+/// Type of change detected between baseline and current spec results.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ChangeType
+{
+    /// <summary>Was passing, now failing (regression).</summary>
+    Regression,
+
+    /// <summary>Was failing, now passing (fix).</summary>
+    Fix,
+
+    /// <summary>New spec that didn't exist in baseline.</summary>
+    New,
+
+    /// <summary>Spec existed in baseline but not in current.</summary>
+    Removed,
+
+    /// <summary>Status changed but not a regression or fix (e.g., pending to skipped).</summary>
+    StatusChange
+}
+
+/// <summary>
+/// Result of comparing two spec runs.
+/// </summary>
+public class SpecDiff
+{
+    /// <summary>
+    /// Whether any regressions were detected.
+    /// </summary>
+    public bool HasRegressions => NewFailing > 0;
+
+    /// <summary>
+    /// Number of specs that were failing but now pass.
+    /// </summary>
+    public int NewPassing { get; init; }
+
+    /// <summary>
+    /// Number of specs that were passing but now fail (regressions).
+    /// </summary>
+    public int NewFailing { get; init; }
+
+    /// <summary>
+    /// Number of specs that failed in both runs.
+    /// </summary>
+    public int StillFailing { get; init; }
+
+    /// <summary>
+    /// Number of specs that passed in both runs.
+    /// </summary>
+    public int StillPassing { get; init; }
+
+    /// <summary>
+    /// Number of new specs not in baseline.
+    /// </summary>
+    public int NewSpecs { get; init; }
+
+    /// <summary>
+    /// Number of specs removed since baseline.
+    /// </summary>
+    public int RemovedSpecs { get; init; }
+
+    /// <summary>
+    /// Detailed list of changes.
+    /// </summary>
+    public List<SpecChange> Changes { get; init; } = [];
+
+    /// <summary>
+    /// Summary message for quick review.
+    /// </summary>
+    public string Summary => HasRegressions
+        ? $"⚠️ {NewFailing} regression(s) detected"
+        : NewPassing > 0
+            ? $"✅ {NewPassing} fix(es), no regressions"
+            : "✅ No changes in test results";
+}
+
+/// <summary>
+/// A single change between baseline and current spec results.
+/// </summary>
+public class SpecChange
+{
+    /// <summary>
+    /// Full context path of the spec (e.g., "Calculator > add > returns sum").
+    /// </summary>
+    public required string SpecPath { get; init; }
+
+    /// <summary>
+    /// Type of change.
+    /// </summary>
+    public ChangeType Type { get; init; }
+
+    /// <summary>
+    /// Status in the baseline run.
+    /// </summary>
+    public string? OldStatus { get; init; }
+
+    /// <summary>
+    /// Status in the current run.
+    /// </summary>
+    public string? NewStatus { get; init; }
+
+    /// <summary>
+    /// Error message if the spec failed.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+}

--- a/src/DraftSpec.Mcp/Services/SpecDiffService.cs
+++ b/src/DraftSpec.Mcp/Services/SpecDiffService.cs
@@ -1,0 +1,174 @@
+using DraftSpec.Mcp.Models;
+
+namespace DraftSpec.Mcp.Services;
+
+/// <summary>
+/// Compares two spec runs to detect regressions and fixes.
+/// </summary>
+public static class SpecDiffService
+{
+    /// <summary>
+    /// Compare baseline and current spec reports to detect changes.
+    /// </summary>
+    /// <param name="baseline">The baseline spec report (previous run)</param>
+    /// <param name="current">The current spec report (new run)</param>
+    /// <returns>Diff result with changes and summary</returns>
+    public static SpecDiff Compare(SpecReport? baseline, SpecReport? current)
+    {
+        if (baseline == null && current == null)
+        {
+            return new SpecDiff();
+        }
+
+        var baselineSpecs = baseline != null ? FlattenSpecs(baseline) : [];
+        var currentSpecs = current != null ? FlattenSpecs(current) : [];
+
+        var changes = new List<SpecChange>();
+        var newPassing = 0;
+        var newFailing = 0;
+        var stillFailing = 0;
+        var stillPassing = 0;
+        var newSpecs = 0;
+        var removedSpecs = 0;
+
+        // Find specs in current that exist in baseline
+        foreach (var (path, currentSpec) in currentSpecs)
+        {
+            if (baselineSpecs.TryGetValue(path, out var baselineSpec))
+            {
+                var baselineStatus = NormalizeStatus(baselineSpec.Status);
+                var currentStatus = NormalizeStatus(currentSpec.Status);
+
+                if (baselineStatus == currentStatus)
+                {
+                    // No change
+                    if (currentStatus == "passed")
+                        stillPassing++;
+                    else if (currentStatus == "failed")
+                        stillFailing++;
+                }
+                else if (baselineStatus == "passed" && currentStatus == "failed")
+                {
+                    // Regression!
+                    newFailing++;
+                    changes.Add(new SpecChange
+                    {
+                        SpecPath = path,
+                        Type = ChangeType.Regression,
+                        OldStatus = baselineSpec.Status,
+                        NewStatus = currentSpec.Status,
+                        ErrorMessage = currentSpec.Error
+                    });
+                }
+                else if (baselineStatus == "failed" && currentStatus == "passed")
+                {
+                    // Fix!
+                    newPassing++;
+                    changes.Add(new SpecChange
+                    {
+                        SpecPath = path,
+                        Type = ChangeType.Fix,
+                        OldStatus = baselineSpec.Status,
+                        NewStatus = currentSpec.Status
+                    });
+                }
+                else
+                {
+                    // Other status change (e.g., pending -> skipped)
+                    changes.Add(new SpecChange
+                    {
+                        SpecPath = path,
+                        Type = ChangeType.StatusChange,
+                        OldStatus = baselineSpec.Status,
+                        NewStatus = currentSpec.Status
+                    });
+                }
+            }
+            else
+            {
+                // New spec
+                newSpecs++;
+                changes.Add(new SpecChange
+                {
+                    SpecPath = path,
+                    Type = ChangeType.New,
+                    OldStatus = null,
+                    NewStatus = currentSpec.Status
+                });
+            }
+        }
+
+        // Find specs in baseline that don't exist in current
+        foreach (var (path, baselineSpec) in baselineSpecs)
+        {
+            if (!currentSpecs.ContainsKey(path))
+            {
+                removedSpecs++;
+                changes.Add(new SpecChange
+                {
+                    SpecPath = path,
+                    Type = ChangeType.Removed,
+                    OldStatus = baselineSpec.Status,
+                    NewStatus = null
+                });
+            }
+        }
+
+        return new SpecDiff
+        {
+            NewPassing = newPassing,
+            NewFailing = newFailing,
+            StillFailing = stillFailing,
+            StillPassing = stillPassing,
+            NewSpecs = newSpecs,
+            RemovedSpecs = removedSpecs,
+            Changes = changes
+        };
+    }
+
+    /// <summary>
+    /// Flatten a spec report into a dictionary of path -> spec result.
+    /// </summary>
+    private static Dictionary<string, SpecResultReport> FlattenSpecs(SpecReport report)
+    {
+        var result = new Dictionary<string, SpecResultReport>();
+        FlattenContext(report.Contexts, [], result);
+        return result;
+    }
+
+    private static void FlattenContext(
+        List<SpecContextReport> contexts,
+        List<string> parentPath,
+        Dictionary<string, SpecResultReport> result)
+    {
+        foreach (var context in contexts)
+        {
+            var currentPath = parentPath.Concat([context.Description]).ToList();
+
+            // Add specs from this context
+            foreach (var spec in context.Specs)
+            {
+                var fullPath = string.Join(" > ", currentPath.Concat([spec.Description]));
+                result[fullPath] = spec;
+            }
+
+            // Recurse into nested contexts
+            FlattenContext(context.Contexts, currentPath, result);
+        }
+    }
+
+    /// <summary>
+    /// Normalize status string for comparison.
+    /// </summary>
+    private static string NormalizeStatus(string status)
+    {
+        return status.ToLowerInvariant() switch
+        {
+            "pass" or "passed" => "passed",
+            "fail" or "failed" => "failed",
+            "pending" => "pending",
+            "skip" or "skipped" => "skipped",
+            _ => status.ToLowerInvariant()
+        };
+    }
+}

--- a/src/DraftSpec.Mcp/Tools/DiffTools.cs
+++ b/src/DraftSpec.Mcp/Tools/DiffTools.cs
@@ -1,0 +1,77 @@
+using System.ComponentModel;
+using System.Text.Json;
+using DraftSpec.Formatters;
+using DraftSpec.Mcp.Models;
+using DraftSpec.Mcp.Services;
+using ModelContextProtocol.Server;
+using MpcModels = DraftSpec.Mcp.Models;
+
+namespace DraftSpec.Mcp.Tools;
+
+/// <summary>
+/// MCP tools for comparing spec results.
+/// </summary>
+[McpServerToolType]
+public static class DiffTools
+{
+    /// <summary>
+    /// Compare two spec runs to detect regressions and fixes.
+    /// </summary>
+    [McpServerTool(Name = "diff_specs")]
+    [Description("Compare baseline and current spec results to detect regressions. " +
+                 "Useful for CI/CD gates, PR reviews, and refactoring verification. " +
+                 "Returns detailed changes including regressions (passed→failed), " +
+                 "fixes (failed→passed), new specs, and removed specs.")]
+    public static string DiffSpecs(
+        [Description("Baseline spec results JSON (from a previous run_spec call)")]
+        string baselineResults,
+        [Description("Current spec results JSON (from the latest run_spec call)")]
+        string currentResults)
+    {
+        MpcModels.SpecReport? baseline = null;
+        MpcModels.SpecReport? current = null;
+
+        // Parse baseline results
+        if (!string.IsNullOrWhiteSpace(baselineResults))
+        {
+            try
+            {
+                // Try to parse as RunSpecResult first (full response from run_spec)
+                var runResult = JsonSerializer.Deserialize<RunSpecResult>(baselineResults, JsonOptionsProvider.Default);
+                baseline = runResult?.Report;
+
+                // If no report in RunSpecResult, try parsing as direct SpecReport
+                baseline ??= JsonSerializer.Deserialize<MpcModels.SpecReport>(baselineResults, JsonOptionsProvider.Default);
+            }
+            catch (JsonException)
+            {
+                return JsonSerializer.Serialize(new
+                {
+                    error = "Failed to parse baseline results as valid spec report JSON"
+                }, JsonOptionsProvider.Default);
+            }
+        }
+
+        // Parse current results
+        if (!string.IsNullOrWhiteSpace(currentResults))
+        {
+            try
+            {
+                var runResult = JsonSerializer.Deserialize<RunSpecResult>(currentResults, JsonOptionsProvider.Default);
+                current = runResult?.Report;
+                current ??= JsonSerializer.Deserialize<MpcModels.SpecReport>(currentResults, JsonOptionsProvider.Default);
+            }
+            catch (JsonException)
+            {
+                return JsonSerializer.Serialize(new
+                {
+                    error = "Failed to parse current results as valid spec report JSON"
+                }, JsonOptionsProvider.Default);
+            }
+        }
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        return JsonSerializer.Serialize(diff, JsonOptionsProvider.Default);
+    }
+}

--- a/tests/DraftSpec.Tests/Mcp/SpecDiffServiceTests.cs
+++ b/tests/DraftSpec.Tests/Mcp/SpecDiffServiceTests.cs
@@ -1,0 +1,290 @@
+using DraftSpec.Mcp.Models;
+using DraftSpec.Mcp.Services;
+using Models = DraftSpec.Mcp.Models;
+
+namespace DraftSpec.Tests.Mcp;
+
+/// <summary>
+/// Tests for SpecDiffService.
+/// </summary>
+public class SpecDiffServiceTests
+{
+    #region No Changes
+
+    [Test]
+    public async Task Compare_BothNull_ReturnsEmptyDiff()
+    {
+        var diff = SpecDiffService.Compare(null, null);
+
+        await Assert.That(diff.HasRegressions).IsFalse();
+        await Assert.That(diff.Changes).IsEmpty();
+    }
+
+    [Test]
+    public async Task Compare_IdenticalResults_NoChanges()
+    {
+        var baseline = CreateReport(("Test > spec1", "passed"), ("Test > spec2", "passed"));
+        var current = CreateReport(("Test > spec1", "passed"), ("Test > spec2", "passed"));
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        await Assert.That(diff.HasRegressions).IsFalse();
+        await Assert.That(diff.NewPassing).IsEqualTo(0);
+        await Assert.That(diff.NewFailing).IsEqualTo(0);
+        await Assert.That(diff.StillPassing).IsEqualTo(2);
+        await Assert.That(diff.Changes).IsEmpty();
+    }
+
+    #endregion
+
+    #region Regressions
+
+    [Test]
+    public async Task Compare_Regression_Detected()
+    {
+        var baseline = CreateReport(("Test > spec1", "passed"));
+        var current = CreateReport(("Test > spec1", "failed"));
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        await Assert.That(diff.HasRegressions).IsTrue();
+        await Assert.That(diff.NewFailing).IsEqualTo(1);
+        await Assert.That(diff.Changes.Count).IsEqualTo(1);
+        await Assert.That(diff.Changes[0].Type).IsEqualTo(ChangeType.Regression);
+        await Assert.That(diff.Changes[0].SpecPath).IsEqualTo("Test > spec1");
+    }
+
+    [Test]
+    public async Task Compare_MultipleRegressions_AllDetected()
+    {
+        var baseline = CreateReport(
+            ("Test > spec1", "passed"),
+            ("Test > spec2", "passed"),
+            ("Test > spec3", "passed"));
+        var current = CreateReport(
+            ("Test > spec1", "failed"),
+            ("Test > spec2", "passed"),
+            ("Test > spec3", "failed"));
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        await Assert.That(diff.HasRegressions).IsTrue();
+        await Assert.That(diff.NewFailing).IsEqualTo(2);
+        await Assert.That(diff.StillPassing).IsEqualTo(1);
+    }
+
+    #endregion
+
+    #region Fixes
+
+    [Test]
+    public async Task Compare_Fix_Detected()
+    {
+        var baseline = CreateReport(("Test > spec1", "failed"));
+        var current = CreateReport(("Test > spec1", "passed"));
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        await Assert.That(diff.HasRegressions).IsFalse();
+        await Assert.That(diff.NewPassing).IsEqualTo(1);
+        await Assert.That(diff.Changes.Count).IsEqualTo(1);
+        await Assert.That(diff.Changes[0].Type).IsEqualTo(ChangeType.Fix);
+    }
+
+    [Test]
+    public async Task Compare_MixedFixesAndRegressions()
+    {
+        var baseline = CreateReport(
+            ("Test > spec1", "passed"),
+            ("Test > spec2", "failed"));
+        var current = CreateReport(
+            ("Test > spec1", "failed"),
+            ("Test > spec2", "passed"));
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        await Assert.That(diff.HasRegressions).IsTrue();
+        await Assert.That(diff.NewFailing).IsEqualTo(1);
+        await Assert.That(diff.NewPassing).IsEqualTo(1);
+    }
+
+    #endregion
+
+    #region New and Removed Specs
+
+    [Test]
+    public async Task Compare_NewSpec_Detected()
+    {
+        var baseline = CreateReport(("Test > spec1", "passed"));
+        var current = CreateReport(("Test > spec1", "passed"), ("Test > spec2", "passed"));
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        await Assert.That(diff.NewSpecs).IsEqualTo(1);
+        await Assert.That(diff.Changes.Any(c => c.Type == ChangeType.New)).IsTrue();
+    }
+
+    [Test]
+    public async Task Compare_RemovedSpec_Detected()
+    {
+        var baseline = CreateReport(("Test > spec1", "passed"), ("Test > spec2", "passed"));
+        var current = CreateReport(("Test > spec1", "passed"));
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        await Assert.That(diff.RemovedSpecs).IsEqualTo(1);
+        await Assert.That(diff.Changes.Any(c => c.Type == ChangeType.Removed)).IsTrue();
+    }
+
+    #endregion
+
+    #region Still Failing
+
+    [Test]
+    public async Task Compare_StillFailing_Tracked()
+    {
+        var baseline = CreateReport(("Test > spec1", "failed"));
+        var current = CreateReport(("Test > spec1", "failed"));
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        await Assert.That(diff.StillFailing).IsEqualTo(1);
+        await Assert.That(diff.HasRegressions).IsFalse(); // Not a new regression
+    }
+
+    #endregion
+
+    #region Summary
+
+    [Test]
+    public async Task Summary_WithRegressions_ShowsWarning()
+    {
+        var baseline = CreateReport(("Test > spec1", "passed"));
+        var current = CreateReport(("Test > spec1", "failed"));
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        await Assert.That(diff.Summary).Contains("regression");
+    }
+
+    [Test]
+    public async Task Summary_WithFixesOnly_ShowsSuccess()
+    {
+        var baseline = CreateReport(("Test > spec1", "failed"));
+        var current = CreateReport(("Test > spec1", "passed"));
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        await Assert.That(diff.Summary).Contains("fix");
+        await Assert.That(diff.Summary).Contains("no regression");
+    }
+
+    [Test]
+    public async Task Summary_NoChanges_ShowsNoChanges()
+    {
+        var baseline = CreateReport(("Test > spec1", "passed"));
+        var current = CreateReport(("Test > spec1", "passed"));
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        await Assert.That(diff.Summary).Contains("No changes");
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Test]
+    public async Task Compare_BaselineNull_AllSpecsAreNew()
+    {
+        var current = CreateReport(("Test > spec1", "passed"), ("Test > spec2", "failed"));
+
+        var diff = SpecDiffService.Compare(null, current);
+
+        await Assert.That(diff.NewSpecs).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Compare_CurrentNull_AllSpecsRemoved()
+    {
+        var baseline = CreateReport(("Test > spec1", "passed"), ("Test > spec2", "failed"));
+
+        var diff = SpecDiffService.Compare(baseline, null);
+
+        await Assert.That(diff.RemovedSpecs).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Compare_StatusNormalization_PassAndPassed()
+    {
+        var baseline = CreateReport(("Test > spec1", "pass"));
+        var current = CreateReport(("Test > spec1", "passed"));
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        await Assert.That(diff.StillPassing).IsEqualTo(1);
+        await Assert.That(diff.Changes).IsEmpty();
+    }
+
+    [Test]
+    public async Task Compare_StatusNormalization_FailAndFailed()
+    {
+        var baseline = CreateReport(("Test > spec1", "fail"));
+        var current = CreateReport(("Test > spec1", "failed"));
+
+        var diff = SpecDiffService.Compare(baseline, current);
+
+        await Assert.That(diff.StillFailing).IsEqualTo(1);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static Models.SpecReport CreateReport(params (string path, string status)[] specs)
+    {
+        var report = new Models.SpecReport
+        {
+            Summary = new Models.SpecSummary(),
+            Contexts = []
+        };
+
+        foreach (var (path, status) in specs)
+        {
+            var parts = path.Split(" > ");
+            var contextDesc = parts[0];
+            var specDesc = parts.Length > 1 ? string.Join(" > ", parts.Skip(1)) : parts[0];
+
+            var context = report.Contexts.FirstOrDefault(c => c.Description == contextDesc);
+            if (context == null)
+            {
+                context = new Models.SpecContextReport { Description = contextDesc };
+                report.Contexts.Add(context);
+            }
+
+            // Handle nested paths
+            var currentContext = context;
+            for (var i = 1; i < parts.Length - 1; i++)
+            {
+                var nestedDesc = parts[i];
+                var nested = currentContext.Contexts.FirstOrDefault(c => c.Description == nestedDesc);
+                if (nested == null)
+                {
+                    nested = new Models.SpecContextReport { Description = nestedDesc };
+                    currentContext.Contexts.Add(nested);
+                }
+                currentContext = nested;
+            }
+
+            currentContext.Specs.Add(new Models.SpecResultReport
+            {
+                Description = parts[^1],
+                Status = status
+            });
+        }
+
+        return report;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Adds `diff_specs` MCP tool to compare baseline and current spec results, detecting regressions and fixes.

**New Tool: `diff_specs`**
- Input: `baselineResults` and `currentResults` JSON from `run_spec`
- Output: Detailed diff with change counts and individual changes

**Change Types:**
- `Regression` - was passing, now failing ⚠️
- `Fix` - was failing, now passing ✅
- `New` - didn't exist in baseline
- `Removed` - existed in baseline, not in current

**Use Cases:**
- CI/CD gates: fail builds on regressions
- PR reviews: show spec impact of code changes
- Refactoring: verify behavior preservation

## Test plan
- [x] 736 tests pass (16 new diff tests)
- [x] Regression detection
- [x] Fix detection
- [x] New/removed spec tracking
- [x] Status normalization (pass/passed)

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)