### PR TITLE
Strengthen session ID generation with cryptographic randomness

### DIFF
--- a/src/DraftSpec.Mcp/Services/SessionManager.cs
+++ b/src/DraftSpec.Mcp/Services/SessionManager.cs
@@ -161,8 +161,9 @@ public class SessionManager : IDisposable
 
     private static string GenerateSessionId()
     {
-        // Generate a short, readable session ID
-        return $"session-{DateTime.UtcNow:yyyyMMdd-HHmmss}-{Guid.NewGuid().ToString()[..8]}";
+        // Generate a cryptographically random session ID using full GUID (122 bits of randomness)
+        // No predictable timestamp prefix - purely random for security
+        return $"session-{Guid.NewGuid():N}";
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Replace predictable timestamp-based session IDs with fully random GUIDs for improved security.

**Before:** `session-{yyyyMMdd}-{HHmmss}-{guid8}` (partially guessable if creation time is known)
**After:** `session-{guid32}` (122 bits of cryptographic randomness)

## Security improvement
Attackers can no longer narrow down possible session IDs by knowing approximate creation time. The old format leaked timing information, reducing effective entropy.

## Test coverage
3 new tests added:
- `SessionIds_AreUnique` - verifies 100 concurrent session IDs are unique
- `SessionId_HasNoPredictableTimestamp` - verifies no date/time patterns
- `SessionId_UsesFullGuidEntropy` - verifies 32 hex characters of randomness

## Test plan
- [x] All 20 SessionManager tests pass
- [x] Full test suite passes (972 tests)

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)