### PR TITLE
Add additional collection assertions

### DIFF
--- a/src/DraftSpec/Expectations/Expectation.cs
+++ b/src/DraftSpec/Expectations/Expectation.cs
@@ -94,6 +94,50 @@ public readonly struct Expectation<T>
                 $"Expected {Expression} to not be null");
     }
 
+    /// <summary>
+    /// Assert that the actual value is an instance of the specified type.
+    /// </summary>
+    /// <typeparam name="TExpected">The expected type.</typeparam>
+    /// <returns>The value cast to the expected type for further assertions.</returns>
+    public TExpected toBeInstanceOf<TExpected>()
+    {
+        if (Actual is null)
+            throw new AssertionException(
+                $"Expected {Expression} to be instance of {typeof(TExpected).Name}, but was null");
+
+        if (Actual is not TExpected typedValue)
+            throw new AssertionException(
+                $"Expected {Expression} to be instance of {typeof(TExpected).Name}, but was {Actual.GetType().Name}");
+
+        return typedValue;
+    }
+
+    /// <summary>
+    /// Assert that the actual value is equivalent to the expected value using deep comparison.
+    /// Uses JSON serialization to compare object structures.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    public void toBeEquivalentTo(T expected)
+    {
+        if (Actual is null && expected is null)
+            return;
+
+        if (Actual is null)
+            throw new AssertionException(
+                $"Expected {Expression} to be equivalent to {ExpectationHelpers.Format(expected)}, but was null");
+
+        if (expected is null)
+            throw new AssertionException(
+                $"Expected {Expression} to be equivalent to null, but was {ExpectationHelpers.Format(Actual)}");
+
+        var actualJson = System.Text.Json.JsonSerializer.Serialize(Actual);
+        var expectedJson = System.Text.Json.JsonSerializer.Serialize(expected);
+
+        if (actualJson != expectedJson)
+            throw new AssertionException(
+                $"Expected {Expression} to be equivalent to {ExpectationHelpers.Format(expected)}, but was {ExpectationHelpers.Format(Actual)}");
+    }
+
     // Cached comparer to avoid repeated lookups - uses optimized paths for primitives
     private static readonly Comparer<T> _comparer = Comparer<T>.Default;
 

--- a/src/DraftSpec/Expectations/NegatedCollectionExpectation.cs
+++ b/src/DraftSpec/Expectations/NegatedCollectionExpectation.cs
@@ -98,6 +98,41 @@ public readonly struct NegatedCollectionExpectation<T>
     }
 
     /// <summary>
+    /// Assert that the collection does NOT contain exactly the specified items (order-independent).
+    /// </summary>
+    public void toContainExactly(IEnumerable<T> expected)
+    {
+        var actualList = Materialize().ToList();
+        var expectedList = expected.ToList();
+
+        if (actualList.Count != expectedList.Count)
+            return; // Different count means they don't match exactly - pass
+
+        // Check if they have the same items (accounting for duplicates)
+        var actualCopy = new List<T>(actualList);
+        foreach (var item in expectedList)
+        {
+            var index = actualCopy.FindIndex(a => EqualityComparer<T>.Default.Equals(a, item));
+            if (index >= 0)
+                actualCopy.RemoveAt(index);
+            else
+                return; // Missing item means they don't match exactly - pass
+        }
+
+        // If we get here, they match exactly
+        throw new AssertionException(
+            $"Expected {Expression} to not contain exactly [{string.Join(", ", expectedList.Select(e => ExpectationHelpers.Format(e)))}], but it did");
+    }
+
+    /// <summary>
+    /// Assert that the collection does NOT contain exactly the specified items (order-independent).
+    /// </summary>
+    public void toContainExactly(params T[] expected)
+    {
+        toContainExactly((IEnumerable<T>)expected);
+    }
+
+    /// <summary>
     /// Materializes the collection to avoid multiple enumeration.
     /// </summary>
     private IReadOnlyCollection<T> Materialize()

--- a/src/DraftSpec/Expectations/NegatedExpectation.cs
+++ b/src/DraftSpec/Expectations/NegatedExpectation.cs
@@ -54,6 +54,39 @@ public readonly struct NegatedExpectation<T>
                 $"Expected {Expression} to not be null");
     }
 
+    /// <summary>
+    /// Assert that the actual value is NOT an instance of the specified type.
+    /// </summary>
+    /// <typeparam name="TExpected">The type the value should not be.</typeparam>
+    public void toBeInstanceOf<TExpected>()
+    {
+        if (Actual is TExpected)
+            throw new AssertionException(
+                $"Expected {Expression} to not be instance of {typeof(TExpected).Name}, but it was");
+    }
+
+    /// <summary>
+    /// Assert that the actual value is NOT equivalent to the expected value using deep comparison.
+    /// Uses JSON serialization to compare object structures.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    public void toBeEquivalentTo(T expected)
+    {
+        if (Actual is null && expected is null)
+            throw new AssertionException(
+                $"Expected {Expression} to not be equivalent to null, but both were null");
+
+        if (Actual is null || expected is null)
+            return; // One is null and the other isn't - they're not equivalent
+
+        var actualJson = System.Text.Json.JsonSerializer.Serialize(Actual);
+        var expectedJson = System.Text.Json.JsonSerializer.Serialize(expected);
+
+        if (actualJson == expectedJson)
+            throw new AssertionException(
+                $"Expected {Expression} to not be equivalent to {ExpectationHelpers.Format(expected)}, but it was");
+    }
+
     // Cached comparer to avoid repeated lookups
     private static readonly Comparer<T> _comparer = Comparer<T>.Default;
 

--- a/tests/DraftSpec.Tests/Expectations/CollectionAssertionTests.cs
+++ b/tests/DraftSpec.Tests/Expectations/CollectionAssertionTests.cs
@@ -1,0 +1,376 @@
+namespace DraftSpec.Tests.Expectations;
+
+/// <summary>
+/// Tests for additional collection assertions (toContainExactly, toBeInstanceOf, toBeEquivalentTo).
+/// </summary>
+public class CollectionAssertionTests
+{
+    #region toContainExactly
+
+    [Test]
+    public async Task toContainExactly_WithSameItemsSameOrder_Passes()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+        expectation.toContainExactly(1, 2, 3);
+    }
+
+    [Test]
+    public async Task toContainExactly_WithSameItemsDifferentOrder_Passes()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+        expectation.toContainExactly(3, 1, 2);
+    }
+
+    [Test]
+    public async Task toContainExactly_WithDuplicates_Passes()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 2, 3], "list");
+        expectation.toContainExactly(2, 1, 3, 2);
+    }
+
+    [Test]
+    public async Task toContainExactly_WithMissingItem_Throws()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.toContainExactly(1, 2, 4));
+
+        await Assert.That(ex.Message).Contains("missing");
+        await Assert.That(ex.Message).Contains("4");
+    }
+
+    [Test]
+    public async Task toContainExactly_WithExtraItem_Throws()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3, 4], "list");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.toContainExactly(1, 2, 3));
+
+        await Assert.That(ex.Message).Contains("but had 4");
+        await Assert.That(ex.Message).Contains("exactly 3 items");
+    }
+
+    [Test]
+    public async Task toContainExactly_WithDifferentCount_Throws()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2], "list");
+
+        var ex = Assert.Throws<AssertionException>(() => expectation.toContainExactly(1, 2, 3));
+
+        await Assert.That(ex.Message).Contains("but had 2");
+        await Assert.That(ex.Message).Contains("exactly 3 items");
+    }
+
+    [Test]
+    public async Task toContainExactly_WithIEnumerable_Passes()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+        IEnumerable<int> expected = [3, 2, 1];
+
+        expectation.toContainExactly(expected);
+    }
+
+    [Test]
+    public async Task toContainExactly_WithStrings_Passes()
+    {
+        var expectation = new CollectionExpectation<string>(["a", "b", "c"], "list");
+        expectation.toContainExactly("c", "a", "b");
+    }
+
+    [Test]
+    public async Task toContainExactly_EmptyCollections_Passes()
+    {
+        var expectation = new CollectionExpectation<int>([], "list");
+        expectation.toContainExactly();
+    }
+
+    #endregion
+
+    #region toContainExactly (negated)
+
+    [Test]
+    public async Task not_toContainExactly_WithDifferentItems_Passes()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+        expectation.not.toContainExactly(1, 2, 4);
+    }
+
+    [Test]
+    public async Task not_toContainExactly_WithSameItems_Throws()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+
+        var ex = Assert.Throws<AssertionException>(() =>
+            expectation.not.toContainExactly(3, 1, 2));
+
+        await Assert.That(ex.Message).Contains("to not contain exactly");
+    }
+
+    [Test]
+    public async Task not_toContainExactly_WithDifferentCount_Passes()
+    {
+        var expectation = new CollectionExpectation<int>([1, 2, 3], "list");
+        expectation.not.toContainExactly(1, 2);
+    }
+
+    #endregion
+
+    #region toBeInstanceOf
+
+    [Test]
+    public async Task toBeInstanceOf_WithCorrectType_Passes()
+    {
+        var expectation = new Expectation<object>("hello", "value");
+
+        var result = expectation.toBeInstanceOf<string>();
+
+        await Assert.That(result).IsEqualTo("hello");
+    }
+
+    [Test]
+    public async Task toBeInstanceOf_WithDerivedType_Passes()
+    {
+        var ex = new ArgumentNullException("param");
+        var expectation = new Expectation<Exception>(ex, "exception");
+
+        var result = expectation.toBeInstanceOf<ArgumentException>();
+
+        await Assert.That(result).IsTypeOf<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task toBeInstanceOf_WithWrongType_Throws()
+    {
+        var expectation = new Expectation<object>(123, "value");
+
+        var ex = Assert.Throws<AssertionException>(() =>
+            expectation.toBeInstanceOf<string>());
+
+        await Assert.That(ex.Message).Contains("to be instance of String");
+        await Assert.That(ex.Message).Contains("was Int32");
+    }
+
+    [Test]
+    public async Task toBeInstanceOf_WithNull_Throws()
+    {
+        var expectation = new Expectation<object?>(null, "value");
+
+        var ex = Assert.Throws<AssertionException>(() =>
+            expectation.toBeInstanceOf<string>());
+
+        await Assert.That(ex.Message).Contains("was null");
+    }
+
+    [Test]
+    public async Task toBeInstanceOf_ReturnsTypedValue()
+    {
+        var list = new List<int> { 1, 2, 3 };
+        var expectation = new Expectation<object>(list, "collection");
+
+        var result = expectation.toBeInstanceOf<IList<int>>();
+
+        await Assert.That(result.Count).IsEqualTo(3);
+    }
+
+    #endregion
+
+    #region toBeInstanceOf (negated)
+
+    [Test]
+    public async Task not_toBeInstanceOf_WithWrongType_Passes()
+    {
+        var expectation = new Expectation<object>(123, "value");
+        expectation.not.toBeInstanceOf<string>();
+    }
+
+    [Test]
+    public async Task not_toBeInstanceOf_WithNull_Passes()
+    {
+        var expectation = new Expectation<object?>(null, "value");
+        expectation.not.toBeInstanceOf<string>();
+    }
+
+    [Test]
+    public async Task not_toBeInstanceOf_WithCorrectType_Throws()
+    {
+        var expectation = new Expectation<object>("hello", "value");
+
+        var ex = Assert.Throws<AssertionException>(() =>
+            expectation.not.toBeInstanceOf<string>());
+
+        await Assert.That(ex.Message).Contains("to not be instance of String");
+    }
+
+    #endregion
+
+    #region toBeEquivalentTo
+
+    private record Person(string Name, int Age);
+
+    [Test]
+    public async Task toBeEquivalentTo_WithEqualObjects_Passes()
+    {
+        var actual = new Person("Alice", 30);
+        var expected = new Person("Alice", 30);
+        var expectation = new Expectation<Person>(actual, "person");
+
+        expectation.toBeEquivalentTo(expected);
+    }
+
+    [Test]
+    public async Task toBeEquivalentTo_WithDifferentInstances_SameValues_Passes()
+    {
+        var actual = new { Name = "Alice", Age = 30 };
+        var expected = new { Name = "Alice", Age = 30 };
+        var expectation = new Expectation<object>(actual, "person");
+
+        expectation.toBeEquivalentTo(expected);
+    }
+
+    [Test]
+    public async Task toBeEquivalentTo_WithDifferentValues_Throws()
+    {
+        var actual = new Person("Alice", 30);
+        var expected = new Person("Bob", 25);
+        var expectation = new Expectation<Person>(actual, "person");
+
+        var ex = Assert.Throws<AssertionException>(() =>
+            expectation.toBeEquivalentTo(expected));
+
+        await Assert.That(ex.Message).Contains("to be equivalent to");
+    }
+
+    [Test]
+    public async Task toBeEquivalentTo_WithBothNull_Passes()
+    {
+        var expectation = new Expectation<Person?>(null, "person");
+        expectation.toBeEquivalentTo(null);
+    }
+
+    [Test]
+    public async Task toBeEquivalentTo_WithNullActual_Throws()
+    {
+        var expectation = new Expectation<Person?>(null, "person");
+
+        var ex = Assert.Throws<AssertionException>(() =>
+            expectation.toBeEquivalentTo(new Person("Alice", 30)));
+
+        await Assert.That(ex.Message).Contains("was null");
+    }
+
+    [Test]
+    public async Task toBeEquivalentTo_WithNullExpected_Throws()
+    {
+        var expectation = new Expectation<Person?>(new Person("Alice", 30), "person");
+
+        var ex = Assert.Throws<AssertionException>(() =>
+            expectation.toBeEquivalentTo(null));
+
+        await Assert.That(ex.Message).Contains("to be equivalent to null");
+    }
+
+    [Test]
+    public async Task toBeEquivalentTo_WithNestedObjects_Passes()
+    {
+        var actual = new { Name = "Alice", Address = new { City = "NYC", Zip = "10001" } };
+        var expected = new { Name = "Alice", Address = new { City = "NYC", Zip = "10001" } };
+        var expectation = new Expectation<object>(actual, "person");
+
+        expectation.toBeEquivalentTo(expected);
+    }
+
+    [Test]
+    public async Task toBeEquivalentTo_WithNestedObjects_DifferentValues_Throws()
+    {
+        var actual = new { Name = "Alice", Address = new { City = "NYC", Zip = "10001" } };
+        var expected = new { Name = "Alice", Address = new { City = "LA", Zip = "90001" } };
+        var expectation = new Expectation<object>(actual, "person");
+
+        Assert.Throws<AssertionException>(() =>
+            expectation.toBeEquivalentTo(expected));
+    }
+
+    [Test]
+    public async Task toBeEquivalentTo_WithCollections_Passes()
+    {
+        var actual = new { Items = new[] { 1, 2, 3 } };
+        var expected = new { Items = new[] { 1, 2, 3 } };
+        var expectation = new Expectation<object>(actual, "obj");
+
+        expectation.toBeEquivalentTo(expected);
+    }
+
+    #endregion
+
+    #region toBeEquivalentTo (negated)
+
+    [Test]
+    public async Task not_toBeEquivalentTo_WithDifferentValues_Passes()
+    {
+        var actual = new Person("Alice", 30);
+        var expected = new Person("Bob", 25);
+        var expectation = new Expectation<Person>(actual, "person");
+
+        expectation.not.toBeEquivalentTo(expected);
+    }
+
+    [Test]
+    public async Task not_toBeEquivalentTo_WithEqualObjects_Throws()
+    {
+        var actual = new Person("Alice", 30);
+        var expected = new Person("Alice", 30);
+        var expectation = new Expectation<Person>(actual, "person");
+
+        var ex = Assert.Throws<AssertionException>(() =>
+            expectation.not.toBeEquivalentTo(expected));
+
+        await Assert.That(ex.Message).Contains("to not be equivalent to");
+    }
+
+    [Test]
+    public async Task not_toBeEquivalentTo_WithBothNull_Throws()
+    {
+        var expectation = new Expectation<Person?>(null, "person");
+
+        var ex = Assert.Throws<AssertionException>(() =>
+            expectation.not.toBeEquivalentTo(null));
+
+        await Assert.That(ex.Message).Contains("both were null");
+    }
+
+    [Test]
+    public async Task not_toBeEquivalentTo_WithOneNull_Passes()
+    {
+        var expectation = new Expectation<Person?>(null, "person");
+        expectation.not.toBeEquivalentTo(new Person("Alice", 30));
+    }
+
+    #endregion
+
+    #region DSL Integration
+
+    [Test]
+    public async Task DSL_expect_collection_toContainExactly()
+    {
+        var list = new[] { 1, 2, 3 };
+        DraftSpec.Dsl.expect(list).toContainExactly(3, 2, 1);
+    }
+
+    [Test]
+    public async Task DSL_expect_toBeInstanceOf()
+    {
+        object value = "hello";
+        var result = DraftSpec.Dsl.expect(value).toBeInstanceOf<string>();
+        await Assert.That(result).IsEqualTo("hello");
+    }
+
+    [Test]
+    public async Task DSL_expect_toBeEquivalentTo()
+    {
+        var actual = new { Name = "Test" };
+        var expected = new { Name = "Test" };
+        DraftSpec.Dsl.expect(actual).toBeEquivalentTo(expected);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Adds commonly-needed assertions that were missing from the assertion library.

## New Assertions

### `toContainExactly()` - Same items, any order
```csharp
expect(list).toContainExactly(1, 2, 3);  // Must have exactly these items
expect(list).toContainExactly([1, 2, 3]);
```

### `toBeInstanceOf<T>()` - Type checking with typed return
```csharp
var str = expect(obj).toBeInstanceOf<string>();  // Returns typed value
expect(ex).toBeInstanceOf<ArgumentException>();
```

### `toBeEquivalentTo()` - Deep object comparison
```csharp
expect(actual).toBeEquivalentTo(expected);  // Compares via JSON serialization
```

## Negation Support
All assertions work with `.not`:
```csharp
expect(list).not.toContainExactly(1, 2);
expect(obj).not.toBeInstanceOf<string>();
expect(actual).not.toBeEquivalentTo(expected);
```

## Test coverage
36 new tests covering:
- All positive and negative scenarios for each assertion
- Edge cases (null values, empty collections, duplicates)
- DSL integration

## Test plan
- [x] All 36 CollectionAssertion tests pass
- [x] Full test suite passes (1060 tests)

Fixes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)