### PR TITLE
Add natural language assertion helper (parse_assertion tool)

### DIFF
--- a/src/DraftSpec.Mcp/Tools/AssertionTools.cs
+++ b/src/DraftSpec.Mcp/Tools/AssertionTools.cs
@@ -1,0 +1,335 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using DraftSpec.Formatters;
+using ModelContextProtocol.Server;
+
+namespace DraftSpec.Mcp.Tools;
+
+/// <summary>
+/// MCP tools for parsing natural language assertions.
+/// </summary>
+[McpServerToolType]
+public static partial class AssertionTools
+{
+    /// <summary>
+    /// Parse a natural language assertion into DraftSpec expect() syntax.
+    /// </summary>
+    [McpServerTool(Name = "parse_assertion")]
+    [Description("Convert a natural language assertion to DraftSpec expect() syntax. " +
+                 "Parses common assertion patterns and returns the equivalent code.")]
+    public static string ParseAssertion(
+        [Description("Natural language assertion (e.g., 'should be greater than 5', 'should contain hello')")]
+        string naturalLanguage,
+        [Description("Variable or expression name to assert on (e.g., 'result', 'user.Name', 'items.Count')")]
+        string variableName)
+    {
+        var result = Parse(naturalLanguage, variableName);
+        return JsonSerializer.Serialize(result, JsonOptionsProvider.Default);
+    }
+
+    /// <summary>
+    /// Parse natural language assertion to structured result.
+    /// </summary>
+    internal static AssertionParseResult Parse(string naturalLanguage, string variableName)
+    {
+        var input = naturalLanguage.Trim();
+
+        // Try each pattern in order
+        foreach (var pattern in Patterns)
+        {
+            var match = pattern.Regex.Match(input);
+            if (match.Success)
+            {
+                var code = pattern.Generator(variableName, match);
+                return new AssertionParseResult
+                {
+                    Success = true,
+                    Code = code,
+                    Confidence = pattern.Confidence,
+                    Pattern = pattern.Description
+                };
+            }
+        }
+
+        // No pattern matched
+        return new AssertionParseResult
+        {
+            Success = false,
+            Code = $"expect({variableName}).toBe(/* TODO: specify expected value */)",
+            Confidence = 0.0,
+            Pattern = null,
+            Error = $"Could not parse assertion: '{naturalLanguage}'. Using fallback template."
+        };
+    }
+
+    private static readonly AssertionPattern[] Patterns =
+    [
+        // Null checks
+        new(
+            NotBeNullRegex(),
+            "not be null",
+            1.0,
+            (v, _) => $"expect({v}).toNotBeNull()"),
+        new(
+            BeNullRegex(),
+            "be null",
+            1.0,
+            (v, _) => $"expect({v}).toBeNull()"),
+
+        // Boolean checks
+        new(
+            BeTrueRegex(),
+            "be true",
+            1.0,
+            (v, _) => $"expect({v}).toBeTrue()"),
+        new(
+            BeFalseRegex(),
+            "be false",
+            1.0,
+            (v, _) => $"expect({v}).toBeFalse()"),
+
+        // Numeric comparisons
+        new(
+            BeGreaterThanRegex(),
+            "be greater than",
+            0.95,
+            (v, m) => $"expect({v}).toBeGreaterThan({m.Groups["value"].Value})"),
+        new(
+            BeLessThanRegex(),
+            "be less than",
+            0.95,
+            (v, m) => $"expect({v}).toBeLessThan({m.Groups["value"].Value})"),
+        new(
+            BeAtLeastRegex(),
+            "be at least / be >=",
+            0.95,
+            (v, m) => $"expect({v}).toBeAtLeast({m.Groups["value"].Value})"),
+        new(
+            BeAtMostRegex(),
+            "be at most / be <=",
+            0.95,
+            (v, m) => $"expect({v}).toBeAtMost({m.Groups["value"].Value})"),
+
+        // Collection count
+        new(
+            HaveCountRegex(),
+            "have count",
+            0.9,
+            (v, m) => $"expect({v}).toHaveCount({m.Groups["count"].Value})"),
+        new(
+            HaveItemsRegex(),
+            "have N items",
+            0.9,
+            (v, m) => $"expect({v}).toHaveCount({m.Groups["count"].Value})"),
+
+        // Empty checks
+        new(
+            NotBeEmptyRegex(),
+            "not be empty",
+            1.0,
+            (v, _) => $"expect({v}).toNotBeEmpty()"),
+        new(
+            BeEmptyRegex(),
+            "be empty",
+            1.0,
+            (v, _) => $"expect({v}).toBeEmpty()"),
+
+        // String operations
+        new(
+            ContainStringRegex(),
+            "contain string",
+            0.9,
+            (v, m) => $"expect({v}).toContain(\"{EscapeString(m.Groups["text"].Value)}\")"),
+        new(
+            StartWithRegex(),
+            "start with",
+            0.9,
+            (v, m) => $"expect({v}).toStartWith(\"{EscapeString(m.Groups["text"].Value)}\")"),
+        new(
+            EndWithRegex(),
+            "end with",
+            0.9,
+            (v, m) => $"expect({v}).toEndWith(\"{EscapeString(m.Groups["text"].Value)}\")"),
+        new(
+            MatchPatternRegex(),
+            "match pattern",
+            0.85,
+            (v, m) => $"expect({v}).toMatch(\"{EscapeString(m.Groups["pattern"].Value)}\")"),
+
+        // Exception handling - order matters!
+        new(
+            NotThrowRegex(),
+            "not throw",
+            1.0,
+            (v, _) => $"expect(() => {v}).toNotThrow()"),
+        new(
+            ThrowGenericRegex(),
+            "throw (generic)",
+            0.95,
+            (v, _) => $"expect(() => {v}).toThrow()"),
+        new(
+            ThrowExceptionRegex(),
+            "throw specific exception",
+            0.9,
+            (v, m) => $"expect(() => {v}).toThrow<{FormatExceptionType(m.Groups["exception"].Value)}>()"),
+
+        // Equality (should be last as it's most general)
+        new(
+            NotEqualRegex(),
+            "not equal",
+            0.85,
+            (v, m) => $"expect({v}).not.toBe({FormatValue(m.Groups["value"].Value)})"),
+        new(
+            EqualRegex(),
+            "equal / be",
+            0.8,
+            (v, m) => $"expect({v}).toBe({FormatValue(m.Groups["value"].Value)})"),
+    ];
+
+    private static string EscapeString(string value) =>
+        value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+    private static string FormatValue(string value)
+    {
+        // Check if it's a number
+        if (double.TryParse(value, out _))
+            return value;
+
+        // Check if it's a boolean
+        if (value is "true" or "false")
+            return value;
+
+        // Check if it's already quoted
+        if ((value.StartsWith('"') && value.EndsWith('"')) ||
+            (value.StartsWith('\'') && value.EndsWith('\'')))
+            return $"\"{EscapeString(value[1..^1])}\"";
+
+        // Treat as string
+        return $"\"{EscapeString(value)}\"";
+    }
+
+    private static string FormatExceptionType(string exceptionName)
+    {
+        var name = exceptionName.Trim();
+
+        // Remove common prefixes
+        if (name.StartsWith("an ", StringComparison.OrdinalIgnoreCase))
+            name = name[3..];
+        else if (name.StartsWith("a ", StringComparison.OrdinalIgnoreCase))
+            name = name[2..];
+
+        // Normalize to PascalCase and add Exception suffix if needed
+        name = string.Join("", name.Split(' ')
+            .Select(w => char.ToUpperInvariant(w[0]) + w[1..]));
+
+        if (!name.EndsWith("Exception", StringComparison.OrdinalIgnoreCase))
+            name += "Exception";
+
+        return name;
+    }
+
+    // Regex patterns using source generators with case-insensitive matching
+    [GeneratedRegex(@"^(?:should\s+)?not\s+be\s+null$", RegexOptions.IgnoreCase)]
+    private static partial Regex NotBeNullRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?be\s+null$", RegexOptions.IgnoreCase)]
+    private static partial Regex BeNullRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?be\s+true$", RegexOptions.IgnoreCase)]
+    private static partial Regex BeTrueRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?be\s+false$", RegexOptions.IgnoreCase)]
+    private static partial Regex BeFalseRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?be\s+greater\s+than\s+(?<value>-?\d+(?:\.\d+)?)$", RegexOptions.IgnoreCase)]
+    private static partial Regex BeGreaterThanRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?be\s+less\s+than\s+(?<value>-?\d+(?:\.\d+)?)$", RegexOptions.IgnoreCase)]
+    private static partial Regex BeLessThanRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?(?:be\s+(?:at\s+least|>=)|>=)\s*(?<value>-?\d+(?:\.\d+)?)$", RegexOptions.IgnoreCase)]
+    private static partial Regex BeAtLeastRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?(?:be\s+(?:at\s+most|<=)|<=)\s*(?<value>-?\d+(?:\.\d+)?)$", RegexOptions.IgnoreCase)]
+    private static partial Regex BeAtMostRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?have\s+(?:a\s+)?count\s+(?:of\s+)?(?<count>\d+)$", RegexOptions.IgnoreCase)]
+    private static partial Regex HaveCountRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?have\s+(?<count>\d+)\s+items?$", RegexOptions.IgnoreCase)]
+    private static partial Regex HaveItemsRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?not\s+be\s+empty$", RegexOptions.IgnoreCase)]
+    private static partial Regex NotBeEmptyRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?be\s+empty$", RegexOptions.IgnoreCase)]
+    private static partial Regex BeEmptyRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?contain\s+['""]?(?<text>[^'""]+)['""]?$", RegexOptions.IgnoreCase)]
+    private static partial Regex ContainStringRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?start\s+with\s+['""]?(?<text>[^'""]+)['""]?$", RegexOptions.IgnoreCase)]
+    private static partial Regex StartWithRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?end\s+with\s+['""]?(?<text>[^'""]+)['""]?$", RegexOptions.IgnoreCase)]
+    private static partial Regex EndWithRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?match\s+(?:pattern\s+)?['""]?(?<pattern>[^'""]+)['""]?$", RegexOptions.IgnoreCase)]
+    private static partial Regex MatchPatternRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?not\s+throw(?:\s+(?:any\s+)?(?:exception|error))?$", RegexOptions.IgnoreCase)]
+    private static partial Regex NotThrowRegex();
+
+    // Matches "throw", "throw exception", "throw an exception", "throw a exception"
+    [GeneratedRegex(@"^(?:should\s+)?throw(?:\s+(?:an?\s+)?exception)?$", RegexOptions.IgnoreCase)]
+    private static partial Regex ThrowGenericRegex();
+
+    // Matches "throw <ExceptionType>" where type is NOT just "exception"
+    // Excludes: "an exception", "a exception", just "exception"
+    [GeneratedRegex(@"^(?:should\s+)?throw\s+(?<exception>(?!an?\s+exception$|exception$)[A-Za-z]+(?:\s+[A-Za-z]+)*(?:Exception)?)$", RegexOptions.IgnoreCase)]
+    private static partial Regex ThrowExceptionRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?(?:not\s+(?:be\s+)?equal(?:\s+to)?|not\s+equal)\s+(?<value>.+)$", RegexOptions.IgnoreCase)]
+    private static partial Regex NotEqualRegex();
+
+    [GeneratedRegex(@"^(?:should\s+)?(?:(?:be\s+)?equal(?:\s+to)?|be)\s+(?<value>.+)$", RegexOptions.IgnoreCase)]
+    private static partial Regex EqualRegex();
+
+    private record AssertionPattern(
+        Regex Regex,
+        string Description,
+        double Confidence,
+        Func<string, Match, string> Generator);
+}
+
+/// <summary>
+/// Result of parsing a natural language assertion.
+/// </summary>
+public record AssertionParseResult
+{
+    /// <summary>
+    /// Whether parsing was successful.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// The generated DraftSpec expect() code.
+    /// </summary>
+    public required string Code { get; init; }
+
+    /// <summary>
+    /// Confidence score (0.0 to 1.0) indicating how well the pattern matched.
+    /// </summary>
+    public double Confidence { get; init; }
+
+    /// <summary>
+    /// Description of the pattern that matched (if successful).
+    /// </summary>
+    public string? Pattern { get; init; }
+
+    /// <summary>
+    /// Error message if parsing failed.
+    /// </summary>
+    public string? Error { get; init; }
+}

--- a/tests/DraftSpec.Tests/Mcp/Tools/AssertionToolsTests.cs
+++ b/tests/DraftSpec.Tests/Mcp/Tools/AssertionToolsTests.cs
@@ -1,0 +1,445 @@
+using DraftSpec.Mcp.Tools;
+
+namespace DraftSpec.Tests.Mcp.Tools;
+
+/// <summary>
+/// Tests for natural language assertion parsing.
+/// </summary>
+public class AssertionToolsTests
+{
+    #region Null Assertions
+
+    [Test]
+    public async Task Parse_ShouldNotBeNull_ReturnsToNotBeNull()
+    {
+        var result = AssertionTools.Parse("should not be null", "result");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(result).toNotBeNull()");
+        await Assert.That(result.Confidence).IsEqualTo(1.0);
+    }
+
+    [Test]
+    public async Task Parse_NotBeNull_ReturnsToNotBeNull()
+    {
+        var result = AssertionTools.Parse("not be null", "user");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(user).toNotBeNull()");
+    }
+
+    [Test]
+    public async Task Parse_ShouldBeNull_ReturnsToBeNull()
+    {
+        var result = AssertionTools.Parse("should be null", "error");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(error).toBeNull()");
+    }
+
+    #endregion
+
+    #region Boolean Assertions
+
+    [Test]
+    public async Task Parse_ShouldBeTrue_ReturnsToBeTrue()
+    {
+        var result = AssertionTools.Parse("should be true", "isValid");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(isValid).toBeTrue()");
+    }
+
+    [Test]
+    public async Task Parse_ShouldBeFalse_ReturnsToBeFalse()
+    {
+        var result = AssertionTools.Parse("should be false", "hasErrors");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(hasErrors).toBeFalse()");
+    }
+
+    #endregion
+
+    #region Numeric Comparisons
+
+    [Test]
+    public async Task Parse_ShouldBeGreaterThan_ReturnsToBeGreaterThan()
+    {
+        var result = AssertionTools.Parse("should be greater than 5", "count");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(count).toBeGreaterThan(5)");
+        await Assert.That(result.Confidence).IsEqualTo(0.95);
+    }
+
+    [Test]
+    public async Task Parse_BeGreaterThanDecimal_ReturnsToBeGreaterThan()
+    {
+        var result = AssertionTools.Parse("be greater than 3.14", "value");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(value).toBeGreaterThan(3.14)");
+    }
+
+    [Test]
+    public async Task Parse_ShouldBeLessThan_ReturnsToBeLessThan()
+    {
+        var result = AssertionTools.Parse("should be less than 10", "x");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(x).toBeLessThan(10)");
+    }
+
+    [Test]
+    public async Task Parse_BeLessThanNegative_ReturnsToBeLessThan()
+    {
+        var result = AssertionTools.Parse("be less than -5", "temperature");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(temperature).toBeLessThan(-5)");
+    }
+
+    [Test]
+    public async Task Parse_ShouldBeAtLeast_ReturnsToBeAtLeast()
+    {
+        var result = AssertionTools.Parse("should be at least 18", "age");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(age).toBeAtLeast(18)");
+    }
+
+    [Test]
+    public async Task Parse_ShouldBeAtMost_ReturnsToBeAtMost()
+    {
+        var result = AssertionTools.Parse("should be at most 100", "percentage");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(percentage).toBeAtMost(100)");
+    }
+
+    #endregion
+
+    #region Collection Assertions
+
+    [Test]
+    public async Task Parse_ShouldHaveCount_ReturnsToHaveCount()
+    {
+        var result = AssertionTools.Parse("should have count 3", "items");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(items).toHaveCount(3)");
+    }
+
+    [Test]
+    public async Task Parse_HaveCountOf_ReturnsToHaveCount()
+    {
+        var result = AssertionTools.Parse("have a count of 5", "list");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(list).toHaveCount(5)");
+    }
+
+    [Test]
+    public async Task Parse_ShouldHave3Items_ReturnsToHaveCount()
+    {
+        var result = AssertionTools.Parse("should have 3 items", "array");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(array).toHaveCount(3)");
+    }
+
+    [Test]
+    public async Task Parse_Have1Item_ReturnsToHaveCount()
+    {
+        var result = AssertionTools.Parse("have 1 item", "collection");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(collection).toHaveCount(1)");
+    }
+
+    [Test]
+    public async Task Parse_ShouldBeEmpty_ReturnsToBeEmpty()
+    {
+        var result = AssertionTools.Parse("should be empty", "list");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(list).toBeEmpty()");
+    }
+
+    [Test]
+    public async Task Parse_ShouldNotBeEmpty_ReturnsToNotBeEmpty()
+    {
+        var result = AssertionTools.Parse("should not be empty", "results");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(results).toNotBeEmpty()");
+    }
+
+    #endregion
+
+    #region String Assertions
+
+    [Test]
+    public async Task Parse_ShouldContain_ReturnsToContain()
+    {
+        var result = AssertionTools.Parse("should contain 'hello'", "message");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(message).toContain(\"hello\")");
+    }
+
+    [Test]
+    public async Task Parse_ContainWithDoubleQuotes_ReturnsToContain()
+    {
+        var result = AssertionTools.Parse("contain \"world\"", "text");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(text).toContain(\"world\")");
+    }
+
+    [Test]
+    public async Task Parse_ContainWithoutQuotes_ReturnsToContain()
+    {
+        var result = AssertionTools.Parse("should contain hello", "str");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(str).toContain(\"hello\")");
+    }
+
+    [Test]
+    public async Task Parse_ShouldStartWith_ReturnsToStartWith()
+    {
+        var result = AssertionTools.Parse("should start with 'Error:'", "log");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(log).toStartWith(\"Error:\")");
+    }
+
+    [Test]
+    public async Task Parse_ShouldEndWith_ReturnsToEndWith()
+    {
+        var result = AssertionTools.Parse("should end with '.txt'", "filename");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(filename).toEndWith(\".txt\")");
+    }
+
+    [Test]
+    public async Task Parse_ShouldMatchPattern_ReturnsToMatch()
+    {
+        var result = AssertionTools.Parse("should match pattern '[0-9]+'", "input");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(input).toMatch(\"[0-9]+\")");
+    }
+
+    [Test]
+    public async Task Parse_Match_ReturnsToMatch()
+    {
+        var result = AssertionTools.Parse("match '^test.*'", "value");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(value).toMatch(\"^test.*\")");
+    }
+
+    #endregion
+
+    #region Exception Assertions
+
+    [Test]
+    public async Task Parse_ShouldThrowArgumentException_ReturnsToThrow()
+    {
+        var result = AssertionTools.Parse("should throw ArgumentException", "action");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(() => action).toThrow<ArgumentException>()");
+    }
+
+    [Test]
+    public async Task Parse_ThrowAnInvalidOperationException_ReturnsToThrow()
+    {
+        var result = AssertionTools.Parse("throw an invalid operation exception", "func");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(() => func).toThrow<InvalidOperationException>()");
+    }
+
+    [Test]
+    public async Task Parse_ShouldThrow_ReturnsToThrow()
+    {
+        var result = AssertionTools.Parse("should throw", "call");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(() => call).toThrow()");
+    }
+
+    [Test]
+    public async Task Parse_ThrowAnException_ReturnsToThrow()
+    {
+        var result = AssertionTools.Parse("throw an exception", "method");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(() => method).toThrow()");
+    }
+
+    [Test]
+    public async Task Parse_ShouldNotThrow_ReturnsToNotThrow()
+    {
+        var result = AssertionTools.Parse("should not throw", "operation");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(() => operation).toNotThrow()");
+    }
+
+    [Test]
+    public async Task Parse_NotThrowAnyException_ReturnsToNotThrow()
+    {
+        var result = AssertionTools.Parse("not throw any exception", "safeCall");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(() => safeCall).toNotThrow()");
+    }
+
+    #endregion
+
+    #region Equality Assertions
+
+    [Test]
+    public async Task Parse_ShouldEqualNumber_ReturnsToBe()
+    {
+        var result = AssertionTools.Parse("should equal 42", "answer");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(answer).toBe(42)");
+    }
+
+    [Test]
+    public async Task Parse_ShouldBeEqualToString_ReturnsToBe()
+    {
+        var result = AssertionTools.Parse("should be equal to 'test'", "name");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(name).toBe(\"test\")");
+    }
+
+    [Test]
+    public async Task Parse_ShouldBe_ReturnsToBe()
+    {
+        var result = AssertionTools.Parse("should be hello", "greeting");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(greeting).toBe(\"hello\")");
+    }
+
+    [Test]
+    public async Task Parse_EqualToBoolean_ReturnsToBe()
+    {
+        var result = AssertionTools.Parse("equal to true", "flag");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(flag).toBe(true)");
+    }
+
+    [Test]
+    public async Task Parse_ShouldNotEqual_ReturnsNotToBe()
+    {
+        var result = AssertionTools.Parse("should not equal 0", "count");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(count).not.toBe(0)");
+    }
+
+    [Test]
+    public async Task Parse_NotBeEqualTo_ReturnsNotToBe()
+    {
+        var result = AssertionTools.Parse("not be equal to 'error'", "status");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(status).not.toBe(\"error\")");
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Test]
+    public async Task Parse_UnrecognizedPattern_ReturnsFailureWithFallback()
+    {
+        var result = AssertionTools.Parse("should be awesome", "x");
+
+        // "be awesome" doesn't match a specific pattern, falls through to general "be" pattern
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(x).toBe(\"awesome\")");
+    }
+
+    [Test]
+    public async Task Parse_GibberishInput_ReturnsFallbackTemplate()
+    {
+        var result = AssertionTools.Parse("xyz abc 123", "val");
+
+        await Assert.That(result.Success).IsFalse();
+        await Assert.That(result.Code).Contains("expect(val)");
+        await Assert.That(result.Confidence).IsEqualTo(0.0);
+        await Assert.That(result.Error).IsNotNull();
+    }
+
+    [Test]
+    public async Task Parse_EmptyInput_ReturnsFallback()
+    {
+        var result = AssertionTools.Parse("", "x");
+
+        await Assert.That(result.Success).IsFalse();
+    }
+
+    [Test]
+    public async Task Parse_CaseInsensitive_Works()
+    {
+        var result = AssertionTools.Parse("SHOULD BE NULL", "item");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(item).toBeNull()");
+    }
+
+    [Test]
+    public async Task Parse_LeadingTrailingSpaces_Works()
+    {
+        var result = AssertionTools.Parse("  should be true  ", "flag");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(flag).toBeTrue()");
+    }
+
+    [Test]
+    public async Task Parse_ComplexVariableName_PreservesName()
+    {
+        var result = AssertionTools.Parse("should not be null", "user.Profile.Email");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(user.Profile.Email).toNotBeNull()");
+    }
+
+    #endregion
+
+    #region String Escaping
+
+    [Test]
+    public async Task Parse_StringWithBackslash_EscapesCorrectly()
+    {
+        var result = AssertionTools.Parse(@"contain 'C:\path'", "path");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).Contains(@"\\");
+    }
+
+    [Test]
+    public async Task Parse_StringWithSimpleQuotes_Works()
+    {
+        var result = AssertionTools.Parse("contain 'hello world'", "text");
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.Code).IsEqualTo("expect(text).toContain(\"hello world\")");
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Adds the `parse_assertion` MCP tool that converts natural language assertions to DraftSpec `expect()` syntax, enabling more intuitive spec authoring for AI agents.

## Implementation

- **Rule-based pattern matching** using compiled regex patterns with case-insensitive matching
- **44 comprehensive tests** covering all assertion types and edge cases
- Returns structured JSON with success status, generated code, confidence score, and pattern description

## Supported Patterns

| Natural Language | Generated Code |
|------------------|----------------|
| `should be greater than 5` | `expect(x).toBeGreaterThan(5)` |
| `should contain 'hello'` | `expect(x).toContain("hello")` |
| `should not be null` | `expect(x).toNotBeNull()` |
| `should have 3 items` | `expect(x).toHaveCount(3)` |
| `should throw ArgumentException` | `expect(() => x).toThrow<ArgumentException>()` |
| `should start with 'Error:'` | `expect(x).toStartWith("Error:")` |
| `should be at least 18` | `expect(x).toBeAtLeast(18)` |
| `should match pattern '[0-9]+'` | `expect(x).toMatch("[0-9]+")` |

## Usage

```csharp
// Input
parse_assertion("should be greater than 5", "count")

// Output (JSON)
{
  "success": true,
  "code": "expect(count).toBeGreaterThan(5)",
  "confidence": 0.95,
  "pattern": "be greater than"
}
```

## Test plan

- [x] All 44 assertion parsing tests pass
- [x] Null checks work with/without "should" prefix
- [x] Boolean assertions (true/false)
- [x] Numeric comparisons (greater than, less than, at least, at most)
- [x] Collection assertions (count, empty, not empty)
- [x] String operations (contain, start with, end with, match)
- [x] Exception handling (throw, not throw, specific exception types)
- [x] Equality assertions (equal, not equal)
- [x] Case-insensitive matching
- [x] Fallback for unrecognized patterns

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)