### PR TITLE
Add MCP resources for spec file access (#11)

### DIFF
--- a/src/DraftSpec.Mcp/Program.cs
+++ b/src/DraftSpec.Mcp/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddSingleton<InProcessSpecRunner>();
 builder.Services
     .AddMcpServer()
     .WithStdioServerTransport()
-    .WithToolsFromAssembly();
+    .WithToolsFromAssembly()
+    .WithResourcesFromAssembly();
 
 await builder.Build().RunAsync();

--- a/src/DraftSpec.Mcp/Resources/SpecResources.cs
+++ b/src/DraftSpec.Mcp/Resources/SpecResources.cs
@@ -1,0 +1,224 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+
+namespace DraftSpec.Mcp.Resources;
+
+/// <summary>
+/// MCP resources for accessing spec files.
+/// Enables IDE integrations and spec browsing without separate file system access.
+/// </summary>
+[McpServerResourceType]
+public static class SpecResources
+{
+    /// <summary>
+    /// List all spec files in the working directory.
+    /// </summary>
+    [McpServerResource(UriTemplate = "draftspec://specs", Name = "spec_list")]
+    [Description("List all DraftSpec spec files (*.spec.csx) in the working directory")]
+    public static string ListSpecs(
+        [Description("Directory to search for specs (default: current directory)")]
+        string? directory = null,
+        [Description("Glob pattern to filter specs (default: **/*.spec.csx)")]
+        string? pattern = null)
+    {
+        var searchDir = string.IsNullOrEmpty(directory)
+            ? Directory.GetCurrentDirectory()
+            : Path.GetFullPath(directory);
+
+        if (!Directory.Exists(searchDir))
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = $"Directory not found: {searchDir}",
+                specs = Array.Empty<object>()
+            });
+        }
+
+        var searchPattern = pattern ?? "*.spec.csx";
+        var specs = new List<SpecFileInfo>();
+
+        try
+        {
+            var files = Directory.GetFiles(searchDir, searchPattern, SearchOption.AllDirectories)
+                .OrderBy(f => f)
+                .ToList();
+
+            foreach (var file in files)
+            {
+                var info = new FileInfo(file);
+                specs.Add(new SpecFileInfo
+                {
+                    Path = Path.GetRelativePath(searchDir, file),
+                    FullPath = file,
+                    Name = Path.GetFileNameWithoutExtension(file).Replace(".spec", ""),
+                    Size = info.Length,
+                    ModifiedAt = info.LastWriteTimeUtc
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = ex.Message,
+                specs = Array.Empty<object>()
+            });
+        }
+
+        return JsonSerializer.Serialize(new
+        {
+            directory = searchDir,
+            count = specs.Count,
+            specs
+        }, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true
+        });
+    }
+
+    /// <summary>
+    /// Get the content of a specific spec file.
+    /// </summary>
+    [McpServerResource(UriTemplate = "draftspec://specs/{path}", Name = "spec_content")]
+    [Description("Get the content of a specific DraftSpec spec file")]
+    public static string GetSpec(
+        [Description("Path to the spec file (relative or absolute)")]
+        string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = "Path is required"
+            });
+        }
+
+        var fullPath = Path.IsPathRooted(path)
+            ? path
+            : Path.GetFullPath(path);
+
+        if (!File.Exists(fullPath))
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = $"File not found: {path}"
+            });
+        }
+
+        // Security: Ensure the file has .csx extension
+        if (!fullPath.EndsWith(".csx", StringComparison.OrdinalIgnoreCase))
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = "Only .csx files can be accessed"
+            });
+        }
+
+        try
+        {
+            var info = new FileInfo(fullPath);
+            var content = File.ReadAllText(fullPath);
+
+            return JsonSerializer.Serialize(new
+            {
+                path = path,
+                fullPath,
+                name = Path.GetFileNameWithoutExtension(fullPath).Replace(".spec", ""),
+                size = info.Length,
+                modifiedAt = info.LastWriteTimeUtc,
+                content
+            }, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = ex.Message
+            });
+        }
+    }
+
+    /// <summary>
+    /// Get metadata about a spec file without its content.
+    /// </summary>
+    [McpServerResource(UriTemplate = "draftspec://specs/{path}/metadata", Name = "spec_metadata")]
+    [Description("Get metadata about a spec file (size, modified date) without content")]
+    public static string GetSpecMetadata(
+        [Description("Path to the spec file")]
+        string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = "Path is required"
+            });
+        }
+
+        var fullPath = Path.IsPathRooted(path)
+            ? path
+            : Path.GetFullPath(path);
+
+        if (!File.Exists(fullPath))
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = $"File not found: {path}"
+            });
+        }
+
+        try
+        {
+            var info = new FileInfo(fullPath);
+
+            // Count describe/it blocks for a quick overview
+            var content = File.ReadAllText(fullPath);
+            var describeCount = System.Text.RegularExpressions.Regex.Matches(content, @"\bdescribe\s*\(").Count;
+            var itCount = System.Text.RegularExpressions.Regex.Matches(content, @"\bit\s*\(").Count;
+
+            return JsonSerializer.Serialize(new
+            {
+                path = path,
+                fullPath,
+                name = Path.GetFileNameWithoutExtension(fullPath).Replace(".spec", ""),
+                size = info.Length,
+                modifiedAt = info.LastWriteTimeUtc,
+                createdAt = info.CreationTimeUtc,
+                stats = new
+                {
+                    describeBlocks = describeCount,
+                    specs = itCount
+                }
+            }, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = ex.Message
+            });
+        }
+    }
+}
+
+/// <summary>
+/// Information about a spec file.
+/// </summary>
+internal class SpecFileInfo
+{
+    public string Path { get; set; } = "";
+    public string FullPath { get; set; } = "";
+    public string Name { get; set; } = "";
+    public long Size { get; set; }
+    public DateTime ModifiedAt { get; set; }
+}

--- a/tests/DraftSpec.Tests/Mcp/Resources/SpecResourcesTests.cs
+++ b/tests/DraftSpec.Tests/Mcp/Resources/SpecResourcesTests.cs
@@ -1,0 +1,274 @@
+using System.Text.Json;
+using DraftSpec.Mcp.Resources;
+
+namespace DraftSpec.Tests.Mcp.Resources;
+
+/// <summary>
+/// Tests for SpecResources MCP methods.
+/// </summary>
+public class SpecResourcesTests
+{
+    private string _tempDir = null!;
+
+    [Before(Test)]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"draftspec_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [After(Test)]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    #region ListSpecs
+
+    [Test]
+    public async Task ListSpecs_EmptyDirectory_ReturnsEmptyList()
+    {
+        var result = SpecResources.ListSpecs(_tempDir);
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.GetProperty("count").GetInt32()).IsEqualTo(0);
+        await Assert.That(json.RootElement.GetProperty("specs").GetArrayLength()).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ListSpecs_WithSpecFiles_ReturnsFiles()
+    {
+        // Create test spec files
+        File.WriteAllText(Path.Combine(_tempDir, "test.spec.csx"), "// spec content");
+        File.WriteAllText(Path.Combine(_tempDir, "another.spec.csx"), "// another spec");
+
+        var result = SpecResources.ListSpecs(_tempDir);
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.GetProperty("count").GetInt32()).IsEqualTo(2);
+        await Assert.That(json.RootElement.GetProperty("specs").GetArrayLength()).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ListSpecs_NestedDirectories_FindsAllSpecs()
+    {
+        // Create nested structure
+        var subDir = Path.Combine(_tempDir, "nested");
+        Directory.CreateDirectory(subDir);
+        File.WriteAllText(Path.Combine(_tempDir, "root.spec.csx"), "// root");
+        File.WriteAllText(Path.Combine(subDir, "nested.spec.csx"), "// nested");
+
+        var result = SpecResources.ListSpecs(_tempDir);
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.GetProperty("count").GetInt32()).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ListSpecs_IgnoresNonSpecFiles()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "test.spec.csx"), "// spec");
+        File.WriteAllText(Path.Combine(_tempDir, "other.csx"), "// not a spec");
+        File.WriteAllText(Path.Combine(_tempDir, "readme.md"), "# readme");
+
+        var result = SpecResources.ListSpecs(_tempDir);
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.GetProperty("count").GetInt32()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ListSpecs_NonexistentDirectory_ReturnsError()
+    {
+        var result = SpecResources.ListSpecs("/nonexistent/path");
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.TryGetProperty("error", out _)).IsTrue();
+    }
+
+    [Test]
+    public async Task ListSpecs_IncludesFileMetadata()
+    {
+        var specPath = Path.Combine(_tempDir, "test.spec.csx");
+        File.WriteAllText(specPath, "// spec content here");
+
+        var result = SpecResources.ListSpecs(_tempDir);
+        var json = JsonDocument.Parse(result);
+
+        var spec = json.RootElement.GetProperty("specs")[0];
+        await Assert.That(spec.GetProperty("name").GetString()).IsEqualTo("test");
+        await Assert.That(spec.GetProperty("path").GetString()).IsEqualTo("test.spec.csx");
+        await Assert.That(spec.GetProperty("size").GetInt64()).IsGreaterThan(0);
+    }
+
+    #endregion
+
+    #region GetSpec
+
+    [Test]
+    public async Task GetSpec_ExistingFile_ReturnsContent()
+    {
+        var specPath = Path.Combine(_tempDir, "test.spec.csx");
+        var content = "describe('test', () => { it('works', () => { }); });";
+        File.WriteAllText(specPath, content);
+
+        var result = SpecResources.GetSpec(specPath);
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.GetProperty("content").GetString()).IsEqualTo(content);
+        await Assert.That(json.RootElement.TryGetProperty("error", out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task GetSpec_NonexistentFile_ReturnsError()
+    {
+        var result = SpecResources.GetSpec("/nonexistent/file.spec.csx");
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.TryGetProperty("error", out _)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetSpec_EmptyPath_ReturnsError()
+    {
+        var result = SpecResources.GetSpec("");
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.TryGetProperty("error", out _)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetSpec_NonCsxFile_ReturnsError()
+    {
+        var txtPath = Path.Combine(_tempDir, "test.txt");
+        File.WriteAllText(txtPath, "not a spec");
+
+        var result = SpecResources.GetSpec(txtPath);
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.TryGetProperty("error", out _)).IsTrue();
+        await Assert.That(json.RootElement.GetProperty("error").GetString()).Contains(".csx");
+    }
+
+    [Test]
+    public async Task GetSpec_RelativePath_Works()
+    {
+        var specPath = Path.Combine(_tempDir, "test.spec.csx");
+        File.WriteAllText(specPath, "// content");
+
+        // Change to temp directory and use relative path
+        var originalDir = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(_tempDir);
+            var result = SpecResources.GetSpec("test.spec.csx");
+            var json = JsonDocument.Parse(result);
+
+            await Assert.That(json.RootElement.TryGetProperty("content", out _)).IsTrue();
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalDir);
+        }
+    }
+
+    [Test]
+    public async Task GetSpec_IncludesMetadata()
+    {
+        var specPath = Path.Combine(_tempDir, "mytest.spec.csx");
+        File.WriteAllText(specPath, "// spec");
+
+        var result = SpecResources.GetSpec(specPath);
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.GetProperty("name").GetString()).IsEqualTo("mytest");
+        await Assert.That(json.RootElement.TryGetProperty("size", out _)).IsTrue();
+        await Assert.That(json.RootElement.TryGetProperty("modifiedAt", out _)).IsTrue();
+    }
+
+    #endregion
+
+    #region GetSpecMetadata
+
+    [Test]
+    public async Task GetSpecMetadata_ExistingFile_ReturnsMetadata()
+    {
+        var specPath = Path.Combine(_tempDir, "test.spec.csx");
+        File.WriteAllText(specPath, "describe('Test', () => { it('works'); });");
+
+        var result = SpecResources.GetSpecMetadata(specPath);
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.TryGetProperty("error", out _)).IsFalse();
+        await Assert.That(json.RootElement.GetProperty("name").GetString()).IsEqualTo("test");
+    }
+
+    [Test]
+    public async Task GetSpecMetadata_CountsDescribeBlocks()
+    {
+        var specPath = Path.Combine(_tempDir, "test.spec.csx");
+        File.WriteAllText(specPath, @"
+describe('First', () => {
+    describe('Nested', () => { });
+});
+describe('Second', () => { });
+");
+
+        var result = SpecResources.GetSpecMetadata(specPath);
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.GetProperty("stats").GetProperty("describeBlocks").GetInt32()).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task GetSpecMetadata_CountsItSpecs()
+    {
+        var specPath = Path.Combine(_tempDir, "test.spec.csx");
+        File.WriteAllText(specPath, @"
+describe('Test', () => {
+    it('first', () => { });
+    it('second', () => { });
+    it('third');
+});
+");
+
+        var result = SpecResources.GetSpecMetadata(specPath);
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.GetProperty("stats").GetProperty("specs").GetInt32()).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task GetSpecMetadata_NonexistentFile_ReturnsError()
+    {
+        var result = SpecResources.GetSpecMetadata("/nonexistent/file.spec.csx");
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.TryGetProperty("error", out _)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetSpecMetadata_EmptyPath_ReturnsError()
+    {
+        var result = SpecResources.GetSpecMetadata("");
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.TryGetProperty("error", out _)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetSpecMetadata_IncludesTimestamps()
+    {
+        var specPath = Path.Combine(_tempDir, "test.spec.csx");
+        File.WriteAllText(specPath, "// spec");
+
+        var result = SpecResources.GetSpecMetadata(specPath);
+        var json = JsonDocument.Parse(result);
+
+        await Assert.That(json.RootElement.TryGetProperty("modifiedAt", out _)).IsTrue();
+        await Assert.That(json.RootElement.TryGetProperty("createdAt", out _)).IsTrue();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Expose spec files as MCP resources for IDE integrations and AI assistants.

**Resources added:**
- `spec_list` (draftspec://specs) - List all spec files in a directory with metadata
- `spec_content` (draftspec://specs/{path}) - Get spec file content with full path and metadata
- `spec_metadata` (draftspec://specs/{path}/metadata) - Get file metadata including describe/it block counts

**Features:**
- Recursive spec discovery in directories
- Metadata includes file size, timestamps, and spec structure counts
- Security: Only .csx files can be accessed via GetSpec
- Consistent JSON serialized responses with error handling

## Test plan
- [x] All 871 tests pass
- [x] 18 new tests added for SpecResources
- [x] Tests cover error cases (nonexistent files, empty paths, non-csx files)
- [x] Tests verify metadata extraction (timestamps, describe/it counts)
- [x] Tests verify nested directory discovery

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)