### PR TITLE
Fix exit code not being reset to 0 on successful spec runs

### DIFF
--- a/src/DraftSpec/Internal/SpecExecutor.cs
+++ b/src/DraftSpec/Internal/SpecExecutor.cs
@@ -62,8 +62,8 @@ internal static class SpecExecutor
         else
             FormatToConsole(configuration, report);
 
-        // Set exit code based on failures
-        if (report.Summary.Failed > 0) Environment.ExitCode = 1;
+        // Set exit code based on failures (explicitly set to 0 on success)
+        Environment.ExitCode = report.Summary.Failed > 0 ? 1 : 0;
 
         // Reset state for next run
         resetState();


### PR DESCRIPTION
## Summary
Fix a bug where `Environment.ExitCode` was only set to 1 on failure but never reset to 0 on success. This caused tests running after a failing test to incorrectly report exit code 1 even when all specs passed.

## Root Cause
In `SpecExecutor.cs`, the code was:
```csharp
if (report.Summary.Failed > 0) Environment.ExitCode = 1;
```

This only sets exit code on failure, leaving it unchanged on success.

## Fix
Changed to explicitly set the exit code in all cases:
```csharp
Environment.ExitCode = report.Summary.Failed > 0 ? 1 : 0;
```

## Test plan
- [x] All 1,314 tests pass (previously 2 were failing)
- [x] `Run_AllPassed_ExitCodeZero` now passes
- [x] `Run_OnlyPending_ExitCodeZero` now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)