### PR TITLE
Add .not negation pattern for assertions

### DIFF
--- a/src/DraftSpec/Expectations/ActionExpectation.cs
+++ b/src/DraftSpec/Expectations/ActionExpectation.cs
@@ -35,6 +35,17 @@ public readonly struct ActionExpectation
     }
 
     /// <summary>
+    /// Returns a negated expectation for chaining negative assertions.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// expect(() => action()).not.toThrow();
+    /// expect(() => action()).not.toThrow&lt;InvalidOperationException&gt;();
+    /// </code>
+    /// </example>
+    public NegatedActionExpectation not => new(Action, Expression);
+
+    /// <summary>
     /// Assert that the action throws an exception of the specified type.
     /// </summary>
     public TException toThrow<TException>() where TException : Exception

--- a/src/DraftSpec/Expectations/AsyncActionExpectation.cs
+++ b/src/DraftSpec/Expectations/AsyncActionExpectation.cs
@@ -35,6 +35,17 @@ public readonly struct AsyncActionExpectation
     }
 
     /// <summary>
+    /// Returns a negated expectation for chaining negative assertions.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// await expect(async () => await action()).not.toThrowAsync();
+    /// await expect(async () => await action()).not.toThrowAsync&lt;InvalidOperationException&gt;();
+    /// </code>
+    /// </example>
+    public NegatedAsyncActionExpectation not => new(AsyncAction, Expression);
+
+    /// <summary>
     /// Assert that the async action throws an exception of the specified type.
     /// </summary>
     /// <returns>The thrown exception for further assertions.</returns>

--- a/src/DraftSpec/Expectations/BoolExpectation.cs
+++ b/src/DraftSpec/Expectations/BoolExpectation.cs
@@ -35,6 +35,17 @@ public readonly struct BoolExpectation
     }
 
     /// <summary>
+    /// Returns a negated expectation for chaining negative assertions.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// expect(value).not.toBeTrue();
+    /// expect(value).not.toBeFalse();
+    /// </code>
+    /// </example>
+    public NegatedBoolExpectation not => new(Actual, Expression);
+
+    /// <summary>
     /// Assert that the value is true.
     /// </summary>
     public void toBeTrue()

--- a/src/DraftSpec/Expectations/CollectionExpectation.cs
+++ b/src/DraftSpec/Expectations/CollectionExpectation.cs
@@ -38,6 +38,17 @@ public readonly struct CollectionExpectation<T>
     }
 
     /// <summary>
+    /// Returns a negated expectation for chaining negative assertions.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// expect(list).not.toContain(item);
+    /// expect(list).not.toBeEmpty();
+    /// </code>
+    /// </example>
+    public NegatedCollectionExpectation<T> not => new(Actual, Expression);
+
+    /// <summary>
     /// Assert that the collection contains the specified item.
     /// </summary>
     public void toContain(T expected)

--- a/src/DraftSpec/Expectations/Expectation.cs
+++ b/src/DraftSpec/Expectations/Expectation.cs
@@ -52,6 +52,17 @@ public readonly struct Expectation<T>
     }
 
     /// <summary>
+    /// Returns a negated expectation for chaining negative assertions.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// expect(value).not.toBe(5);
+    /// expect(value).not.toBeNull();
+    /// </code>
+    /// </example>
+    public NegatedExpectation<T> not => new(Actual, Expression);
+
+    /// <summary>
     /// Asserts that the actual value equals the expected value.
     /// </summary>
     /// <param name="expected">The expected value.</param>

--- a/src/DraftSpec/Expectations/NegatedActionExpectation.cs
+++ b/src/DraftSpec/Expectations/NegatedActionExpectation.cs
@@ -1,0 +1,70 @@
+namespace DraftSpec;
+
+/// <summary>
+/// Negated expectation wrapper for action/exception assertions.
+/// Returned by <c>expect(action).not</c> to enable negative assertions.
+/// </summary>
+/// <example>
+/// <code>
+/// expect(() => action()).not.toThrow();
+/// expect(() => action()).not.toThrow&lt;InvalidOperationException&gt;();
+/// </code>
+/// </example>
+public readonly struct NegatedActionExpectation
+{
+    /// <summary>
+    /// The action being asserted.
+    /// </summary>
+    public Action Action { get; }
+
+    /// <summary>
+    /// The expression text captured from the call site (for error messages).
+    /// </summary>
+    public string? Expression { get; }
+
+    /// <summary>
+    /// Creates a negated expectation for the specified action.
+    /// </summary>
+    public NegatedActionExpectation(Action action, string? expr)
+    {
+        Action = action;
+        Expression = expr;
+    }
+
+    /// <summary>
+    /// Assert that the action does NOT throw an exception of the specified type.
+    /// Passes if no exception is thrown or a different type is thrown.
+    /// </summary>
+    public void toThrow<TException>() where TException : Exception
+    {
+        try
+        {
+            Action();
+        }
+        catch (TException)
+        {
+            throw new AssertionException(
+                $"Expected {Expression} to not throw {typeof(TException).Name}, but it did");
+        }
+        catch
+        {
+            // Different exception type - this is fine
+        }
+    }
+
+    /// <summary>
+    /// Assert that the action does NOT throw any exception.
+    /// </summary>
+    public void toThrow()
+    {
+        try
+        {
+            Action();
+        }
+        catch (Exception ex)
+        {
+            throw new AssertionException(
+                $"Expected {Expression} to not throw, but threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}

--- a/src/DraftSpec/Expectations/NegatedAsyncActionExpectation.cs
+++ b/src/DraftSpec/Expectations/NegatedAsyncActionExpectation.cs
@@ -1,0 +1,70 @@
+namespace DraftSpec;
+
+/// <summary>
+/// Negated expectation wrapper for async action/exception assertions.
+/// Returned by <c>expect(asyncAction).not</c> to enable negative assertions.
+/// </summary>
+/// <example>
+/// <code>
+/// await expect(async () => await action()).not.toThrowAsync();
+/// await expect(async () => await action()).not.toThrowAsync&lt;InvalidOperationException&gt;();
+/// </code>
+/// </example>
+public readonly struct NegatedAsyncActionExpectation
+{
+    /// <summary>
+    /// The async action being asserted.
+    /// </summary>
+    public Func<Task> AsyncAction { get; }
+
+    /// <summary>
+    /// The expression text captured from the call site (for error messages).
+    /// </summary>
+    public string? Expression { get; }
+
+    /// <summary>
+    /// Creates a negated expectation for the specified async action.
+    /// </summary>
+    public NegatedAsyncActionExpectation(Func<Task> asyncAction, string? expr)
+    {
+        AsyncAction = asyncAction;
+        Expression = expr;
+    }
+
+    /// <summary>
+    /// Assert that the async action does NOT throw an exception of the specified type.
+    /// Passes if no exception is thrown or a different type is thrown.
+    /// </summary>
+    public async Task toThrowAsync<TException>() where TException : Exception
+    {
+        try
+        {
+            await AsyncAction();
+        }
+        catch (TException)
+        {
+            throw new AssertionException(
+                $"Expected {Expression} to not throw {typeof(TException).Name}, but it did");
+        }
+        catch
+        {
+            // Different exception type - this is fine
+        }
+    }
+
+    /// <summary>
+    /// Assert that the async action does NOT throw any exception.
+    /// </summary>
+    public async Task toThrowAsync()
+    {
+        try
+        {
+            await AsyncAction();
+        }
+        catch (Exception ex)
+        {
+            throw new AssertionException(
+                $"Expected {Expression} to not throw, but threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}

--- a/src/DraftSpec/Expectations/NegatedBoolExpectation.cs
+++ b/src/DraftSpec/Expectations/NegatedBoolExpectation.cs
@@ -1,0 +1,63 @@
+namespace DraftSpec;
+
+/// <summary>
+/// Negated expectation wrapper for boolean assertions.
+/// Returned by <c>expect(bool).not</c> to enable negative assertions.
+/// </summary>
+/// <example>
+/// <code>
+/// expect(value).not.toBeTrue();
+/// expect(value).not.toBeFalse();
+/// </code>
+/// </example>
+public readonly struct NegatedBoolExpectation
+{
+    /// <summary>
+    /// The actual boolean value being asserted.
+    /// </summary>
+    public bool Actual { get; }
+
+    /// <summary>
+    /// The expression text captured from the call site (for error messages).
+    /// </summary>
+    public string? Expression { get; }
+
+    /// <summary>
+    /// Creates a negated expectation for the specified boolean value.
+    /// </summary>
+    public NegatedBoolExpectation(bool actual, string? expr)
+    {
+        Actual = actual;
+        Expression = expr;
+    }
+
+    /// <summary>
+    /// Assert that the value is NOT true (i.e., it is false).
+    /// </summary>
+    public void toBeTrue()
+    {
+        if (Actual)
+            throw new AssertionException(
+                $"Expected {Expression} to not be true, but was true");
+    }
+
+    /// <summary>
+    /// Assert that the value is NOT false (i.e., it is true).
+    /// </summary>
+    public void toBeFalse()
+    {
+        if (!Actual)
+            throw new AssertionException(
+                $"Expected {Expression} to not be false, but was false");
+    }
+
+    /// <summary>
+    /// Assert that the value does NOT equal the expected value.
+    /// </summary>
+    public void toBe(bool expected)
+    {
+        if (Actual == expected)
+            throw new AssertionException(
+                $"Expected {Expression} to not be {expected}");
+    }
+}

--- a/src/DraftSpec/Expectations/NegatedCollectionExpectation.cs
+++ b/src/DraftSpec/Expectations/NegatedCollectionExpectation.cs
@@ -1,0 +1,107 @@
+using DraftSpec.Expectations;
+
+namespace DraftSpec;
+
+/// <summary>
+/// Negated expectation wrapper for collection assertions.
+/// Returned by <c>expect(collection).not</c> to enable negative assertions.
+/// </summary>
+/// <typeparam name="T">The type of elements in the collection.</typeparam>
+/// <example>
+/// <code>
+/// expect(list).not.toContain(item);
+/// expect(list).not.toBeEmpty();
+/// </code>
+/// </example>
+public readonly struct NegatedCollectionExpectation<T>
+{
+    /// <summary>
+    /// The actual collection being asserted.
+    /// </summary>
+    public IEnumerable<T> Actual { get; }
+
+    /// <summary>
+    /// The expression text captured from the call site (for error messages).
+    /// </summary>
+    public string? Expression { get; }
+
+    /// <summary>
+    /// Creates a negated expectation for the specified collection.
+    /// </summary>
+    public NegatedCollectionExpectation(IEnumerable<T> actual, string? expr)
+    {
+        Actual = actual;
+        Expression = expr;
+    }
+
+    /// <summary>
+    /// Assert that the collection does NOT contain the specified item.
+    /// </summary>
+    public void toContain(T expected)
+    {
+        if (Actual.Contains(expected))
+            throw new AssertionException(
+                $"Expected {Expression} to not contain {ExpectationHelpers.Format(expected)}, but it did");
+    }
+
+    /// <summary>
+    /// Assert that the collection does NOT contain all the specified items.
+    /// </summary>
+    public void toContainAll(params T[] expected)
+    {
+        var materialized = Materialize();
+        if (expected.All(e => materialized.Contains(e)))
+            throw new AssertionException(
+                $"Expected {Expression} to not contain all of [{string.Join(", ", expected.Select(e => ExpectationHelpers.Format(e)))}], but it did");
+    }
+
+    /// <summary>
+    /// Assert that the collection does NOT have the specified count.
+    /// </summary>
+    public void toHaveCount(int expected)
+    {
+        var materialized = Materialize();
+        var count = materialized.Count;
+        if (count == expected)
+            throw new AssertionException(
+                $"Expected {Expression} to not have count {expected}, but it did");
+    }
+
+    /// <summary>
+    /// Assert that the collection is NOT empty.
+    /// </summary>
+    public void toBeEmpty()
+    {
+        var materialized = Materialize();
+        if (materialized.Count == 0)
+            throw new AssertionException(
+                $"Expected {Expression} to not be empty");
+    }
+
+    /// <summary>
+    /// Assert that the collection does NOT equal the expected sequence.
+    /// </summary>
+    public void toBe(IEnumerable<T> expected)
+    {
+        var materialized = Materialize();
+        if (materialized.SequenceEqual(expected))
+            throw new AssertionException(
+                $"Expected {Expression} to not be [{string.Join(", ", expected.Select(e => ExpectationHelpers.Format(e)))}]");
+    }
+
+    /// <summary>
+    /// Assert that the collection does NOT equal the expected items.
+    /// </summary>
+    public void toBe(params T[] expected)
+    {
+        toBe((IEnumerable<T>)expected);
+    }
+
+    /// <summary>
+    /// Materializes the collection to avoid multiple enumeration.
+    /// </summary>
+    private IReadOnlyCollection<T> Materialize()
+    {
+        return Actual as IReadOnlyCollection<T> ?? Actual.ToList();
+    }
+}

--- a/src/DraftSpec/Expectations/NegatedExpectation.cs
+++ b/src/DraftSpec/Expectations/NegatedExpectation.cs
@@ -1,0 +1,98 @@
+using DraftSpec.Expectations;
+
+namespace DraftSpec;
+
+/// <summary>
+/// Negated expectation wrapper for fluent assertions.
+/// Returned by <c>expect(value).not</c> to enable negative assertions.
+/// </summary>
+/// <typeparam name="T">The type of value being asserted.</typeparam>
+/// <example>
+/// <code>
+/// expect(value).not.toBe(5);
+/// expect(value).not.toBeNull();
+/// </code>
+/// </example>
+public readonly struct NegatedExpectation<T>
+{
+    /// <summary>
+    /// The actual value being asserted.
+    /// </summary>
+    public T Actual { get; }
+
+    /// <summary>
+    /// The expression text captured from the call site (for error messages).
+    /// </summary>
+    public string? Expression { get; }
+
+    /// <summary>
+    /// Creates a negated expectation for the specified value.
+    /// </summary>
+    public NegatedExpectation(T actual, string? expr)
+    {
+        Actual = actual;
+        Expression = expr;
+    }
+
+    /// <summary>
+    /// Assert that the actual value does NOT equal the expected value.
+    /// </summary>
+    public void toBe(T expected)
+    {
+        if (Equals(Actual, expected))
+            throw new AssertionException(
+                $"Expected {Expression} to not be {ExpectationHelpers.Format(expected)}");
+    }
+
+    /// <summary>
+    /// Assert that the actual value is NOT null.
+    /// </summary>
+    public void toBeNull()
+    {
+        if (Actual is null)
+            throw new AssertionException(
+                $"Expected {Expression} to not be null");
+    }
+
+    // Cached comparer to avoid repeated lookups
+    private static readonly Comparer<T> _comparer = Comparer<T>.Default;
+
+    /// <summary>
+    /// Assert that the actual value is NOT greater than the expected value.
+    /// </summary>
+    public void toBeGreaterThan(T expected)
+    {
+        if (expected is null)
+            throw new AssertionException("Expected value cannot be null for comparison");
+
+        if (_comparer.Compare(Actual, expected) > 0)
+            throw new AssertionException(
+                $"Expected {Expression ?? "value"} to not be greater than {ExpectationHelpers.Format(expected)}, but was {ExpectationHelpers.Format(Actual)}");
+    }
+
+    /// <summary>
+    /// Assert that the actual value is NOT less than the expected value.
+    /// </summary>
+    public void toBeLessThan(T expected)
+    {
+        if (expected is null)
+            throw new AssertionException("Expected value cannot be null for comparison");
+
+        if (_comparer.Compare(Actual, expected) < 0)
+            throw new AssertionException(
+                $"Expected {Expression ?? "value"} to not be less than {ExpectationHelpers.Format(expected)}, but was {ExpectationHelpers.Format(Actual)}");
+    }
+
+    /// <summary>
+    /// Assert that the actual value is NOT in the specified range (inclusive).
+    /// </summary>
+    public void toBeInRange(T min, T max)
+    {
+        if (min is null || max is null)
+            throw new AssertionException("Range bounds cannot be null for comparison");
+
+        if (_comparer.Compare(Actual, min) >= 0 && _comparer.Compare(Actual, max) <= 0)
+            throw new AssertionException(
+                $"Expected {Expression ?? "value"} to not be in range [{ExpectationHelpers.Format(min)}, {ExpectationHelpers.Format(max)}], but was {ExpectationHelpers.Format(Actual)}");
+    }
+}

--- a/src/DraftSpec/Expectations/NegatedStringExpectation.cs
+++ b/src/DraftSpec/Expectations/NegatedStringExpectation.cs
@@ -1,0 +1,131 @@
+namespace DraftSpec;
+
+/// <summary>
+/// Negated expectation wrapper for string assertions.
+/// Returned by <c>expect(string).not</c> to enable negative assertions.
+/// </summary>
+/// <example>
+/// <code>
+/// expect(str).not.toBe("hello");
+/// expect(str).not.toContain("foo");
+/// expect(str).not.toBeNullOrEmpty();
+/// </code>
+/// </example>
+public readonly struct NegatedStringExpectation
+{
+    /// <summary>
+    /// The actual string value being asserted.
+    /// </summary>
+    public string? Actual { get; }
+
+    /// <summary>
+    /// The expression text captured from the call site (for error messages).
+    /// </summary>
+    public string? Expression { get; }
+
+    /// <summary>
+    /// Creates a negated expectation for the specified string value.
+    /// </summary>
+    public NegatedStringExpectation(string? actual, string? expr)
+    {
+        Actual = actual;
+        Expression = expr;
+    }
+
+    /// <summary>
+    /// Assert that the string does NOT equal the expected value.
+    /// </summary>
+    public void toBe(string? expected)
+    {
+        if (Actual == expected)
+            throw new AssertionException(
+                $"Expected {Expression} to not be \"{expected}\"");
+    }
+
+    /// <summary>
+    /// Assert that the string does NOT contain the substring.
+    /// </summary>
+    public void toContain(string substring)
+    {
+        if (Actual is not null && Actual.Contains(substring, StringComparison.Ordinal))
+            throw new AssertionException(
+                $"Expected {Expression} to not contain \"{substring}\", but it did");
+    }
+
+    /// <summary>
+    /// Assert that the string does NOT start with the prefix.
+    /// </summary>
+    public void toStartWith(string prefix)
+    {
+        if (Actual is not null && Actual.StartsWith(prefix, StringComparison.Ordinal))
+            throw new AssertionException(
+                $"Expected {Expression} to not start with \"{prefix}\", but it did");
+    }
+
+    /// <summary>
+    /// Assert that the string does NOT end with the suffix.
+    /// </summary>
+    public void toEndWith(string suffix)
+    {
+        if (Actual is not null && Actual.EndsWith(suffix, StringComparison.Ordinal))
+            throw new AssertionException(
+                $"Expected {Expression} to not end with \"{suffix}\", but it did");
+    }
+
+    /// <summary>
+    /// Assert that the string is NOT null or empty.
+    /// </summary>
+    public void toBeNullOrEmpty()
+    {
+        if (string.IsNullOrEmpty(Actual))
+            throw new AssertionException(
+                $"Expected {Expression} to not be null or empty, but it was");
+    }
+
+    /// <summary>
+    /// Assert that the string is NOT null.
+    /// </summary>
+    public void toBeNull()
+    {
+        if (Actual is null)
+            throw new AssertionException(
+                $"Expected {Expression} to not be null");
+    }
+
+    /// <summary>
+    /// Assert that the string does NOT match the regex pattern.
+    /// </summary>
+    public void toMatch(string pattern)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+
+        if (Actual is not null && System.Text.RegularExpressions.Regex.IsMatch(Actual, pattern))
+            throw new AssertionException(
+                $"Expected {Expression} to not match pattern \"{pattern}\", but it did");
+    }
+
+    /// <summary>
+    /// Assert that the string does NOT match the regex.
+    /// </summary>
+    public void toMatch(System.Text.RegularExpressions.Regex regex)
+    {
+        ArgumentNullException.ThrowIfNull(regex);
+
+        if (Actual is not null && regex.IsMatch(Actual))
+            throw new AssertionException(
+                $"Expected {Expression} to not match pattern \"{regex}\", but it did");
+    }
+
+    /// <summary>
+    /// Assert that the string does NOT have the expected length.
+    /// </summary>
+    public void toHaveLength(int expectedLength)
+    {
+        if (expectedLength < 0)
+            throw new ArgumentOutOfRangeException(nameof(expectedLength), "Length must be non-negative");
+
+        if (Actual is not null && Actual.Length == expectedLength)
+            throw new AssertionException(
+                $"Expected {Expression} to not have length {expectedLength}, but it did");
+    }
+}

--- a/src/DraftSpec/Expectations/StringExpectation.cs
+++ b/src/DraftSpec/Expectations/StringExpectation.cs
@@ -35,6 +35,17 @@ public readonly struct StringExpectation
     }
 
     /// <summary>
+    /// Returns a negated expectation for chaining negative assertions.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// expect(str).not.toBe("hello");
+    /// expect(str).not.toContain("foo");
+    /// </code>
+    /// </example>
+    public NegatedStringExpectation not => new(Actual, Expression);
+
+    /// <summary>
     /// Assert equality.
     /// </summary>
     public void toBe(string? expected)

--- a/tests/DraftSpec.Tests/Expectations/NegationPatternTests.cs
+++ b/tests/DraftSpec.Tests/Expectations/NegationPatternTests.cs
@@ -1,0 +1,487 @@
+namespace DraftSpec.Tests.Expectations;
+
+/// <summary>
+/// Tests for the .not negation pattern across all expectation types.
+/// </summary>
+public class NegationPatternTests
+{
+    #region Expectation<T>.not
+
+    [Test]
+    public async Task GenericExpectation_not_toBe_WhenDifferent_Passes()
+    {
+        var expectation = new Expectation<int>(5, "value");
+        expectation.not.toBe(10);
+    }
+
+    [Test]
+    public async Task GenericExpectation_not_toBe_WhenEqual_Throws()
+    {
+        var expectation = new Expectation<int>(5, "value");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toBe(5));
+
+        await Assert.That(ex.Message).Contains("to not be 5");
+    }
+
+    [Test]
+    public async Task GenericExpectation_not_toBeNull_WhenNotNull_Passes()
+    {
+        var expectation = new Expectation<string>("hello", "value");
+        expectation.not.toBeNull();
+    }
+
+    [Test]
+    public async Task GenericExpectation_not_toBeNull_WhenNull_Throws()
+    {
+        var expectation = new Expectation<string?>(null, "value");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toBeNull());
+
+        await Assert.That(ex.Message).Contains("to not be null");
+    }
+
+    [Test]
+    public async Task GenericExpectation_not_toBeGreaterThan_WhenNotGreater_Passes()
+    {
+        var expectation = new Expectation<int>(5, "value");
+        expectation.not.toBeGreaterThan(10);
+    }
+
+    [Test]
+    public async Task GenericExpectation_not_toBeGreaterThan_WhenGreater_Throws()
+    {
+        var expectation = new Expectation<int>(15, "value");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toBeGreaterThan(10));
+
+        await Assert.That(ex.Message).Contains("to not be greater than");
+    }
+
+    [Test]
+    public async Task GenericExpectation_not_toBeInRange_WhenOutside_Passes()
+    {
+        var expectation = new Expectation<int>(20, "value");
+        expectation.not.toBeInRange(1, 10);
+    }
+
+    [Test]
+    public async Task GenericExpectation_not_toBeInRange_WhenInside_Throws()
+    {
+        var expectation = new Expectation<int>(5, "value");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toBeInRange(1, 10));
+
+        await Assert.That(ex.Message).Contains("to not be in range");
+    }
+
+    #endregion
+
+    #region BoolExpectation.not
+
+    [Test]
+    public async Task BoolExpectation_not_toBeTrue_WhenFalse_Passes()
+    {
+        var expectation = new BoolExpectation(false, "flag");
+        expectation.not.toBeTrue();
+    }
+
+    [Test]
+    public async Task BoolExpectation_not_toBeTrue_WhenTrue_Throws()
+    {
+        var expectation = new BoolExpectation(true, "flag");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toBeTrue());
+
+        await Assert.That(ex.Message).Contains("to not be true");
+    }
+
+    [Test]
+    public async Task BoolExpectation_not_toBeFalse_WhenTrue_Passes()
+    {
+        var expectation = new BoolExpectation(true, "flag");
+        expectation.not.toBeFalse();
+    }
+
+    [Test]
+    public async Task BoolExpectation_not_toBeFalse_WhenFalse_Throws()
+    {
+        var expectation = new BoolExpectation(false, "flag");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toBeFalse());
+
+        await Assert.That(ex.Message).Contains("to not be false");
+    }
+
+    [Test]
+    public async Task BoolExpectation_not_toBe_WhenDifferent_Passes()
+    {
+        var expectation = new BoolExpectation(true, "flag");
+        expectation.not.toBe(false);
+    }
+
+    [Test]
+    public async Task BoolExpectation_not_toBe_WhenSame_Throws()
+    {
+        var expectation = new BoolExpectation(true, "flag");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toBe(true));
+
+        await Assert.That(ex.Message).Contains("to not be True");
+    }
+
+    #endregion
+
+    #region StringExpectation.not
+
+    [Test]
+    public async Task StringExpectation_not_toBe_WhenDifferent_Passes()
+    {
+        var expectation = new StringExpectation("hello", "str");
+        expectation.not.toBe("world");
+    }
+
+    [Test]
+    public async Task StringExpectation_not_toBe_WhenSame_Throws()
+    {
+        var expectation = new StringExpectation("hello", "str");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toBe("hello"));
+
+        await Assert.That(ex.Message).Contains("to not be");
+    }
+
+    [Test]
+    public async Task StringExpectation_not_toContain_WhenNotContaining_Passes()
+    {
+        var expectation = new StringExpectation("hello world", "str");
+        expectation.not.toContain("foo");
+    }
+
+    [Test]
+    public async Task StringExpectation_not_toContain_WhenContaining_Throws()
+    {
+        var expectation = new StringExpectation("hello world", "str");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toContain("world"));
+
+        await Assert.That(ex.Message).Contains("to not contain");
+    }
+
+    [Test]
+    public async Task StringExpectation_not_toStartWith_WhenNotStarting_Passes()
+    {
+        var expectation = new StringExpectation("hello world", "str");
+        expectation.not.toStartWith("world");
+    }
+
+    [Test]
+    public async Task StringExpectation_not_toStartWith_WhenStarting_Throws()
+    {
+        var expectation = new StringExpectation("hello world", "str");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toStartWith("hello"));
+
+        await Assert.That(ex.Message).Contains("to not start with");
+    }
+
+    [Test]
+    public async Task StringExpectation_not_toEndWith_WhenNotEnding_Passes()
+    {
+        var expectation = new StringExpectation("hello world", "str");
+        expectation.not.toEndWith("hello");
+    }
+
+    [Test]
+    public async Task StringExpectation_not_toEndWith_WhenEnding_Throws()
+    {
+        var expectation = new StringExpectation("hello world", "str");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toEndWith("world"));
+
+        await Assert.That(ex.Message).Contains("to not end with");
+    }
+
+    [Test]
+    public async Task StringExpectation_not_toBeNullOrEmpty_WhenNotEmpty_Passes()
+    {
+        var expectation = new StringExpectation("hello", "str");
+        expectation.not.toBeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task StringExpectation_not_toBeNullOrEmpty_WhenEmpty_Throws()
+    {
+        var expectation = new StringExpectation("", "str");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toBeNullOrEmpty());
+
+        await Assert.That(ex.Message).Contains("to not be null or empty");
+    }
+
+    [Test]
+    public async Task StringExpectation_not_toMatch_WhenNotMatching_Passes()
+    {
+        var expectation = new StringExpectation("hello", "str");
+        expectation.not.toMatch(@"\d+");
+    }
+
+    [Test]
+    public async Task StringExpectation_not_toMatch_WhenMatching_Throws()
+    {
+        var expectation = new StringExpectation("hello123", "str");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toMatch(@"\d+"));
+
+        await Assert.That(ex.Message).Contains("to not match pattern");
+    }
+
+    [Test]
+    public async Task StringExpectation_not_toHaveLength_WhenDifferentLength_Passes()
+    {
+        var expectation = new StringExpectation("hello", "str");
+        expectation.not.toHaveLength(10);
+    }
+
+    [Test]
+    public async Task StringExpectation_not_toHaveLength_WhenSameLength_Throws()
+    {
+        var expectation = new StringExpectation("hello", "str");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toHaveLength(5));
+
+        await Assert.That(ex.Message).Contains("to not have length 5");
+    }
+
+    #endregion
+
+    #region CollectionExpectation<T>.not
+
+    [Test]
+    public async Task CollectionExpectation_not_toContain_WhenNotContaining_Passes()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+        expectation.not.toContain(5);
+    }
+
+    [Test]
+    public async Task CollectionExpectation_not_toContain_WhenContaining_Throws()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toContain(2));
+
+        await Assert.That(ex.Message).Contains("to not contain 2");
+    }
+
+    [Test]
+    public async Task CollectionExpectation_not_toBeEmpty_WhenNotEmpty_Passes()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+        expectation.not.toBeEmpty();
+    }
+
+    [Test]
+    public async Task CollectionExpectation_not_toBeEmpty_WhenEmpty_Throws()
+    {
+        var expectation = new CollectionExpectation<int>([], "list");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toBeEmpty());
+
+        await Assert.That(ex.Message).Contains("to not be empty");
+    }
+
+    [Test]
+    public async Task CollectionExpectation_not_toHaveCount_WhenDifferentCount_Passes()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+        expectation.not.toHaveCount(5);
+    }
+
+    [Test]
+    public async Task CollectionExpectation_not_toHaveCount_WhenSameCount_Throws()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toHaveCount(3));
+
+        await Assert.That(ex.Message).Contains("to not have count 3");
+    }
+
+    [Test]
+    public async Task CollectionExpectation_not_toBe_WhenDifferent_Passes()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+        expectation.not.toBe([1, 2, 4]);
+    }
+
+    [Test]
+    public async Task CollectionExpectation_not_toBe_WhenSame_Throws()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toBe([1, 2, 3]));
+
+        await Assert.That(ex.Message).Contains("to not be");
+    }
+
+    #endregion
+
+    #region ActionExpectation.not
+
+    [Test]
+    public async Task ActionExpectation_not_toThrow_WhenNoException_Passes()
+    {
+        var expectation = new ActionExpectation(() => { }, "action");
+        expectation.not.toThrow();
+    }
+
+    [Test]
+    public async Task ActionExpectation_not_toThrow_WhenThrows_Throws()
+    {
+        var expectation = new ActionExpectation(() => throw new Exception("oops"), "action");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.not.toThrow());
+
+        await Assert.That(ex.Message).Contains("to not throw");
+    }
+
+    [Test]
+    public async Task ActionExpectation_not_toThrowGeneric_WhenNoException_Passes()
+    {
+        var expectation = new ActionExpectation(() => { }, "action");
+        expectation.not.toThrow<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ActionExpectation_not_toThrowGeneric_WhenDifferentException_Passes()
+    {
+        var expectation = new ActionExpectation(() => throw new ArgumentException(), "action");
+        expectation.not.toThrow<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task ActionExpectation_not_toThrowGeneric_WhenCorrectException_Throws()
+    {
+        var expectation = new ActionExpectation(
+            () => throw new InvalidOperationException("oops"), "action");
+
+        var ex = Assert.Throws<AssertionException>(() =>
+            expectation.not.toThrow<InvalidOperationException>());
+
+        await Assert.That(ex.Message).Contains("to not throw InvalidOperationException");
+    }
+
+    #endregion
+
+    #region AsyncActionExpectation.not
+
+    [Test]
+    public async Task AsyncActionExpectation_not_toThrowAsync_WhenNoException_Passes()
+    {
+        var expectation = new AsyncActionExpectation(async () => await Task.Yield(), "asyncAction");
+        await expectation.not.toThrowAsync();
+    }
+
+    [Test]
+    public async Task AsyncActionExpectation_not_toThrowAsync_WhenThrows_Throws()
+    {
+        var expectation = new AsyncActionExpectation(
+            async () =>
+            {
+                await Task.Yield();
+                throw new Exception("oops");
+            },
+            "asyncAction");
+
+        var ex = await Assert.ThrowsAsync<AssertionException>(async () =>
+            await expectation.not.toThrowAsync());
+
+        await Assert.That(ex.Message).Contains("to not throw");
+    }
+
+    [Test]
+    public async Task AsyncActionExpectation_not_toThrowAsyncGeneric_WhenNoException_Passes()
+    {
+        var expectation = new AsyncActionExpectation(async () => await Task.Yield(), "asyncAction");
+        await expectation.not.toThrowAsync<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task AsyncActionExpectation_not_toThrowAsyncGeneric_WhenDifferentException_Passes()
+    {
+        var expectation = new AsyncActionExpectation(
+            async () =>
+            {
+                await Task.Yield();
+                throw new ArgumentException();
+            },
+            "asyncAction");
+
+        await expectation.not.toThrowAsync<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task AsyncActionExpectation_not_toThrowAsyncGeneric_WhenCorrectException_Throws()
+    {
+        var expectation = new AsyncActionExpectation(
+            async () =>
+            {
+                await Task.Yield();
+                throw new InvalidOperationException("oops");
+            },
+            "asyncAction");
+
+        var ex = await Assert.ThrowsAsync<AssertionException>(async () =>
+            await expectation.not.toThrowAsync<InvalidOperationException>());
+
+        await Assert.That(ex.Message).Contains("to not throw InvalidOperationException");
+    }
+
+    #endregion
+
+    #region DSL Integration
+
+    [Test]
+    public async Task DSL_expect_not_toBe_WorksWithChaining()
+    {
+        // Using the DSL syntax
+        int value = 5;
+        DraftSpec.Dsl.expect(value).not.toBe(10);
+    }
+
+    [Test]
+    public async Task DSL_expect_string_not_toContain_WorksWithChaining()
+    {
+        string str = "hello";
+        DraftSpec.Dsl.expect(str).not.toContain("world");
+    }
+
+    [Test]
+    public async Task DSL_expect_bool_not_toBeTrue_WorksWithChaining()
+    {
+        bool flag = false;
+        DraftSpec.Dsl.expect(flag).not.toBeTrue();
+    }
+
+    [Test]
+    public async Task DSL_expect_collection_not_toContain_WorksWithChaining()
+    {
+        var list = new[] { 1, 2, 3 };
+        DraftSpec.Dsl.expect(list).not.toContain(5);
+    }
+
+    [Test]
+    public async Task DSL_expect_action_not_toThrow_WorksWithChaining()
+    {
+        DraftSpec.Dsl.expect(() => { }).not.toThrow();
+    }
+
+    [Test]
+    public async Task DSL_expect_asyncAction_not_toThrowAsync_WorksWithChaining()
+    {
+        await DraftSpec.Dsl.expect(async () => await Task.Yield()).not.toThrowAsync();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Adds chainable `.not` property to all expectation types for RSpec/Jest-like negative assertions.

## Usage
```csharp
expect(value).not.toBe(5);
expect(str).not.toContain("foo");
expect(list).not.toBeEmpty();
expect(() => action()).not.toThrow();
await expect(async () => ...).not.toThrowAsync();
```

## Implementation
- `NegatedExpectation<T>` with toBe, toBeNull, toBeGreaterThan, toBeLessThan, toBeInRange
- `NegatedBoolExpectation` with toBeTrue, toBeFalse, toBe
- `NegatedStringExpectation` with toBe, toContain, toStartWith, toEndWith, toMatch, toHaveLength, etc.
- `NegatedCollectionExpectation<T>` with toContain, toContainAll, toHaveCount, toBeEmpty, toBe
- `NegatedActionExpectation` with toThrow, toThrow<T>
- `NegatedAsyncActionExpectation` with toThrowAsync, toThrowAsync<T>

## Backwards Compatibility
Existing `toNotXxx()` methods are preserved for backwards compatibility.

## Test coverage
52 new tests covering:
- All negation assertions for each expectation type
- Both passing and failing scenarios
- DSL integration tests

## Test plan
- [x] All 52 NegationPattern tests pass
- [x] Full test suite passes (1024 tests)

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)