### PR TITLE
Add async action expectation (toThrowAsync)

### DIFF
--- a/src/DraftSpec/Dsl.Expect.cs
+++ b/src/DraftSpec/Dsl.Expect.cs
@@ -45,6 +45,16 @@ public static partial class Dsl
     }
 
     /// <summary>
+    /// Create an expectation for an async action (async exception testing).
+    /// </summary>
+    public static AsyncActionExpectation expect(
+        Func<Task> asyncAction,
+        [CallerArgumentExpression("asyncAction")] string? expr = null)
+    {
+        return new AsyncActionExpectation(asyncAction, expr);
+    }
+
+    /// <summary>
     /// Create an expectation for an array.
     /// </summary>
     public static CollectionExpectation<T> expect<T>(

--- a/src/DraftSpec/Expectations/AsyncActionExpectation.cs
+++ b/src/DraftSpec/Expectations/AsyncActionExpectation.cs
@@ -1,0 +1,95 @@
+namespace DraftSpec;
+
+/// <summary>
+/// Expectation wrapper for async actions, used for testing async exception behavior.
+/// </summary>
+/// <remarks>
+/// Created via <c>expect(async () => await action())</c>. Provides assertions like
+/// <c>toThrowAsync&lt;T&gt;()</c> and <c>toNotThrowAsync()</c>.
+/// Extension methods can access <see cref="AsyncAction"/> and <see cref="Expression"/>
+/// to create custom matchers.
+/// </remarks>
+public readonly struct AsyncActionExpectation
+{
+    /// <summary>
+    /// The async action being asserted.
+    /// Exposed for extension methods to create custom matchers.
+    /// </summary>
+    public Func<Task> AsyncAction { get; }
+
+    /// <summary>
+    /// The expression text captured from the call site (for error messages).
+    /// Exposed for extension methods to create custom matchers.
+    /// </summary>
+    public string? Expression { get; }
+
+    /// <summary>
+    /// Creates an expectation for the specified async action.
+    /// </summary>
+    /// <param name="asyncAction">The async action to execute and assert against.</param>
+    /// <param name="expr">The expression text (for error messages).</param>
+    public AsyncActionExpectation(Func<Task> asyncAction, string? expr)
+    {
+        AsyncAction = asyncAction;
+        Expression = expr;
+    }
+
+    /// <summary>
+    /// Assert that the async action throws an exception of the specified type.
+    /// </summary>
+    /// <returns>The thrown exception for further assertions.</returns>
+    public async Task<TException> toThrowAsync<TException>() where TException : Exception
+    {
+        try
+        {
+            await AsyncAction();
+        }
+        catch (TException ex)
+        {
+            return ex;
+        }
+        catch (Exception ex)
+        {
+            throw new AssertionException(
+                $"Expected {Expression} to throw {typeof(TException).Name}, but threw {ex.GetType().Name}: {ex.Message}");
+        }
+
+        throw new AssertionException(
+            $"Expected {Expression} to throw {typeof(TException).Name}, but no exception was thrown");
+    }
+
+    /// <summary>
+    /// Assert that the async action throws any exception.
+    /// </summary>
+    /// <returns>The thrown exception for further assertions.</returns>
+    public async Task<Exception> toThrowAsync()
+    {
+        try
+        {
+            await AsyncAction();
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+
+        throw new AssertionException(
+            $"Expected {Expression} to throw an exception, but no exception was thrown");
+    }
+
+    /// <summary>
+    /// Assert that the async action does not throw any exception.
+    /// </summary>
+    public async Task toNotThrowAsync()
+    {
+        try
+        {
+            await AsyncAction();
+        }
+        catch (Exception ex)
+        {
+            throw new AssertionException(
+                $"Expected {Expression} to not throw, but threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}

--- a/tests/DraftSpec.Tests/Expectations/AsyncActionExpectationTests.cs
+++ b/tests/DraftSpec.Tests/Expectations/AsyncActionExpectationTests.cs
@@ -1,0 +1,203 @@
+namespace DraftSpec.Tests.Expectations;
+
+/// <summary>
+/// Tests for AsyncActionExpectation (async exception testing).
+/// </summary>
+public class AsyncActionExpectationTests
+{
+    #region toThrowAsync<T>
+
+    [Test]
+    public async Task toThrowAsync_WithCorrectExceptionType_ReturnsException()
+    {
+        var expectation = new AsyncActionExpectation(
+            async () =>
+            {
+                await Task.Yield();
+                throw new InvalidOperationException("test message");
+            },
+            "asyncAction");
+
+        var ex = await expectation.toThrowAsync<InvalidOperationException>();
+
+        await Assert.That(ex.Message).IsEqualTo("test message");
+    }
+
+    [Test]
+    public async Task toThrowAsync_WithWrongExceptionType_Throws()
+    {
+        var expectation = new AsyncActionExpectation(
+            async () =>
+            {
+                await Task.Yield();
+                throw new ArgumentException("wrong type");
+            },
+            "asyncAction");
+
+        var ex = await Assert.ThrowsAsync<AssertionException>(async () =>
+            await expectation.toThrowAsync<InvalidOperationException>());
+
+        await Assert.That(ex.Message).Contains("to throw InvalidOperationException");
+        await Assert.That(ex.Message).Contains("but threw ArgumentException");
+    }
+
+    [Test]
+    public async Task toThrowAsync_WithNoException_Throws()
+    {
+        var expectation = new AsyncActionExpectation(
+            async () =>
+            {
+                await Task.Yield();
+                // does nothing
+            },
+            "asyncAction");
+
+        var ex = await Assert.ThrowsAsync<AssertionException>(async () =>
+            await expectation.toThrowAsync<InvalidOperationException>());
+
+        await Assert.That(ex.Message).Contains("to throw InvalidOperationException");
+        await Assert.That(ex.Message).Contains("no exception was thrown");
+    }
+
+    [Test]
+    public async Task toThrowAsync_WithDerivedExceptionType_Catches()
+    {
+        var expectation = new AsyncActionExpectation(
+            async () =>
+            {
+                await Task.Yield();
+                throw new ArgumentNullException("param");
+            },
+            "asyncAction");
+
+        // ArgumentNullException derives from ArgumentException
+        var ex = await expectation.toThrowAsync<ArgumentException>();
+
+        await Assert.That(ex).IsTypeOf<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task toThrowAsync_WithImmediateThrow_Catches()
+    {
+        // Test that sync exceptions in async methods are caught
+        var expectation = new AsyncActionExpectation(
+            () => throw new InvalidOperationException("sync throw"),
+            "asyncAction");
+
+        var ex = await expectation.toThrowAsync<InvalidOperationException>();
+
+        await Assert.That(ex.Message).IsEqualTo("sync throw");
+    }
+
+    #endregion
+
+    #region toThrowAsync (any exception)
+
+    [Test]
+    public async Task toThrowAsync_AnyException_WhenThrows_ReturnsException()
+    {
+        var expectation = new AsyncActionExpectation(
+            async () =>
+            {
+                await Task.Yield();
+                throw new Exception("any exception");
+            },
+            "asyncAction");
+
+        var ex = await expectation.toThrowAsync();
+
+        await Assert.That(ex.Message).IsEqualTo("any exception");
+    }
+
+    [Test]
+    public async Task toThrowAsync_AnyException_WhenNoThrow_Throws()
+    {
+        var expectation = new AsyncActionExpectation(
+            async () =>
+            {
+                await Task.Yield();
+                // does nothing
+            },
+            "asyncAction");
+
+        var ex = await Assert.ThrowsAsync<AssertionException>(async () =>
+            await expectation.toThrowAsync());
+
+        await Assert.That(ex.Message).Contains("to throw an exception");
+        await Assert.That(ex.Message).Contains("no exception was thrown");
+    }
+
+    #endregion
+
+    #region toNotThrowAsync
+
+    [Test]
+    public async Task toNotThrowAsync_WhenNoException_Passes()
+    {
+        var expectation = new AsyncActionExpectation(
+            async () =>
+            {
+                await Task.Yield();
+                // does nothing
+            },
+            "asyncAction");
+
+        await expectation.toNotThrowAsync(); // Should not throw
+    }
+
+    [Test]
+    public async Task toNotThrowAsync_WhenThrows_ThrowsAssertionException()
+    {
+        var expectation = new AsyncActionExpectation(
+            async () =>
+            {
+                await Task.Yield();
+                throw new InvalidOperationException("oops");
+            },
+            "asyncAction");
+
+        var ex = await Assert.ThrowsAsync<AssertionException>(async () =>
+            await expectation.toNotThrowAsync());
+
+        await Assert.That(ex.Message).Contains("to not throw");
+        await Assert.That(ex.Message).Contains("InvalidOperationException");
+        await Assert.That(ex.Message).Contains("oops");
+    }
+
+    [Test]
+    public async Task toNotThrowAsync_WithDelayedCompletion_Passes()
+    {
+        var expectation = new AsyncActionExpectation(
+            async () =>
+            {
+                await Task.Delay(10);
+            },
+            "asyncAction");
+
+        await expectation.toNotThrowAsync(); // Should not throw
+    }
+
+    #endregion
+
+    #region DSL Integration
+
+    [Test]
+    public async Task expect_WithFuncTask_ReturnsAsyncActionExpectation()
+    {
+        // Test that the DSL correctly creates AsyncActionExpectation
+        var expectation = DraftSpec.Dsl.expect(async () => await Task.Yield());
+
+        await Assert.That(expectation).IsTypeOf<AsyncActionExpectation>();
+    }
+
+    [Test]
+    public async Task expect_WithAsyncLambda_CapturesExpression()
+    {
+        var expectation = DraftSpec.Dsl.expect(async () => await Task.Yield());
+
+        // The expression should be captured (non-null)
+        await Assert.That(expectation.Expression).IsNotNull();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Adds `AsyncActionExpectation` for testing exceptions in async methods:
- `toThrowAsync<T>()`: Assert async action throws specific exception type
- `toThrowAsync()`: Assert async action throws any exception
- `toNotThrowAsync()`: Assert async action completes without exception

Also adds DSL overload: `expect(Func<Task> asyncAction)`

## Usage
```csharp
await expect(async () => await service.ProcessAsync()).toThrowAsync<InvalidOperationException>();
await expect(async () => await api.CallAsync()).toNotThrowAsync();
```

## Test coverage
12 new tests covering:
- Correct exception type capture and return
- Wrong exception type handling
- No exception thrown scenarios
- Derived exception type matching
- Synchronous exceptions in async methods
- DSL integration

## Test plan
- [x] All 12 AsyncActionExpectation tests pass
- [x] Full test suite passes (969 tests)

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)