### PR TITLE
Add toMatch and toHaveLength string assertions

### DIFF
--- a/src/DraftSpec/Expectations/StringExpectation.cs
+++ b/src/DraftSpec/Expectations/StringExpectation.cs
@@ -93,4 +93,48 @@ public readonly struct StringExpectation
             throw new AssertionException(
                 $"Expected {Expression} to be null, but was \"{Actual}\"");
     }
+
+    /// <summary>
+    /// Assert that the string matches a regular expression pattern.
+    /// </summary>
+    /// <param name="pattern">The regex pattern to match against.</param>
+    public void toMatch(string pattern)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+
+        if (Actual is null || !System.Text.RegularExpressions.Regex.IsMatch(Actual, pattern))
+            throw new AssertionException(
+                $"Expected {Expression} to match pattern \"{pattern}\", but was \"{Actual}\"");
+    }
+
+    /// <summary>
+    /// Assert that the string matches a regular expression.
+    /// </summary>
+    /// <param name="regex">The regex to match against.</param>
+    public void toMatch(System.Text.RegularExpressions.Regex regex)
+    {
+        ArgumentNullException.ThrowIfNull(regex);
+
+        if (Actual is null || !regex.IsMatch(Actual))
+            throw new AssertionException(
+                $"Expected {Expression} to match pattern \"{regex}\", but was \"{Actual}\"");
+    }
+
+    /// <summary>
+    /// Assert that the string has the expected length.
+    /// </summary>
+    /// <param name="expectedLength">The expected length.</param>
+    public void toHaveLength(int expectedLength)
+    {
+        if (expectedLength < 0)
+            throw new ArgumentOutOfRangeException(nameof(expectedLength), "Length must be non-negative");
+
+        if (Actual is null)
+            throw new AssertionException(
+                $"Expected {Expression} to have length {expectedLength}, but was null");
+
+        if (Actual.Length != expectedLength)
+            throw new AssertionException(
+                $"Expected {Expression} to have length {expectedLength}, but had length {Actual.Length}");
+    }
 }

--- a/tests/DraftSpec.Tests/Expectations/StringExpectationTests.cs
+++ b/tests/DraftSpec.Tests/Expectations/StringExpectationTests.cs
@@ -185,4 +185,155 @@ public class StringExpectationTests
     }
 
     #endregion
+
+    #region toMatch (string pattern)
+
+    [Test]
+    public async Task toMatch_WhenPatternMatches_Passes()
+    {
+        var expectation = new StringExpectation("hello123world", "value");
+        expectation.toMatch(@"\d+");
+    }
+
+    [Test]
+    public async Task toMatch_WhenPatternDoesNotMatch_Throws()
+    {
+        var expectation = new StringExpectation("hello world", "value");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.toMatch(@"\d+"));
+
+        await Assert.That(ex.Message).Contains("to match pattern");
+    }
+
+    [Test]
+    public async Task toMatch_WithNullActual_Throws()
+    {
+        var expectation = new StringExpectation(null, "value");
+
+        Assert.Throws<AssertionException>(() => expectation.toMatch(@"\d+"));
+    }
+
+    [Test]
+    public async Task toMatch_WithNullPattern_ThrowsArgumentNull()
+    {
+        var expectation = new StringExpectation("hello", "value");
+
+        Assert.Throws<ArgumentNullException>(() => expectation.toMatch((string)null!));
+    }
+
+    [Test]
+    public async Task toMatch_WithComplexPattern_Passes()
+    {
+        var expectation = new StringExpectation("user@example.com", "email");
+        expectation.toMatch(@"^[\w.+-]+@[\w-]+\.[\w.-]+$");
+    }
+
+    [Test]
+    public async Task toMatch_WithAnchoredPattern_WorksCorrectly()
+    {
+        var expectation = new StringExpectation("hello", "value");
+
+        // Should match when pattern is not anchored
+        expectation.toMatch("ell");
+
+        // Should fail when anchored pattern doesn't match
+        Assert.Throws<AssertionException>(() => expectation.toMatch("^ell$"));
+    }
+
+    #endregion
+
+    #region toMatch (Regex)
+
+    [Test]
+    public async Task toMatch_WithRegex_WhenMatches_Passes()
+    {
+        var expectation = new StringExpectation("HELLO123", "value");
+        var regex = new System.Text.RegularExpressions.Regex(@"\d+", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        expectation.toMatch(regex);
+    }
+
+    [Test]
+    public async Task toMatch_WithRegex_WhenDoesNotMatch_Throws()
+    {
+        var expectation = new StringExpectation("hello", "value");
+        var regex = new System.Text.RegularExpressions.Regex(@"\d+");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.toMatch(regex));
+
+        await Assert.That(ex.Message).Contains("to match pattern");
+    }
+
+    [Test]
+    public async Task toMatch_WithRegex_NullActual_Throws()
+    {
+        var expectation = new StringExpectation(null, "value");
+        var regex = new System.Text.RegularExpressions.Regex(@"\d+");
+
+        Assert.Throws<AssertionException>(() => expectation.toMatch(regex));
+    }
+
+    [Test]
+    public async Task toMatch_WithNullRegex_ThrowsArgumentNull()
+    {
+        var expectation = new StringExpectation("hello", "value");
+
+        Assert.Throws<ArgumentNullException>(() => expectation.toMatch((System.Text.RegularExpressions.Regex)null!));
+    }
+
+    #endregion
+
+    #region toHaveLength
+
+    [Test]
+    public async Task toHaveLength_WhenLengthMatches_Passes()
+    {
+        var expectation = new StringExpectation("hello", "value");
+        expectation.toHaveLength(5);
+    }
+
+    [Test]
+    public async Task toHaveLength_WhenLengthDoesNotMatch_Throws()
+    {
+        var expectation = new StringExpectation("hello", "value");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.toHaveLength(3));
+
+        await Assert.That(ex.Message).Contains("to have length 3");
+        await Assert.That(ex.Message).Contains("had length 5");
+    }
+
+    [Test]
+    public async Task toHaveLength_WithNullActual_Throws()
+    {
+        var expectation = new StringExpectation(null, "value");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.toHaveLength(5));
+
+        await Assert.That(ex.Message).Contains("was null");
+    }
+
+    [Test]
+    public async Task toHaveLength_WithEmptyString_PassesForZero()
+    {
+        var expectation = new StringExpectation("", "value");
+        expectation.toHaveLength(0);
+    }
+
+    [Test]
+    public async Task toHaveLength_WithNegativeLength_ThrowsArgumentOutOfRange()
+    {
+        var expectation = new StringExpectation("hello", "value");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => expectation.toHaveLength(-1));
+    }
+
+    [Test]
+    public async Task toHaveLength_WithUnicodeString_CountsCharacters()
+    {
+        // "Hello 🌍" has 8 characters (including the emoji which is 1 character in .NET)
+        var expectation = new StringExpectation("Hello 🌍", "value");
+        expectation.toHaveLength(8);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- Add `toMatch(string pattern)` assertion for regex pattern matching
- Add `toMatch(Regex regex)` overload for compiled regex with options
- Add `toHaveLength(int length)` assertion for string length validation

## Test coverage
16 new tests covering:
- Pattern matching (partial and anchored patterns)
- Regex with options (e.g., `RegexOptions.IgnoreCase`)
- Null string handling (throws AssertionException)
- Null pattern/regex argument validation (throws ArgumentNullException)
- Complex patterns (email validation example)
- Length validation with edge cases (empty string, negative length, Unicode)

## Test plan
- [x] All 35 StringExpectation tests pass
- [x] Full test suite passes (906 tests)

Fixes #64
Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)