### PR TITLE
Add SpecDiscoverer for MTP test enumeration

### DIFF
--- a/src/DraftSpec.TestingPlatform/DiscoveredSpec.cs
+++ b/src/DraftSpec.TestingPlatform/DiscoveredSpec.cs
@@ -1,0 +1,83 @@
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Represents a discovered spec with its metadata for MTP test enumeration.
+/// </summary>
+/// <remarks>
+/// This is a flattened view of a spec from the SpecContext tree, containing
+/// all information needed for MTP discovery and execution.
+/// </remarks>
+public sealed class DiscoveredSpec
+{
+    /// <summary>
+    /// Stable, unique identifier for this spec.
+    /// Format: relative/path/file.spec.csx:Context/Path/spec description
+    /// </summary>
+    /// <example>
+    /// specs/UserService.spec.csx:UserService/CreateAsync/creates a user with valid data
+    /// </example>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// The spec description (the "it should..." text).
+    /// </summary>
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// Full display name including context path.
+    /// </summary>
+    /// <example>
+    /// UserService > CreateAsync > creates a user with valid data
+    /// </example>
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// The context path as an array of context descriptions.
+    /// Does not include the spec description itself.
+    /// </summary>
+    /// <example>
+    /// ["UserService", "CreateAsync"]
+    /// </example>
+    public required IReadOnlyList<string> ContextPath { get; init; }
+
+    /// <summary>
+    /// Absolute path to the source CSX file.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Relative path to the source CSX file from the project root.
+    /// Used in the stable ID.
+    /// </summary>
+    public required string RelativeSourceFile { get; init; }
+
+    /// <summary>
+    /// True if the spec has no body (placeholder for future implementation).
+    /// </summary>
+    public bool IsPending { get; init; }
+
+    /// <summary>
+    /// True if the spec is explicitly skipped (via xit()).
+    /// </summary>
+    public bool IsSkipped { get; init; }
+
+    /// <summary>
+    /// True if the spec is focused (via fit()).
+    /// </summary>
+    public bool IsFocused { get; init; }
+
+    /// <summary>
+    /// Tags associated with this spec for filtering.
+    /// </summary>
+    public IReadOnlyList<string> Tags { get; init; } = [];
+
+    /// <summary>
+    /// Reference to the original spec definition for execution.
+    /// </summary>
+    internal SpecDefinition? SpecDefinition { get; init; }
+
+    /// <summary>
+    /// Reference to the containing context for execution.
+    /// </summary>
+    internal SpecContext? Context { get; init; }
+}

--- a/src/DraftSpec.TestingPlatform/SpecDiscoverer.cs
+++ b/src/DraftSpec.TestingPlatform/SpecDiscoverer.cs
@@ -1,0 +1,203 @@
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Discovers specs from CSX files in a project directory.
+/// </summary>
+/// <remarks>
+/// The discoverer finds all *.spec.csx files, executes them to build the spec tree,
+/// then flattens the tree into a list of DiscoveredSpec instances with stable IDs.
+/// </remarks>
+internal sealed class SpecDiscoverer
+{
+    private readonly string _projectDirectory;
+    private readonly CsxScriptHost _scriptHost;
+
+    /// <summary>
+    /// Creates a new spec discoverer.
+    /// </summary>
+    /// <param name="projectDirectory">The project root directory for finding CSX files and computing relative paths.</param>
+    public SpecDiscoverer(string projectDirectory)
+    {
+        _projectDirectory = Path.GetFullPath(projectDirectory);
+        _scriptHost = new CsxScriptHost(_projectDirectory);
+    }
+
+    /// <summary>
+    /// Discovers all specs from CSX files in the project directory.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of discovered specs with stable IDs.</returns>
+    public async Task<IReadOnlyList<DiscoveredSpec>> DiscoverAsync(CancellationToken cancellationToken = default)
+    {
+        var csxFiles = FindSpecFiles();
+        var allSpecs = new List<DiscoveredSpec>();
+
+        foreach (var csxFile in csxFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Reset state before each file to ensure isolation
+            Dsl.Reset();
+
+            try
+            {
+                var rootContext = await _scriptHost.ExecuteAsync(csxFile, cancellationToken);
+
+                if (rootContext != null)
+                {
+                    var relativePath = GetRelativePath(csxFile);
+                    var specs = FlattenContext(rootContext, csxFile, relativePath);
+                    allSpecs.AddRange(specs);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Log error but continue with other files
+                // TODO: Consider surfacing discovery errors to MTP
+                Console.Error.WriteLine($"Error discovering specs in {csxFile}: {ex.Message}");
+            }
+            finally
+            {
+                // Always reset after processing
+                Dsl.Reset();
+            }
+        }
+
+        return allSpecs;
+    }
+
+    /// <summary>
+    /// Discovers specs from a single CSX file.
+    /// </summary>
+    /// <param name="csxFilePath">Path to the CSX file.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of discovered specs from the file.</returns>
+    public async Task<IReadOnlyList<DiscoveredSpec>> DiscoverFileAsync(
+        string csxFilePath,
+        CancellationToken cancellationToken = default)
+    {
+        var absolutePath = Path.GetFullPath(csxFilePath, _projectDirectory);
+
+        // Reset state before execution
+        Dsl.Reset();
+
+        try
+        {
+            var rootContext = await _scriptHost.ExecuteAsync(absolutePath, cancellationToken);
+
+            if (rootContext == null)
+            {
+                return [];
+            }
+
+            var relativePath = GetRelativePath(absolutePath);
+            return FlattenContext(rootContext, absolutePath, relativePath);
+        }
+        finally
+        {
+            Dsl.Reset();
+        }
+    }
+
+    /// <summary>
+    /// Finds all *.spec.csx files in the project directory.
+    /// </summary>
+    private IEnumerable<string> FindSpecFiles()
+    {
+        return Directory.EnumerateFiles(_projectDirectory, "*.spec.csx", SearchOption.AllDirectories);
+    }
+
+    /// <summary>
+    /// Gets the relative path from the project directory.
+    /// </summary>
+    private string GetRelativePath(string absolutePath)
+    {
+        return Path.GetRelativePath(_projectDirectory, absolutePath);
+    }
+
+    /// <summary>
+    /// Flattens a SpecContext tree into a list of DiscoveredSpec instances.
+    /// </summary>
+    private static List<DiscoveredSpec> FlattenContext(
+        SpecContext context,
+        string sourceFile,
+        string relativeSourceFile)
+    {
+        var specs = new List<DiscoveredSpec>();
+        FlattenContextRecursive(context, sourceFile, relativeSourceFile, [], specs);
+        return specs;
+    }
+
+    /// <summary>
+    /// Recursively flattens the context tree.
+    /// </summary>
+    private static void FlattenContextRecursive(
+        SpecContext context,
+        string sourceFile,
+        string relativeSourceFile,
+        List<string> contextPath,
+        List<DiscoveredSpec> results)
+    {
+        // Add current context to path
+        var currentPath = new List<string>(contextPath) { context.Description };
+
+        // Process specs in this context
+        foreach (var spec in context.Specs)
+        {
+            var specId = GenerateStableId(relativeSourceFile, currentPath, spec.Description);
+            var displayName = GenerateDisplayName(currentPath, spec.Description);
+
+            results.Add(new DiscoveredSpec
+            {
+                Id = specId,
+                Description = spec.Description,
+                DisplayName = displayName,
+                ContextPath = currentPath.ToArray(),
+                SourceFile = sourceFile,
+                RelativeSourceFile = relativeSourceFile,
+                IsPending = spec.IsPending,
+                IsSkipped = spec.IsSkipped,
+                IsFocused = spec.IsFocused,
+                Tags = spec.Tags,
+                SpecDefinition = spec,
+                Context = context
+            });
+        }
+
+        // Process child contexts recursively
+        foreach (var child in context.Children)
+        {
+            FlattenContextRecursive(child, sourceFile, relativeSourceFile, currentPath, results);
+        }
+    }
+
+    /// <summary>
+    /// Generates a stable, unique ID for a spec.
+    /// Format: relative/path/file.spec.csx:Context/Path/spec description
+    /// </summary>
+    private static string GenerateStableId(
+        string relativeSourceFile,
+        IReadOnlyList<string> contextPath,
+        string specDescription)
+    {
+        // Normalize path separators to forward slashes for cross-platform consistency
+        var normalizedPath = relativeSourceFile.Replace('\\', '/');
+
+        // Build context path with forward slashes
+        var contextPathString = string.Join("/", contextPath);
+
+        return $"{normalizedPath}:{contextPathString}/{specDescription}";
+    }
+
+    /// <summary>
+    /// Generates a human-readable display name.
+    /// Format: Context > Path > spec description
+    /// </summary>
+    private static string GenerateDisplayName(
+        IReadOnlyList<string> contextPath,
+        string specDescription)
+    {
+        var parts = new List<string>(contextPath) { specDescription };
+        return string.Join(" > ", parts);
+    }
+}

--- a/tests/DraftSpec.Tests/TestingPlatform/SpecDiscovererTests.cs
+++ b/tests/DraftSpec.Tests/TestingPlatform/SpecDiscovererTests.cs
@@ -1,0 +1,384 @@
+using DraftSpec.TestingPlatform;
+
+namespace DraftSpec.Tests.TestingPlatform;
+
+public class SpecDiscovererTests
+{
+    private string _tempDir = null!;
+
+    [Before(Test)]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"draftspec_discoverer_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        global::DraftSpec.Dsl.Reset();
+    }
+
+    [After(Test)]
+    public void Cleanup()
+    {
+        global::DraftSpec.Dsl.Reset();
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task DiscoverAsync_FindsAllSpecFiles()
+    {
+        // Arrange
+        var specsDir = Path.Combine(_tempDir, "Specs");
+        Directory.CreateDirectory(specsDir);
+
+        await File.WriteAllTextAsync(Path.Combine(specsDir, "first.spec.csx"), """
+            using static DraftSpec.Dsl;
+            describe("First", () => { it("spec 1", () => { }); });
+            """);
+
+        await File.WriteAllTextAsync(Path.Combine(specsDir, "second.spec.csx"), """
+            using static DraftSpec.Dsl;
+            describe("Second", () => { it("spec 2", () => { }); });
+            """);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverAsync();
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(2);
+        await Assert.That(specs.Select(s => s.Description)).Contains("spec 1");
+        await Assert.That(specs.Select(s => s.Description)).Contains("spec 2");
+    }
+
+    [Test]
+    public async Task DiscoverFileAsync_ReturnsSpecsFromSingleFile()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Calculator", () =>
+            {
+                it("adds numbers", () => { });
+                it("subtracts numbers", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "calc.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(2);
+        await Assert.That(specs[0].Description).IsEqualTo("adds numbers");
+        await Assert.That(specs[1].Description).IsEqualTo("subtracts numbers");
+    }
+
+    [Test]
+    public async Task DiscoverFileAsync_GeneratesStableIds()
+    {
+        // Arrange
+        var specsDir = Path.Combine(_tempDir, "specs");
+        Directory.CreateDirectory(specsDir);
+
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("UserService", () =>
+            {
+                describe("CreateAsync", () =>
+                {
+                    it("creates a user with valid data", () => { });
+                });
+            });
+            """;
+
+        var csxPath = Path.Combine(specsDir, "UserService.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(1);
+        await Assert.That(specs[0].Id).IsEqualTo("specs/UserService.spec.csx:UserService/CreateAsync/creates a user with valid data");
+    }
+
+    [Test]
+    public async Task DiscoverFileAsync_CapturesContextPath()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Parent", () =>
+            {
+                describe("Child", () =>
+                {
+                    it("grandchild spec", () => { });
+                });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "nested.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(1);
+        await Assert.That(specs[0].ContextPath.Count).IsEqualTo(2);
+        await Assert.That(specs[0].ContextPath[0]).IsEqualTo("Parent");
+        await Assert.That(specs[0].ContextPath[1]).IsEqualTo("Child");
+    }
+
+    [Test]
+    public async Task DiscoverFileAsync_GeneratesDisplayName()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Auth", () =>
+            {
+                describe("Login", () =>
+                {
+                    it("validates credentials", () => { });
+                });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "auth.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs[0].DisplayName).IsEqualTo("Auth > Login > validates credentials");
+    }
+
+    [Test]
+    public async Task DiscoverFileAsync_CapturesPendingSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Pending", () =>
+            {
+                it("implemented spec", () => { });
+                it("pending spec without body");
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "pending.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(2);
+        await Assert.That(specs[0].IsPending).IsFalse();
+        await Assert.That(specs[1].IsPending).IsTrue();
+    }
+
+    [Test]
+    public async Task DiscoverFileAsync_CapturesSkippedSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Skipped", () =>
+            {
+                it("normal spec", () => { });
+                xit("skipped spec", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "skipped.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(2);
+        await Assert.That(specs[0].IsSkipped).IsFalse();
+        await Assert.That(specs[1].IsSkipped).IsTrue();
+    }
+
+    [Test]
+    public async Task DiscoverFileAsync_CapturesFocusedSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Focused", () =>
+            {
+                it("normal spec", () => { });
+                fit("focused spec", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "focused.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(2);
+        await Assert.That(specs[0].IsFocused).IsFalse();
+        await Assert.That(specs[1].IsFocused).IsTrue();
+    }
+
+    [Test]
+    public async Task DiscoverFileAsync_CapturesTags()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Tagged", () =>
+            {
+                it("spec without tags", () => { });
+                tags(["unit", "fast"], () => {
+                    it("spec with tags", () => { });
+                });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "tagged.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(2);
+        await Assert.That(specs[0].Tags.Count).IsEqualTo(0);
+        await Assert.That(specs[1].Tags.Count).IsEqualTo(2);
+        await Assert.That(specs[1].Tags).Contains("unit");
+        await Assert.That(specs[1].Tags).Contains("fast");
+    }
+
+    [Test]
+    public async Task DiscoverFileAsync_IncludesSourceFilePaths()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+            describe("Test", () => { it("spec", () => { }); });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "source.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs[0].SourceFile).IsEqualTo(csxPath);
+        await Assert.That(specs[0].RelativeSourceFile).IsEqualTo("source.spec.csx");
+    }
+
+    [Test]
+    public async Task DiscoverAsync_IsolatesStateBetweenFiles()
+    {
+        // Arrange
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "a.spec.csx"), """
+            using static DraftSpec.Dsl;
+            describe("FileA", () => { it("spec a", () => { }); });
+            """);
+
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "b.spec.csx"), """
+            using static DraftSpec.Dsl;
+            describe("FileB", () => { it("spec b", () => { }); });
+            """);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverAsync();
+
+        // Assert - each file should have independent specs, not combined
+        await Assert.That(specs.Count).IsEqualTo(2);
+
+        var fileASpecs = specs.Where(s => s.ContextPath[0] == "FileA").ToList();
+        var fileBSpecs = specs.Where(s => s.ContextPath[0] == "FileB").ToList();
+
+        await Assert.That(fileASpecs.Count).IsEqualTo(1);
+        await Assert.That(fileBSpecs.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task DiscoverFileAsync_EmptyFile_ReturnsEmptyList()
+    {
+        // Arrange - file with no specs
+        var csxContent = """
+            using static DraftSpec.Dsl;
+            // No describe blocks
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "empty.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task DiscoverAsync_HandlesNestedDirectories()
+    {
+        // Arrange
+        var nestedDir = Path.Combine(_tempDir, "features", "auth");
+        Directory.CreateDirectory(nestedDir);
+
+        await File.WriteAllTextAsync(Path.Combine(nestedDir, "login.spec.csx"), """
+            using static DraftSpec.Dsl;
+            describe("Login", () => { it("works", () => { }); });
+            """);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverAsync();
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(1);
+        // Path should use forward slashes
+        await Assert.That(specs[0].Id).Contains("features/auth/login.spec.csx");
+    }
+}


### PR DESCRIPTION
## Summary

Implements discovery mode for MTP integration, enabling test enumeration before execution:

- **DiscoveredSpec** model class with:
  - Stable, unique ID: `relative/path/file.spec.csx:Context/Path/description`
  - Display name: `Context > Path > description`
  - Context path as array for hierarchical display
  - Pending, skipped, focused flags
  - Tags for filtering
  - Source file paths (absolute and relative)

- **SpecDiscoverer** that:
  - Finds all `*.spec.csx` files in project directory (including subdirectories)
  - Executes each file using CsxScriptHost to build the spec tree
  - Flattens the SpecContext tree into a list of DiscoveredSpec instances
  - Resets Dsl state between files for isolation
  - Handles errors gracefully (logs but continues with other files)

### Design Note

The discovery mode check in `run()` was not needed since MTP specs don't call `run()` - they just define `describe`/`it` blocks and the MTP adapter controls execution. This was a simplification decided in Issue #120.

### Stable ID Format

```
specs/UserService.spec.csx:UserService/CreateAsync/creates a user with valid data
```

Components:
- Relative file path from project root (forward slashes for cross-platform)
- Context path (describe blocks, `/` separated)
- Spec description

## Test Plan

- [x] All 1601 existing tests pass
- [x] 13 new SpecDiscoverer tests:
  - Finds all spec files in directory
  - Returns specs from single file
  - Generates stable IDs
  - Captures context path
  - Generates display names
  - Captures pending specs
  - Captures skipped specs
  - Captures focused specs
  - Captures tags
  - Includes source file paths
  - Isolates state between files
  - Handles empty files
  - Handles nested directories

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)