### PR TITLE
Use HashCode instead of SHA256 for script cache keys

### DIFF
--- a/src/DraftSpec.Mcp/Services/InProcessSpecRunner.cs
+++ b/src/DraftSpec.Mcp/Services/InProcessSpecRunner.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using DraftSpec.Formatters;
@@ -252,12 +251,14 @@ public class InProcessSpecRunner
     }
 
     /// <summary>
-    /// Compute content hash for caching.
+    /// Compute content hash for caching using HashCode (fast non-cryptographic hash).
+    /// Uses .NET's built-in HashCode which internally uses a variant of xxHash.
     /// </summary>
     private static string ComputeHash(string content)
     {
-        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(content));
-        return Convert.ToHexString(bytes).ToLowerInvariant();
+        var hash = new HashCode();
+        hash.AddBytes(Encoding.UTF8.GetBytes(content));
+        return hash.ToHashCode().ToString("x8");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Replace cryptographic SHA256 with .NET's built-in `HashCode` for script content hashing. `HashCode` internally uses a variant of xxHash which is significantly faster (~10x) for non-cryptographic cache key generation.

## Changes
- Replace `SHA256.HashData` with `HashCode.AddBytes`
- Remove `System.Security.Cryptography` dependency
- Output 8-char hex string (32-bit) vs 64-char (256-bit)

## Performance Impact
- SHA256: ~500 MB/s, cryptographically secure (overkill for cache keys)
- HashCode/xxHash: ~5-10 GB/s, fast non-cryptographic hash
- For typical spec content (~1-10KB), this saves microseconds per hash

## Test plan
- [x] All 1156 tests pass
- [x] Existing cache tests verify caching still works correctly
- [x] No new package dependencies (uses .NET core libraries)

Fixes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)