### PR TITLE
Cache focus/spec count on tree construction to eliminate traversals

### DIFF
--- a/src/DraftSpec/SpecContext.cs
+++ b/src/DraftSpec/SpecContext.cs
@@ -32,6 +32,22 @@ public class SpecContext
     private readonly List<SpecContext> _children = [];
     private readonly List<SpecDefinition> _specs = [];
 
+    // Cached counts computed during tree construction
+    private int _totalSpecCount;
+    private bool _hasFocusedDescendants;
+
+    /// <summary>
+    /// Total number of specs in this context and all descendants.
+    /// Computed incrementally during tree construction.
+    /// </summary>
+    public int TotalSpecCount => _totalSpecCount;
+
+    /// <summary>
+    /// Whether this context or any descendant contains a focused spec.
+    /// Computed incrementally during tree construction.
+    /// </summary>
+    public bool HasFocusedDescendants => _hasFocusedDescendants;
+
     /// <summary>
     /// Child contexts (read-only view). Use <see cref="AddChild"/> to add.
     /// </summary>
@@ -90,6 +106,40 @@ public class SpecContext
     public void AddSpec(SpecDefinition spec)
     {
         _specs.Add(spec);
+
+        // Update cached counts
+        IncrementSpecCount();
+
+        if (spec.IsFocused)
+        {
+            PropagateHasFocused();
+        }
+    }
+
+    /// <summary>
+    /// Increments spec count in this context and all ancestors.
+    /// </summary>
+    private void IncrementSpecCount()
+    {
+        var current = this;
+        while (current != null)
+        {
+            current._totalSpecCount++;
+            current = current.Parent;
+        }
+    }
+
+    /// <summary>
+    /// Propagates HasFocusedDescendants flag up to all ancestors.
+    /// </summary>
+    private void PropagateHasFocused()
+    {
+        var current = this;
+        while (current != null && !current._hasFocusedDescendants)
+        {
+            current._hasFocusedDescendants = true;
+            current = current.Parent;
+        }
     }
 
     /// <summary>

--- a/tests/DraftSpec.Tests/Core/SpecContextTests.cs
+++ b/tests/DraftSpec.Tests/Core/SpecContextTests.cs
@@ -204,4 +204,172 @@ public class SpecContextTests
     }
 
     #endregion
+
+    #region TotalSpecCount Incremental Computation
+
+    [Test]
+    public async Task TotalSpecCount_EmptyContext_IsZero()
+    {
+        var context = new SpecContext("test");
+
+        await Assert.That(context.TotalSpecCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task TotalSpecCount_SingleSpec_IsOne()
+    {
+        var context = new SpecContext("test");
+        context.AddSpec(new SpecDefinition("spec", () => { }));
+
+        await Assert.That(context.TotalSpecCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TotalSpecCount_MultipleSpecs_CountsAll()
+    {
+        var context = new SpecContext("test");
+        context.AddSpec(new SpecDefinition("spec1", () => { }));
+        context.AddSpec(new SpecDefinition("spec2", () => { }));
+        context.AddSpec(new SpecDefinition("spec3", () => { }));
+
+        await Assert.That(context.TotalSpecCount).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task TotalSpecCount_NestedContexts_PropagatesUp()
+    {
+        var parent = new SpecContext("parent");
+        var child = new SpecContext("child", parent);
+
+        child.AddSpec(new SpecDefinition("child spec", () => { }));
+
+        // Both parent and child should count the spec
+        await Assert.That(child.TotalSpecCount).IsEqualTo(1);
+        await Assert.That(parent.TotalSpecCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TotalSpecCount_DeepNesting_PropagatesAllTheWay()
+    {
+        var root = new SpecContext("root");
+        var level1 = new SpecContext("level1", root);
+        var level2 = new SpecContext("level2", level1);
+        var level3 = new SpecContext("level3", level2);
+
+        level3.AddSpec(new SpecDefinition("deep spec", () => { }));
+
+        await Assert.That(level3.TotalSpecCount).IsEqualTo(1);
+        await Assert.That(level2.TotalSpecCount).IsEqualTo(1);
+        await Assert.That(level1.TotalSpecCount).IsEqualTo(1);
+        await Assert.That(root.TotalSpecCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task TotalSpecCount_MultipleBranches_SumsCorrectly()
+    {
+        var root = new SpecContext("root");
+        var child1 = new SpecContext("child1", root);
+        var child2 = new SpecContext("child2", root);
+
+        root.AddSpec(new SpecDefinition("root spec", () => { }));
+        child1.AddSpec(new SpecDefinition("child1 spec 1", () => { }));
+        child1.AddSpec(new SpecDefinition("child1 spec 2", () => { }));
+        child2.AddSpec(new SpecDefinition("child2 spec", () => { }));
+
+        await Assert.That(child1.TotalSpecCount).IsEqualTo(2);
+        await Assert.That(child2.TotalSpecCount).IsEqualTo(1);
+        await Assert.That(root.TotalSpecCount).IsEqualTo(4);
+    }
+
+    #endregion
+
+    #region HasFocusedDescendants Incremental Computation
+
+    [Test]
+    public async Task HasFocusedDescendants_EmptyContext_IsFalse()
+    {
+        var context = new SpecContext("test");
+
+        await Assert.That(context.HasFocusedDescendants).IsFalse();
+    }
+
+    [Test]
+    public async Task HasFocusedDescendants_NonFocusedSpec_IsFalse()
+    {
+        var context = new SpecContext("test");
+        context.AddSpec(new SpecDefinition("spec", () => { }));
+
+        await Assert.That(context.HasFocusedDescendants).IsFalse();
+    }
+
+    [Test]
+    public async Task HasFocusedDescendants_FocusedSpec_IsTrue()
+    {
+        var context = new SpecContext("test");
+        context.AddSpec(new SpecDefinition("spec", () => { }) { IsFocused = true });
+
+        await Assert.That(context.HasFocusedDescendants).IsTrue();
+    }
+
+    [Test]
+    public async Task HasFocusedDescendants_NestedFocusedSpec_PropagatesUp()
+    {
+        var parent = new SpecContext("parent");
+        var child = new SpecContext("child", parent);
+
+        child.AddSpec(new SpecDefinition("focused spec", () => { }) { IsFocused = true });
+
+        await Assert.That(child.HasFocusedDescendants).IsTrue();
+        await Assert.That(parent.HasFocusedDescendants).IsTrue();
+    }
+
+    [Test]
+    public async Task HasFocusedDescendants_DeepNesting_PropagatesAllTheWay()
+    {
+        var root = new SpecContext("root");
+        var level1 = new SpecContext("level1", root);
+        var level2 = new SpecContext("level2", level1);
+        var level3 = new SpecContext("level3", level2);
+
+        level3.AddSpec(new SpecDefinition("deep focused", () => { }) { IsFocused = true });
+
+        await Assert.That(level3.HasFocusedDescendants).IsTrue();
+        await Assert.That(level2.HasFocusedDescendants).IsTrue();
+        await Assert.That(level1.HasFocusedDescendants).IsTrue();
+        await Assert.That(root.HasFocusedDescendants).IsTrue();
+    }
+
+    [Test]
+    public async Task HasFocusedDescendants_OnlyInOneBranch_DoesNotAffectSibling()
+    {
+        var root = new SpecContext("root");
+        var child1 = new SpecContext("child1", root);
+        var child2 = new SpecContext("child2", root);
+
+        child1.AddSpec(new SpecDefinition("focused", () => { }) { IsFocused = true });
+        child2.AddSpec(new SpecDefinition("not focused", () => { }));
+
+        await Assert.That(child1.HasFocusedDescendants).IsTrue();
+        await Assert.That(child2.HasFocusedDescendants).IsFalse();
+        await Assert.That(root.HasFocusedDescendants).IsTrue();
+    }
+
+    [Test]
+    public async Task HasFocusedDescendants_AlreadyTrue_DoesNotRepropagate()
+    {
+        var root = new SpecContext("root");
+        var child = new SpecContext("child", root);
+
+        // Add first focused spec
+        child.AddSpec(new SpecDefinition("focused1", () => { }) { IsFocused = true });
+
+        await Assert.That(root.HasFocusedDescendants).IsTrue();
+
+        // Add second focused spec - should not cause any issues
+        child.AddSpec(new SpecDefinition("focused2", () => { }) { IsFocused = true });
+
+        await Assert.That(root.HasFocusedDescendants).IsTrue();
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
Adds incremental computation of `TotalSpecCount` and `HasFocusedDescendants` during tree construction, eliminating O(n) traversals before execution.

**Changes to SpecContext:**
- Add `TotalSpecCount` property (incremented and propagated on `AddSpec`)
- Add `HasFocusedDescendants` property (propagated on focused spec add)
- Add `IncrementSpecCount()` helper to propagate count up to ancestors
- Add `PropagateHasFocused()` helper to set flag on ancestors

**Changes to SpecRunner:**
- Use `rootContext.HasFocusedDescendants` instead of `HasFocusedSpecs()`
- Use `rootContext.TotalSpecCount` instead of `CountSpecs()`
- Remove now-unused `HasFocusedSpecs()` and `CountSpecs()` methods

**Performance improvement:**
- Before: O(n) + O(n) traversals before every test run
- After: O(1) property access (computed incrementally during construction)

## Test plan
- [x] All 1156 tests pass
- [x] 13 new tests for incremental computation
- [x] Tests verify propagation through nested contexts

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)