### PR TITLE
Add Webhook Reporter for external notifications

### DIFF
--- a/src/DraftSpec/Plugins/Reporters/WebhookReporter.cs
+++ b/src/DraftSpec/Plugins/Reporters/WebhookReporter.cs
@@ -1,0 +1,335 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using DraftSpec.Formatters;
+
+namespace DraftSpec.Plugins.Reporters;
+
+/// <summary>
+/// Payload format for webhook notifications.
+/// </summary>
+public enum WebhookPayloadFormat
+{
+    /// <summary>
+    /// Full SpecReport as JSON.
+    /// </summary>
+    Json,
+
+    /// <summary>
+    /// Slack-formatted message with blocks.
+    /// </summary>
+    Slack,
+
+    /// <summary>
+    /// Discord embed with color-coded status.
+    /// </summary>
+    Discord,
+
+    /// <summary>
+    /// Minimal summary JSON payload.
+    /// </summary>
+    Summary
+}
+
+/// <summary>
+/// Configuration options for the webhook reporter.
+/// </summary>
+public class WebhookReporterOptions
+{
+    /// <summary>
+    /// The webhook URL to POST to.
+    /// </summary>
+    public required string Url { get; init; }
+
+    /// <summary>
+    /// Optional authorization header value (e.g., "Bearer token123").
+    /// </summary>
+    public string? AuthHeader { get; init; }
+
+    /// <summary>
+    /// The payload format to use. Default: Json.
+    /// </summary>
+    public WebhookPayloadFormat Format { get; init; } = WebhookPayloadFormat.Json;
+
+    /// <summary>
+    /// Only send webhook on test failures. Default: false.
+    /// </summary>
+    public bool SendOnFailureOnly { get; init; }
+
+    /// <summary>
+    /// HTTP timeout in milliseconds. Default: 5000.
+    /// </summary>
+    public int TimeoutMs { get; init; } = 5000;
+
+    /// <summary>
+    /// Number of retry attempts on failure. Default: 1.
+    /// </summary>
+    public int MaxRetries { get; init; } = 1;
+
+    /// <summary>
+    /// Delay between retries in milliseconds. Default: 1000.
+    /// </summary>
+    public int RetryDelayMs { get; init; } = 1000;
+
+    /// <summary>
+    /// Custom headers to include in the request.
+    /// </summary>
+    public Dictionary<string, string>? CustomHeaders { get; init; }
+}
+
+/// <summary>
+/// Reporter that sends spec results to external systems via HTTP webhooks.
+/// Supports Slack, Discord, and generic JSON payloads.
+/// </summary>
+public class WebhookReporter : IReporter, IDisposable
+{
+    private readonly WebhookReporterOptions _options;
+    private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
+
+    /// <summary>
+    /// Create a WebhookReporter with the specified options.
+    /// </summary>
+    /// <param name="options">Webhook configuration options</param>
+    public WebhookReporter(WebhookReporterOptions options)
+        : this(options, null)
+    {
+    }
+
+    /// <summary>
+    /// Create a WebhookReporter with custom HttpClient (for testing).
+    /// </summary>
+    /// <param name="options">Webhook configuration options</param>
+    /// <param name="httpClient">Custom HttpClient instance</param>
+    public WebhookReporter(WebhookReporterOptions options, HttpClient? httpClient)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ValidateOptions(options);
+
+        _options = options;
+
+        if (httpClient != null)
+        {
+            _httpClient = httpClient;
+            _ownsHttpClient = false;
+        }
+        else
+        {
+            _httpClient = new HttpClient
+            {
+                Timeout = TimeSpan.FromMilliseconds(options.TimeoutMs)
+            };
+            _ownsHttpClient = true;
+        }
+    }
+
+    /// <summary>
+    /// Gets the reporter name identifier.
+    /// </summary>
+    public string Name => "webhook";
+
+    /// <summary>
+    /// Send the spec report to the configured webhook when the run completes.
+    /// </summary>
+    public async Task OnRunCompletedAsync(SpecReport report)
+    {
+        // Check if we should skip sending
+        if (_options.SendOnFailureOnly && report.Summary.Success)
+            return;
+
+        var payload = FormatPayload(report);
+        await SendWithRetryAsync(payload);
+    }
+
+    private async Task SendWithRetryAsync(string payload)
+    {
+        Exception? lastException = null;
+
+        for (var attempt = 0; attempt <= _options.MaxRetries; attempt++)
+        {
+            try
+            {
+                // Create fresh content for each attempt (content gets disposed after send)
+                using var content = new StringContent(payload, Encoding.UTF8, "application/json");
+                using var request = new HttpRequestMessage(HttpMethod.Post, _options.Url);
+                request.Content = content;
+
+                // Add authorization header
+                if (!string.IsNullOrEmpty(_options.AuthHeader))
+                    request.Headers.TryAddWithoutValidation("Authorization", _options.AuthHeader);
+
+                // Add custom headers
+                if (_options.CustomHeaders != null)
+                {
+                    foreach (var (key, value) in _options.CustomHeaders)
+                        request.Headers.TryAddWithoutValidation(key, value);
+                }
+
+                var response = await _httpClient.SendAsync(request);
+                response.EnsureSuccessStatusCode();
+                return; // Success
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+            {
+                lastException = ex;
+
+                if (attempt < _options.MaxRetries)
+                    await Task.Delay(_options.RetryDelayMs);
+            }
+        }
+
+        // All retries failed - throw with context
+        throw new WebhookDeliveryException(
+            $"Failed to deliver webhook after {_options.MaxRetries + 1} attempts",
+            lastException);
+    }
+
+    private string FormatPayload(SpecReport report)
+    {
+        return _options.Format switch
+        {
+            WebhookPayloadFormat.Json => report.ToJson(),
+            WebhookPayloadFormat.Slack => FormatSlackPayload(report),
+            WebhookPayloadFormat.Discord => FormatDiscordPayload(report),
+            WebhookPayloadFormat.Summary => FormatSummaryPayload(report),
+            _ => report.ToJson()
+        };
+    }
+
+    private static string FormatSlackPayload(SpecReport report)
+    {
+        var summary = report.Summary;
+        var status = summary.Success ? ":white_check_mark: PASSED" : ":x: FAILED";
+        var color = summary.Success ? "#36a64f" : "#dc3545";
+
+        var payload = new
+        {
+            attachments = new[]
+            {
+                new
+                {
+                    color,
+                    blocks = new object[]
+                    {
+                        new
+                        {
+                            type = "header",
+                            text = new
+                            {
+                                type = "plain_text",
+                                text = $"DraftSpec Results: {status}",
+                                emoji = true
+                            }
+                        },
+                        new
+                        {
+                            type = "section",
+                            fields = new[]
+                            {
+                                new { type = "mrkdwn", text = $"*Total:* {summary.Total}" },
+                                new { type = "mrkdwn", text = $"*Passed:* {summary.Passed}" },
+                                new { type = "mrkdwn", text = $"*Failed:* {summary.Failed}" },
+                                new { type = "mrkdwn", text = $"*Duration:* {summary.DurationMs:F0}ms" }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        return JsonSerializer.Serialize(payload, JsonOptionsProvider.Default);
+    }
+
+    private static string FormatDiscordPayload(SpecReport report)
+    {
+        var summary = report.Summary;
+        var color = summary.Success ? 0x36a64f : 0xdc3545; // Green or Red
+
+        var payload = new
+        {
+            embeds = new[]
+            {
+                new
+                {
+                    title = summary.Success ? "Tests Passed" : "Tests Failed",
+                    color,
+                    fields = new[]
+                    {
+                        new { name = "Total", value = summary.Total.ToString(), inline = true },
+                        new { name = "Passed", value = summary.Passed.ToString(), inline = true },
+                        new { name = "Failed", value = summary.Failed.ToString(), inline = true },
+                        new { name = "Pending", value = summary.Pending.ToString(), inline = true },
+                        new { name = "Skipped", value = summary.Skipped.ToString(), inline = true },
+                        new { name = "Duration", value = $"{summary.DurationMs:F0}ms", inline = true }
+                    },
+                    timestamp = report.Timestamp.ToString("o")
+                }
+            }
+        };
+
+        return JsonSerializer.Serialize(payload, JsonOptionsProvider.Default);
+    }
+
+    private static string FormatSummaryPayload(SpecReport report)
+    {
+        var summary = report.Summary;
+
+        var payload = new
+        {
+            success = summary.Success,
+            total = summary.Total,
+            passed = summary.Passed,
+            failed = summary.Failed,
+            pending = summary.Pending,
+            skipped = summary.Skipped,
+            durationMs = summary.DurationMs,
+            timestamp = report.Timestamp,
+            source = report.Source
+        };
+
+        return JsonSerializer.Serialize(payload, JsonOptionsProvider.Default);
+    }
+
+    private static void ValidateOptions(WebhookReporterOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Url))
+            throw new ArgumentException("Webhook URL is required", nameof(options));
+
+        if (!Uri.TryCreate(options.Url, UriKind.Absolute, out var uri))
+            throw new ArgumentException("Webhook URL must be a valid absolute URI", nameof(options));
+
+        if (uri.Scheme != "http" && uri.Scheme != "https")
+            throw new ArgumentException("Webhook URL must use HTTP or HTTPS", nameof(options));
+
+        if (options.TimeoutMs <= 0)
+            throw new ArgumentException("Timeout must be positive", nameof(options));
+
+        if (options.MaxRetries < 0)
+            throw new ArgumentException("MaxRetries cannot be negative", nameof(options));
+    }
+
+    /// <summary>
+    /// Dispose the HttpClient if owned.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_ownsHttpClient)
+            _httpClient.Dispose();
+    }
+}
+
+/// <summary>
+/// Exception thrown when webhook delivery fails after all retries.
+/// </summary>
+public class WebhookDeliveryException : Exception
+{
+    /// <summary>
+    /// Create a new WebhookDeliveryException.
+    /// </summary>
+    /// <param name="message">Error message describing the failure</param>
+    /// <param name="innerException">The underlying exception that caused the failure</param>
+    public WebhookDeliveryException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
+}

--- a/tests/DraftSpec.Tests/Plugins/Reporters/WebhookReporterTests.cs
+++ b/tests/DraftSpec.Tests/Plugins/Reporters/WebhookReporterTests.cs
@@ -1,0 +1,440 @@
+using System.Net;
+using System.Text.Json;
+using DraftSpec.Formatters;
+using DraftSpec.Plugins.Reporters;
+
+namespace DraftSpec.Tests.Plugins.Reporters;
+
+/// <summary>
+/// Tests for WebhookReporter.
+/// </summary>
+public class WebhookReporterTests
+{
+    #region Construction and Validation
+
+    [Test]
+    public async Task Constructor_ValidOptions_Succeeds()
+    {
+        var options = new WebhookReporterOptions { Url = "https://example.com/webhook" };
+
+        using var reporter = new WebhookReporter(options);
+
+        await Assert.That(reporter.Name).IsEqualTo("webhook");
+    }
+
+    [Test]
+    public async Task Constructor_NullUrl_ThrowsArgumentException()
+    {
+        await Assert.That(() => new WebhookReporter(new WebhookReporterOptions { Url = null! }))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Constructor_EmptyUrl_ThrowsArgumentException()
+    {
+        await Assert.That(() => new WebhookReporter(new WebhookReporterOptions { Url = "" }))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Constructor_InvalidUrl_ThrowsArgumentException()
+    {
+        await Assert.That(() => new WebhookReporter(new WebhookReporterOptions { Url = "not-a-url" }))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Constructor_NonHttpUrl_ThrowsArgumentException()
+    {
+        await Assert.That(() => new WebhookReporter(new WebhookReporterOptions { Url = "ftp://example.com" }))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Constructor_NegativeTimeout_ThrowsArgumentException()
+    {
+        await Assert.That(() => new WebhookReporter(new WebhookReporterOptions
+            {
+                Url = "https://example.com",
+                TimeoutMs = -1
+            }))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Constructor_NegativeRetries_ThrowsArgumentException()
+    {
+        await Assert.That(() => new WebhookReporter(new WebhookReporterOptions
+            {
+                Url = "https://example.com",
+                MaxRetries = -1
+            }))
+            .Throws<ArgumentException>();
+    }
+
+    #endregion
+
+    #region Payload Formats
+
+    [Test]
+    public async Task OnRunCompletedAsync_JsonFormat_SendsFullReport()
+    {
+        var handler = new MockHttpHandler();
+        using var httpClient = new HttpClient(handler);
+
+        var options = new WebhookReporterOptions
+        {
+            Url = "https://example.com/webhook",
+            Format = WebhookPayloadFormat.Json
+        };
+
+        using var reporter = new WebhookReporter(options, httpClient);
+        var report = CreateTestReport(passed: 3, failed: 1);
+
+        await reporter.OnRunCompletedAsync(report);
+
+        await Assert.That(handler.RequestCount).IsEqualTo(1);
+        var payload = handler.LastRequestContent!;
+        await Assert.That(payload).Contains("\"summary\"");
+        await Assert.That(payload).Contains("\"contexts\"");
+    }
+
+    [Test]
+    public async Task OnRunCompletedAsync_SlackFormat_SendsSlackPayload()
+    {
+        var handler = new MockHttpHandler();
+        using var httpClient = new HttpClient(handler);
+
+        var options = new WebhookReporterOptions
+        {
+            Url = "https://hooks.slack.com/webhook",
+            Format = WebhookPayloadFormat.Slack
+        };
+
+        using var reporter = new WebhookReporter(options, httpClient);
+        var report = CreateTestReport(passed: 5, failed: 0);
+
+        await reporter.OnRunCompletedAsync(report);
+
+        var payload = handler.LastRequestContent!;
+        await Assert.That(payload).Contains("attachments");
+        await Assert.That(payload).Contains("blocks");
+        await Assert.That(payload).Contains("PASSED");
+    }
+
+    [Test]
+    public async Task OnRunCompletedAsync_SlackFormat_FailedTests_ShowsFailed()
+    {
+        var handler = new MockHttpHandler();
+        using var httpClient = new HttpClient(handler);
+
+        var options = new WebhookReporterOptions
+        {
+            Url = "https://hooks.slack.com/webhook",
+            Format = WebhookPayloadFormat.Slack
+        };
+
+        using var reporter = new WebhookReporter(options, httpClient);
+        var report = CreateTestReport(passed: 3, failed: 2);
+
+        await reporter.OnRunCompletedAsync(report);
+
+        var payload = handler.LastRequestContent!;
+        await Assert.That(payload).Contains("FAILED");
+        await Assert.That(payload).Contains("#dc3545"); // Red color
+    }
+
+    [Test]
+    public async Task OnRunCompletedAsync_DiscordFormat_SendsEmbed()
+    {
+        var handler = new MockHttpHandler();
+        using var httpClient = new HttpClient(handler);
+
+        var options = new WebhookReporterOptions
+        {
+            Url = "https://discord.com/api/webhooks/123",
+            Format = WebhookPayloadFormat.Discord
+        };
+
+        using var reporter = new WebhookReporter(options, httpClient);
+        var report = CreateTestReport(passed: 10, failed: 0);
+
+        await reporter.OnRunCompletedAsync(report);
+
+        var payload = handler.LastRequestContent!;
+        await Assert.That(payload).Contains("embeds");
+        await Assert.That(payload).Contains("Tests Passed");
+        await Assert.That(payload).Contains("fields");
+    }
+
+    [Test]
+    public async Task OnRunCompletedAsync_DiscordFormat_FailedTests_ShowsRed()
+    {
+        var handler = new MockHttpHandler();
+        using var httpClient = new HttpClient(handler);
+
+        var options = new WebhookReporterOptions
+        {
+            Url = "https://discord.com/api/webhooks/123",
+            Format = WebhookPayloadFormat.Discord
+        };
+
+        using var reporter = new WebhookReporter(options, httpClient);
+        var report = CreateTestReport(passed: 5, failed: 5);
+
+        await reporter.OnRunCompletedAsync(report);
+
+        var payload = handler.LastRequestContent!;
+        await Assert.That(payload).Contains("Tests Failed");
+        // Verify red color is present (0xdc3545 = 14435653)
+        var json = JsonDocument.Parse(payload);
+        var color = json.RootElement.GetProperty("embeds")[0].GetProperty("color").GetInt32();
+        await Assert.That(color).IsEqualTo(0xdc3545);
+    }
+
+    [Test]
+    public async Task OnRunCompletedAsync_SummaryFormat_SendsMinimalPayload()
+    {
+        var handler = new MockHttpHandler();
+        using var httpClient = new HttpClient(handler);
+
+        var options = new WebhookReporterOptions
+        {
+            Url = "https://example.com/webhook",
+            Format = WebhookPayloadFormat.Summary
+        };
+
+        using var reporter = new WebhookReporter(options, httpClient);
+        var report = CreateTestReport(passed: 8, failed: 2);
+
+        await reporter.OnRunCompletedAsync(report);
+
+        var payload = handler.LastRequestContent!;
+        var json = JsonDocument.Parse(payload);
+
+        await Assert.That(json.RootElement.GetProperty("success").GetBoolean()).IsFalse();
+        await Assert.That(json.RootElement.GetProperty("total").GetInt32()).IsEqualTo(10);
+        await Assert.That(json.RootElement.GetProperty("passed").GetInt32()).IsEqualTo(8);
+        await Assert.That(json.RootElement.GetProperty("failed").GetInt32()).IsEqualTo(2);
+    }
+
+    #endregion
+
+    #region SendOnFailureOnly
+
+    [Test]
+    public async Task OnRunCompletedAsync_SendOnFailureOnly_PassingTests_DoesNotSend()
+    {
+        var handler = new MockHttpHandler();
+        using var httpClient = new HttpClient(handler);
+
+        var options = new WebhookReporterOptions
+        {
+            Url = "https://example.com/webhook",
+            SendOnFailureOnly = true
+        };
+
+        using var reporter = new WebhookReporter(options, httpClient);
+        var report = CreateTestReport(passed: 10, failed: 0);
+
+        await reporter.OnRunCompletedAsync(report);
+
+        await Assert.That(handler.RequestCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task OnRunCompletedAsync_SendOnFailureOnly_FailingTests_Sends()
+    {
+        var handler = new MockHttpHandler();
+        using var httpClient = new HttpClient(handler);
+
+        var options = new WebhookReporterOptions
+        {
+            Url = "https://example.com/webhook",
+            SendOnFailureOnly = true
+        };
+
+        using var reporter = new WebhookReporter(options, httpClient);
+        var report = CreateTestReport(passed: 8, failed: 2);
+
+        await reporter.OnRunCompletedAsync(report);
+
+        await Assert.That(handler.RequestCount).IsEqualTo(1);
+    }
+
+    #endregion
+
+    #region Headers
+
+    [Test]
+    public async Task OnRunCompletedAsync_WithAuthHeader_SendsAuthorization()
+    {
+        var handler = new MockHttpHandler();
+        using var httpClient = new HttpClient(handler);
+
+        var options = new WebhookReporterOptions
+        {
+            Url = "https://example.com/webhook",
+            AuthHeader = "Bearer token123"
+        };
+
+        using var reporter = new WebhookReporter(options, httpClient);
+        var report = CreateTestReport(passed: 1, failed: 0);
+
+        await reporter.OnRunCompletedAsync(report);
+
+        await Assert.That(handler.LastAuthHeader).IsEqualTo("Bearer token123");
+    }
+
+    [Test]
+    public async Task OnRunCompletedAsync_WithCustomHeaders_SendsHeaders()
+    {
+        var handler = new MockHttpHandler();
+        using var httpClient = new HttpClient(handler);
+
+        var options = new WebhookReporterOptions
+        {
+            Url = "https://example.com/webhook",
+            CustomHeaders = new Dictionary<string, string>
+            {
+                ["X-Custom-Header"] = "custom-value",
+                ["X-Another"] = "another-value"
+            }
+        };
+
+        using var reporter = new WebhookReporter(options, httpClient);
+        var report = CreateTestReport(passed: 1, failed: 0);
+
+        await reporter.OnRunCompletedAsync(report);
+
+        await Assert.That(handler.LastCustomHeaders).ContainsKey("X-Custom-Header");
+        await Assert.That(handler.LastCustomHeaders!["X-Custom-Header"]).IsEqualTo("custom-value");
+    }
+
+    #endregion
+
+    #region Retry Logic
+
+    [Test]
+    public async Task OnRunCompletedAsync_ServerError_Retries()
+    {
+        var handler = new MockHttpHandler
+        {
+            FailCount = 1,
+            FailStatusCode = HttpStatusCode.InternalServerError
+        };
+        using var httpClient = new HttpClient(handler);
+
+        var options = new WebhookReporterOptions
+        {
+            Url = "https://example.com/webhook",
+            MaxRetries = 2,
+            RetryDelayMs = 10 // Short delay for tests
+        };
+
+        using var reporter = new WebhookReporter(options, httpClient);
+        var report = CreateTestReport(passed: 1, failed: 0);
+
+        await reporter.OnRunCompletedAsync(report);
+
+        await Assert.That(handler.RequestCount).IsEqualTo(2); // 1 fail + 1 success
+    }
+
+    [Test]
+    public async Task OnRunCompletedAsync_AllRetriesFail_ThrowsWebhookDeliveryException()
+    {
+        var handler = new MockHttpHandler
+        {
+            FailCount = 10, // More than retries
+            FailStatusCode = HttpStatusCode.ServiceUnavailable
+        };
+        using var httpClient = new HttpClient(handler);
+
+        var options = new WebhookReporterOptions
+        {
+            Url = "https://example.com/webhook",
+            MaxRetries = 2,
+            RetryDelayMs = 10
+        };
+
+        using var reporter = new WebhookReporter(options, httpClient);
+        var report = CreateTestReport(passed: 1, failed: 0);
+
+        await Assert.That(async () => await reporter.OnRunCompletedAsync(report))
+            .Throws<WebhookDeliveryException>();
+
+        await Assert.That(handler.RequestCount).IsEqualTo(3); // 1 initial + 2 retries
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static SpecReport CreateTestReport(int passed, int failed, int pending = 0, int skipped = 0)
+    {
+        return new SpecReport
+        {
+            Timestamp = DateTime.UtcNow,
+            Source = "test",
+            Summary = new SpecSummary
+            {
+                Total = passed + failed + pending + skipped,
+                Passed = passed,
+                Failed = failed,
+                Pending = pending,
+                Skipped = skipped,
+                DurationMs = 1234.5
+            },
+            Contexts =
+            [
+                new SpecContextReport
+                {
+                    Description = "Test Suite",
+                    Specs = [],
+                    Contexts = []
+                }
+            ]
+        };
+    }
+
+    /// <summary>
+    /// Mock HTTP handler for testing webhook delivery.
+    /// </summary>
+    private class MockHttpHandler : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+        public string? LastRequestContent { get; private set; }
+        public string? LastAuthHeader { get; private set; }
+        public Dictionary<string, string>? LastCustomHeaders { get; private set; }
+        public int FailCount { get; set; }
+        public HttpStatusCode FailStatusCode { get; set; } = HttpStatusCode.InternalServerError;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+
+            // Capture request details
+            if (request.Content != null)
+                LastRequestContent = await request.Content.ReadAsStringAsync(cancellationToken);
+
+            if (request.Headers.Authorization != null)
+                LastAuthHeader = request.Headers.Authorization.ToString();
+
+            LastCustomHeaders = request.Headers
+                .Where(h => h.Key.StartsWith("X-"))
+                .ToDictionary(h => h.Key, h => string.Join(",", h.Value));
+
+            // Simulate failures
+            if (RequestCount <= FailCount)
+            {
+                return new HttpResponseMessage(FailStatusCode);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Add WebhookReporter to send spec results to external systems via HTTP webhooks (Slack, Discord, CI/CD, monitoring).

## Features

### Payload Formats
- **Json**: Full SpecReport serialized to JSON
- **Slack**: Formatted message with blocks and color-coded status
- **Discord**: Embed with fields and color-coded status  
- **Summary**: Minimal payload with just summary statistics

### Configuration Options
```csharp
var options = new WebhookReporterOptions
{
    Url = "https://hooks.slack.com/...",      // Required
    Format = WebhookPayloadFormat.Slack,       // Json, Slack, Discord, Summary
    AuthHeader = "Bearer token123",            // Optional
    SendOnFailureOnly = true,                  // Only notify on failures
    TimeoutMs = 5000,                          // HTTP timeout
    MaxRetries = 2,                            // Retry attempts
    RetryDelayMs = 1000,                       // Delay between retries
    CustomHeaders = new() { ["X-Key"] = "val" } // Additional headers
};
```

### Usage
```csharp
var config = new DraftSpecConfiguration();
config.Reporters.Add(new WebhookReporter(options));
```

## Tests (19 tests)
- Constructor validation (URL, timeout, retries)
- All payload format outputs (JSON, Slack, Discord, Summary)
- SendOnFailureOnly behavior
- Header handling (auth + custom)
- Retry logic with mock HTTP handler

## Test Plan
- [x] All 852 tests pass
- [x] 19 new tests for WebhookReporter
- [x] Mock HTTP handler for reliable testing

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)