### PR TITLE
Add --filter and --exclude CLI flags for tag/name filtering

### DIFF
--- a/src/DraftSpec.Cli/CliOptions.cs
+++ b/src/DraftSpec.Cli/CliOptions.cs
@@ -29,4 +29,28 @@ public class CliOptions
     /// Remaining specs will be reported as skipped.
     /// </summary>
     public bool Bail { get; set; }
+
+    /// <summary>
+    /// Comma-separated list of tags to include.
+    /// Only specs with any of these tags will run.
+    /// </summary>
+    public string? FilterTags { get; set; }
+
+    /// <summary>
+    /// Comma-separated list of tags to exclude.
+    /// Specs with any of these tags will be skipped.
+    /// </summary>
+    public string? ExcludeTags { get; set; }
+
+    /// <summary>
+    /// Regex pattern to match spec names (context path + description).
+    /// Only specs matching this pattern will run.
+    /// </summary>
+    public string? FilterName { get; set; }
+
+    /// <summary>
+    /// Regex pattern to exclude spec names (context path + description).
+    /// Specs matching this pattern will be skipped.
+    /// </summary>
+    public string? ExcludeName { get; set; }
 }

--- a/src/DraftSpec.Cli/CliOptionsParser.cs
+++ b/src/DraftSpec.Cli/CliOptionsParser.cs
@@ -65,6 +65,46 @@ public static class CliOptionsParser
             {
                 options.Bail = true;
             }
+            else if (arg is "--filter-tags" or "-t")
+            {
+                if (i + 1 >= args.Length)
+                {
+                    options.Error = "--filter-tags requires a value (comma-separated tags)";
+                    return options;
+                }
+
+                options.FilterTags = args[++i];
+            }
+            else if (arg is "--exclude-tags" or "-x")
+            {
+                if (i + 1 >= args.Length)
+                {
+                    options.Error = "--exclude-tags requires a value (comma-separated tags)";
+                    return options;
+                }
+
+                options.ExcludeTags = args[++i];
+            }
+            else if (arg is "--filter-name" or "-n")
+            {
+                if (i + 1 >= args.Length)
+                {
+                    options.Error = "--filter-name requires a value (regex pattern)";
+                    return options;
+                }
+
+                options.FilterName = args[++i];
+            }
+            else if (arg == "--exclude-name")
+            {
+                if (i + 1 >= args.Length)
+                {
+                    options.Error = "--exclude-name requires a value (regex pattern)";
+                    return options;
+                }
+
+                options.ExcludeName = args[++i];
+            }
             else if (!arg.StartsWith('-'))
             {
                 positional.Add(arg);

--- a/src/DraftSpec.Cli/Commands/RunCommand.cs
+++ b/src/DraftSpec.Cli/Commands/RunCommand.cs
@@ -19,7 +19,12 @@ public static class RunCommand
     public static int Execute(CliOptions options, ICliFormatterRegistry? formatterRegistry = null)
     {
         var finder = new SpecFinder();
-        var runner = new SpecFileRunner(options.NoCache);
+        var runner = new SpecFileRunner(
+            options.NoCache,
+            options.FilterTags,
+            options.ExcludeTags,
+            options.FilterName,
+            options.ExcludeName);
 
         // For non-console formats, we need JSON output from specs
         var needsJson = options.Format is OutputFormats.Json or OutputFormats.Markdown or OutputFormats.Html;

--- a/src/DraftSpec/SpecRunnerBuilder.cs
+++ b/src/DraftSpec/SpecRunnerBuilder.cs
@@ -68,6 +68,22 @@ public class SpecRunnerBuilder
     }
 
     /// <summary>
+    /// Add filter middleware that excludes spec names matching a regex pattern.
+    /// Matches against the full description (context path + spec description).
+    /// </summary>
+    /// <param name="pattern">Regex pattern to exclude</param>
+    /// <param name="options">Regex options (default: IgnoreCase)</param>
+    public SpecRunnerBuilder WithNameExcludeFilter(string pattern, RegexOptions options = RegexOptions.IgnoreCase)
+    {
+        var regex = new Regex(pattern, options);
+        return Use(new FilterMiddleware(ctx =>
+            {
+                var fullDescription = string.Join(" ", ctx.ContextPath.Append(ctx.Spec.Description));
+                return !regex.IsMatch(fullDescription);
+            }, $"matches excluded pattern '{pattern}'"));
+    }
+
+    /// <summary>
     /// Add filter middleware that runs only specs with any of the specified tags.
     /// </summary>
     /// <param name="tags">Tags to match (spec runs if it has ANY of these tags)</param>

--- a/tests/DraftSpec.Tests/Cli/CliOptionsParserTests.cs
+++ b/tests/DraftSpec.Tests/Cli/CliOptionsParserTests.cs
@@ -235,6 +235,130 @@ public class CliOptionsParserTests
 
     #endregion
 
+    #region Filter Options
+
+    [Test]
+    public async Task Parse_FilterTagsOption_SetsFilterTags()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--filter-tags", "fast,unit"]);
+
+        await Assert.That(options.FilterTags).IsEqualTo("fast,unit");
+    }
+
+    [Test]
+    public async Task Parse_ShortFilterTagsOption_SetsFilterTags()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "-t", "integration"]);
+
+        await Assert.That(options.FilterTags).IsEqualTo("integration");
+    }
+
+    [Test]
+    public async Task Parse_FilterTagsWithoutValue_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--filter-tags"]);
+
+        await Assert.That(options.Error).IsNotNull();
+        await Assert.That(options.Error).Contains("--filter-tags requires a value");
+    }
+
+    [Test]
+    public async Task Parse_ExcludeTagsOption_SetsExcludeTags()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--exclude-tags", "slow,flaky"]);
+
+        await Assert.That(options.ExcludeTags).IsEqualTo("slow,flaky");
+    }
+
+    [Test]
+    public async Task Parse_ShortExcludeTagsOption_SetsExcludeTags()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "-x", "wip"]);
+
+        await Assert.That(options.ExcludeTags).IsEqualTo("wip");
+    }
+
+    [Test]
+    public async Task Parse_ExcludeTagsWithoutValue_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--exclude-tags"]);
+
+        await Assert.That(options.Error).IsNotNull();
+        await Assert.That(options.Error).Contains("--exclude-tags requires a value");
+    }
+
+    [Test]
+    public async Task Parse_FilterNameOption_SetsFilterName()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--filter-name", "Calculator.*add"]);
+
+        await Assert.That(options.FilterName).IsEqualTo("Calculator.*add");
+    }
+
+    [Test]
+    public async Task Parse_ShortFilterNameOption_SetsFilterName()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "-n", "should.*return"]);
+
+        await Assert.That(options.FilterName).IsEqualTo("should.*return");
+    }
+
+    [Test]
+    public async Task Parse_FilterNameWithoutValue_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--filter-name"]);
+
+        await Assert.That(options.Error).IsNotNull();
+        await Assert.That(options.Error).Contains("--filter-name requires a value");
+    }
+
+    [Test]
+    public async Task Parse_ExcludeNameOption_SetsExcludeName()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--exclude-name", ".*slow.*"]);
+
+        await Assert.That(options.ExcludeName).IsEqualTo(".*slow.*");
+    }
+
+    [Test]
+    public async Task Parse_ExcludeNameWithoutValue_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--exclude-name"]);
+
+        await Assert.That(options.Error).IsNotNull();
+        await Assert.That(options.Error).Contains("--exclude-name requires a value");
+    }
+
+    [Test]
+    public async Task Parse_FilterOptionsDefaultsAreNull()
+    {
+        var options = CliOptionsParser.Parse(["run", "."]);
+
+        await Assert.That(options.FilterTags).IsNull();
+        await Assert.That(options.ExcludeTags).IsNull();
+        await Assert.That(options.FilterName).IsNull();
+        await Assert.That(options.ExcludeName).IsNull();
+    }
+
+    [Test]
+    public async Task Parse_CombinedFilterOptions_SetsAll()
+    {
+        var options = CliOptionsParser.Parse([
+            "run", ".",
+            "-t", "fast,unit",
+            "-x", "slow",
+            "-n", "Calculator",
+            "--exclude-name", ".*deprecated.*"
+        ]);
+
+        await Assert.That(options.FilterTags).IsEqualTo("fast,unit");
+        await Assert.That(options.ExcludeTags).IsEqualTo("slow");
+        await Assert.That(options.FilterName).IsEqualTo("Calculator");
+        await Assert.That(options.ExcludeName).IsEqualTo(".*deprecated.*");
+    }
+
+    #endregion
+
     #region Error Cases
 
     [Test]


### PR DESCRIPTION
## Summary
Adds CLI flags for filtering specs by tags and name patterns:
- `--filter-tags/-t`: Run only specs with any of the specified tags
- `--exclude-tags/-x`: Skip specs with any of the specified tags
- `--filter-name/-n`: Run only specs matching the regex pattern
- `--exclude-name`: Skip specs matching the regex pattern

**Implementation:**
- Add filter properties to `CliOptions`
- Add argument parsing in `CliOptionsParser`
- Pass filters as environment variables via `SpecFileRunner`
- Read env vars in `Dsl.Run.cs` and configure `SpecRunnerBuilder`
- Add `WithNameExcludeFilter()` method to `SpecRunnerBuilder`

**Examples:**
```bash
draftspec run -t fast,unit          # Run only fast or unit tests
draftspec run -x slow,flaky         # Skip slow and flaky tests
draftspec run -n "Calculator.*add"  # Run specs matching pattern
draftspec run --exclude-name ".*deprecated.*"
```

## Test plan
- [x] All 1123 tests pass
- [x] 18 new tests for CLI option parsing
- [x] 5 new tests for `WithNameExcludeFilter`

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)