### PR TITLE
Implement filtered spec execution for MTP

### DIFF
--- a/src/DraftSpec.TestingPlatform/MtpSpecExecutor.cs
+++ b/src/DraftSpec.TestingPlatform/MtpSpecExecutor.cs
@@ -1,0 +1,167 @@
+using DraftSpec.Configuration;
+
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Executes specs for MTP integration with filtering and result capture.
+/// </summary>
+internal sealed class MtpSpecExecutor
+{
+    private readonly string _projectDirectory;
+    private readonly CsxScriptHost _scriptHost;
+
+    /// <summary>
+    /// Creates a new MTP spec executor.
+    /// </summary>
+    /// <param name="projectDirectory">The project root directory.</param>
+    public MtpSpecExecutor(string projectDirectory)
+    {
+        _projectDirectory = Path.GetFullPath(projectDirectory);
+        _scriptHost = new CsxScriptHost(_projectDirectory);
+    }
+
+    /// <summary>
+    /// Executes all specs from a CSX file and returns results.
+    /// </summary>
+    /// <param name="csxFilePath">Path to the CSX file.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Results paired with relative source file path.</returns>
+    public async Task<ExecutionResult> ExecuteFileAsync(
+        string csxFilePath,
+        CancellationToken cancellationToken = default)
+    {
+        return await ExecuteFileAsync(csxFilePath, requestedIds: null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Executes filtered specs from a CSX file and returns results.
+    /// </summary>
+    /// <param name="csxFilePath">Path to the CSX file.</param>
+    /// <param name="requestedIds">Set of spec IDs to run, or null to run all.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Results paired with relative source file path.</returns>
+    public async Task<ExecutionResult> ExecuteFileAsync(
+        string csxFilePath,
+        HashSet<string>? requestedIds,
+        CancellationToken cancellationToken = default)
+    {
+        var absolutePath = Path.GetFullPath(csxFilePath, _projectDirectory);
+        var relativePath = GetRelativePath(absolutePath);
+
+        // Reset state before execution
+        Dsl.Reset();
+
+        try
+        {
+            // Execute script to build spec tree
+            var rootContext = await _scriptHost.ExecuteAsync(absolutePath, cancellationToken);
+
+            if (rootContext == null)
+            {
+                return new ExecutionResult(relativePath, []);
+            }
+
+            // Create result capture reporter
+            var captureReporter = new ResultCaptureReporter();
+
+            // Build configuration with reporter
+            var config = new DraftSpecConfiguration();
+            config.AddReporter(captureReporter);
+
+            // Build runner with optional filter
+            var builder = new SpecRunnerBuilder()
+                .WithConfiguration(config);
+
+            if (requestedIds != null && requestedIds.Count > 0)
+            {
+                builder.WithFilter(ctx =>
+                {
+                    var id = TestNodeMapper.GenerateStableId(
+                        relativePath,
+                        ctx.ContextPath.ToList(),
+                        ctx.Spec.Description);
+                    return requestedIds.Contains(id);
+                });
+            }
+
+            // Run specs
+            var runner = builder.Build();
+            var results = runner.Run(rootContext);
+
+            // Notify reporter of completion
+            var report = SpecReportBuilder.Build(rootContext, results);
+            await captureReporter.OnRunCompletedAsync(report);
+
+            return new ExecutionResult(relativePath, captureReporter.Results);
+        }
+        finally
+        {
+            Dsl.Reset();
+        }
+    }
+
+    /// <summary>
+    /// Executes specs from multiple files based on requested test IDs.
+    /// Groups IDs by file and executes each file with its relevant IDs.
+    /// </summary>
+    /// <param name="requestedIds">Set of spec IDs to run.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Results from all files.</returns>
+    public async Task<IReadOnlyList<ExecutionResult>> ExecuteByIdsAsync(
+        IEnumerable<string> requestedIds,
+        CancellationToken cancellationToken = default)
+    {
+        // Group IDs by source file
+        var idsByFile = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var id in requestedIds)
+        {
+            var colonIndex = id.IndexOf(':');
+            if (colonIndex <= 0) continue;
+
+            var relativePath = id[..colonIndex];
+            if (!idsByFile.TryGetValue(relativePath, out var fileIds))
+            {
+                fileIds = new HashSet<string>(StringComparer.Ordinal);
+                idsByFile[relativePath] = fileIds;
+            }
+            fileIds.Add(id);
+        }
+
+        // Execute each file
+        var results = new List<ExecutionResult>();
+
+        foreach (var (relativePath, fileIds) in idsByFile)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var absolutePath = Path.GetFullPath(relativePath, _projectDirectory);
+            if (!File.Exists(absolutePath))
+            {
+                continue;
+            }
+
+            var result = await ExecuteFileAsync(absolutePath, fileIds, cancellationToken);
+            results.Add(result);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Gets the relative path from the project directory.
+    /// </summary>
+    private string GetRelativePath(string absolutePath)
+    {
+        return Path.GetRelativePath(_projectDirectory, absolutePath);
+    }
+}
+
+/// <summary>
+/// Result of executing specs from a single file.
+/// </summary>
+/// <param name="RelativeSourceFile">Relative path to the source file.</param>
+/// <param name="Results">Spec results from execution.</param>
+internal sealed record ExecutionResult(
+    string RelativeSourceFile,
+    IReadOnlyList<SpecResult> Results);

--- a/src/DraftSpec.TestingPlatform/ResultCaptureReporter.cs
+++ b/src/DraftSpec.TestingPlatform/ResultCaptureReporter.cs
@@ -1,0 +1,65 @@
+using DraftSpec.Formatters;
+using DraftSpec.Plugins;
+
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Reporter that captures spec results for MTP integration.
+/// Results are collected in memory for mapping to TestNodeUpdateMessage.
+/// </summary>
+internal sealed class ResultCaptureReporter : IReporter
+{
+    private readonly List<SpecResult> _results = [];
+    private readonly object _lock = new();
+
+    /// <summary>
+    /// Reporter name for identification.
+    /// </summary>
+    public string Name => "MtpResultCapture";
+
+    /// <summary>
+    /// Gets the collected results (thread-safe copy).
+    /// </summary>
+    public IReadOnlyList<SpecResult> Results
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _results.ToList();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Called after each spec completes. Captures the result.
+    /// </summary>
+    public Task OnSpecCompletedAsync(SpecResult result)
+    {
+        lock (_lock)
+        {
+            _results.Add(result);
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Called when the entire run is complete. No-op for capture reporter.
+    /// </summary>
+    public Task OnRunCompletedAsync(SpecReport report)
+    {
+        // Results are already captured via OnSpecCompletedAsync
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Clears captured results for reuse.
+    /// </summary>
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _results.Clear();
+        }
+    }
+}

--- a/src/DraftSpec.TestingPlatform/TestNodeMapper.cs
+++ b/src/DraftSpec.TestingPlatform/TestNodeMapper.cs
@@ -1,0 +1,127 @@
+using Microsoft.Testing.Platform.Extensions.Messages;
+
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Maps between DraftSpec types and MTP TestNode messages.
+/// </summary>
+internal static class TestNodeMapper
+{
+    /// <summary>
+    /// Creates a TestNode for a discovered spec (discovery phase).
+    /// </summary>
+    public static TestNode CreateDiscoveryNode(DiscoveredSpec spec)
+    {
+        var properties = new PropertyBag(DiscoveredTestNodeStateProperty.CachedInstance);
+
+        return new TestNode
+        {
+            Uid = new TestNodeUid(spec.Id),
+            DisplayName = spec.DisplayName,
+            Properties = properties
+        };
+    }
+
+    /// <summary>
+    /// Creates a TestNode for a spec result (execution phase).
+    /// </summary>
+    public static TestNode CreateResultNode(DiscoveredSpec spec, SpecResult result)
+    {
+        var stateProperty = GetStateProperty(result);
+        var properties = new PropertyBag(stateProperty);
+
+        // Add timing property if we have duration info
+        if (result.TotalDuration > TimeSpan.Zero)
+        {
+            properties = new PropertyBag(
+                stateProperty,
+                new TimingProperty(new TimingInfo(
+                    DateTimeOffset.UtcNow - result.TotalDuration,
+                    DateTimeOffset.UtcNow,
+                    result.TotalDuration)));
+        }
+
+        return new TestNode
+        {
+            Uid = new TestNodeUid(spec.Id),
+            DisplayName = spec.DisplayName,
+            Properties = properties
+        };
+    }
+
+    /// <summary>
+    /// Creates a TestNode for a spec result using the result's own context path.
+    /// Used when we don't have a DiscoveredSpec (running all specs).
+    /// </summary>
+    public static TestNode CreateResultNode(
+        string relativeSourceFile,
+        SpecResult result)
+    {
+        var id = GenerateStableId(relativeSourceFile, result.ContextPath, result.Spec.Description);
+        var displayName = GenerateDisplayName(result.ContextPath, result.Spec.Description);
+        var stateProperty = GetStateProperty(result);
+
+        var properties = result.TotalDuration > TimeSpan.Zero
+            ? new PropertyBag(
+                stateProperty,
+                new TimingProperty(new TimingInfo(
+                    DateTimeOffset.UtcNow - result.TotalDuration,
+                    DateTimeOffset.UtcNow,
+                    result.TotalDuration)))
+            : new PropertyBag(stateProperty);
+
+        return new TestNode
+        {
+            Uid = new TestNodeUid(id),
+            DisplayName = displayName,
+            Properties = properties
+        };
+    }
+
+    /// <summary>
+    /// Gets the appropriate state property for a spec result.
+    /// </summary>
+    private static TestNodeStateProperty GetStateProperty(SpecResult result)
+    {
+        return result.Status switch
+        {
+            SpecStatus.Passed => PassedTestNodeStateProperty.CachedInstance,
+            SpecStatus.Failed => result.Exception != null
+                ? new FailedTestNodeStateProperty(result.Exception, result.Exception.Message)
+                : new FailedTestNodeStateProperty("Test failed"),
+            SpecStatus.Pending => new SkippedTestNodeStateProperty("Pending - no implementation"),
+            SpecStatus.Skipped => new SkippedTestNodeStateProperty("Skipped"),
+            _ => throw new ArgumentOutOfRangeException(nameof(result.Status))
+        };
+    }
+
+    /// <summary>
+    /// Generates a stable, unique ID for a spec result.
+    /// Format: relative/path/file.spec.csx:Context/Path/spec description
+    /// </summary>
+    public static string GenerateStableId(
+        string relativeSourceFile,
+        IReadOnlyList<string> contextPath,
+        string specDescription)
+    {
+        // Normalize path separators to forward slashes for cross-platform consistency
+        var normalizedPath = relativeSourceFile.Replace('\\', '/');
+
+        // Build context path with forward slashes
+        var contextPathString = string.Join("/", contextPath);
+
+        return $"{normalizedPath}:{contextPathString}/{specDescription}";
+    }
+
+    /// <summary>
+    /// Generates a human-readable display name.
+    /// Format: Context > Path > spec description
+    /// </summary>
+    public static string GenerateDisplayName(
+        IReadOnlyList<string> contextPath,
+        string specDescription)
+    {
+        var parts = new List<string>(contextPath) { specDescription };
+        return string.Join(" > ", parts);
+    }
+}

--- a/tests/DraftSpec.Tests/TestingPlatform/MtpSpecExecutorTests.cs
+++ b/tests/DraftSpec.Tests/TestingPlatform/MtpSpecExecutorTests.cs
@@ -1,0 +1,255 @@
+using DraftSpec.TestingPlatform;
+
+namespace DraftSpec.Tests.TestingPlatform;
+
+public class MtpSpecExecutorTests
+{
+    private string _tempDir = null!;
+
+    [Before(Test)]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"draftspec_executor_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        global::DraftSpec.Dsl.Reset();
+    }
+
+    [After(Test)]
+    public void Cleanup()
+    {
+        global::DraftSpec.Dsl.Reset();
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ExecuteFileAsync_ReturnsResultsForAllSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Calculator", () =>
+            {
+                it("adds numbers", () => expect(1 + 1).toBe(2));
+                it("subtracts numbers", () => expect(5 - 3).toBe(2));
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "calc.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var executor = new MtpSpecExecutor(_tempDir);
+
+        // Act
+        var result = await executor.ExecuteFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.Results.Count).IsEqualTo(2);
+        await Assert.That(result.Results.All(r => r.Status == SpecStatus.Passed)).IsTrue();
+    }
+
+    [Test]
+    public async Task ExecuteFileAsync_CapturesFailedSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Failing", () =>
+            {
+                it("fails assertion", () => expect(1).toBe(2));
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "fail.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var executor = new MtpSpecExecutor(_tempDir);
+
+        // Act
+        var result = await executor.ExecuteFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.Results.Count).IsEqualTo(1);
+        await Assert.That(result.Results[0].Status).IsEqualTo(SpecStatus.Failed);
+        await Assert.That(result.Results[0].Exception).IsNotNull();
+    }
+
+    [Test]
+    public async Task ExecuteFileAsync_CapturesPendingSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Pending", () =>
+            {
+                it("pending spec without body");
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "pending.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var executor = new MtpSpecExecutor(_tempDir);
+
+        // Act
+        var result = await executor.ExecuteFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.Results.Count).IsEqualTo(1);
+        await Assert.That(result.Results[0].Status).IsEqualTo(SpecStatus.Pending);
+    }
+
+    [Test]
+    public async Task ExecuteFileAsync_CapturesSkippedSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Skipped", () =>
+            {
+                xit("skipped spec", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "skipped.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var executor = new MtpSpecExecutor(_tempDir);
+
+        // Act
+        var result = await executor.ExecuteFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.Results.Count).IsEqualTo(1);
+        await Assert.That(result.Results[0].Status).IsEqualTo(SpecStatus.Skipped);
+    }
+
+    [Test]
+    public async Task ExecuteFileAsync_WithFilter_RunsOnlyRequestedSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Math", () =>
+            {
+                it("adds", () => expect(1 + 1).toBe(2));
+                it("subtracts", () => expect(5 - 3).toBe(2));
+                it("multiplies", () => expect(2 * 3).toBe(6));
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "math.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var executor = new MtpSpecExecutor(_tempDir);
+
+        // Only request the "adds" spec
+        var requestedIds = new HashSet<string>
+        {
+            "math.spec.csx:Math/adds"
+        };
+
+        // Act
+        var result = await executor.ExecuteFileAsync(csxPath, requestedIds);
+
+        // Assert - only one spec should run (adds), others skipped
+        var passedSpecs = result.Results.Where(r => r.Status == SpecStatus.Passed).ToList();
+        var skippedSpecs = result.Results.Where(r => r.Status == SpecStatus.Skipped).ToList();
+
+        await Assert.That(passedSpecs.Count).IsEqualTo(1);
+        await Assert.That(passedSpecs[0].Spec.Description).IsEqualTo("adds");
+        await Assert.That(skippedSpecs.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ExecuteFileAsync_IncludesTimingInfo()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Timing", () =>
+            {
+                it("takes some time", async () =>
+                {
+                    await System.Threading.Tasks.Task.Delay(50);
+                });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "timing.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var executor = new MtpSpecExecutor(_tempDir);
+
+        // Act
+        var result = await executor.ExecuteFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.Results.Count).IsEqualTo(1);
+        await Assert.That(result.Results[0].Duration.TotalMilliseconds).IsGreaterThanOrEqualTo(40);
+    }
+
+    [Test]
+    public async Task ExecuteFileAsync_IncludesRelativeSourceFile()
+    {
+        // Arrange
+        var specsDir = Path.Combine(_tempDir, "specs");
+        Directory.CreateDirectory(specsDir);
+
+        var csxContent = """
+            using static DraftSpec.Dsl;
+            describe("Test", () => { it("works", () => { }); });
+            """;
+
+        var csxPath = Path.Combine(specsDir, "nested.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var executor = new MtpSpecExecutor(_tempDir);
+
+        // Act
+        var result = await executor.ExecuteFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.RelativeSourceFile).IsEqualTo(Path.Combine("specs", "nested.spec.csx"));
+    }
+
+    [Test]
+    public async Task ExecuteByIdsAsync_GroupsByFileAndExecutes()
+    {
+        // Arrange
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "a.spec.csx"), """
+            using static DraftSpec.Dsl;
+            describe("FileA", () => { it("spec a", () => { }); });
+            """);
+
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "b.spec.csx"), """
+            using static DraftSpec.Dsl;
+            describe("FileB", () => { it("spec b", () => { }); });
+            """);
+
+        var executor = new MtpSpecExecutor(_tempDir);
+
+        var requestedIds = new[]
+        {
+            "a.spec.csx:FileA/spec a",
+            "b.spec.csx:FileB/spec b"
+        };
+
+        // Act
+        var results = await executor.ExecuteByIdsAsync(requestedIds);
+
+        // Assert
+        await Assert.That(results.Count).IsEqualTo(2);
+
+        var passedResults = results.SelectMany(r => r.Results).Where(r => r.Status == SpecStatus.Passed).ToList();
+        await Assert.That(passedResults.Count).IsEqualTo(2);
+    }
+}


### PR DESCRIPTION
## Summary

Implements filtered spec execution and result reporting for MTP integration, enabling `dotnet test` to run DraftSpec specs.

### New Components

- **ResultCaptureReporter** - Collects `SpecResult` instances via `IReporter` interface
- **MtpSpecExecutor** - Orchestrates CSX execution with filtering:
  - `ExecuteFileAsync` - runs all or filtered specs from a single file
  - `ExecuteByIdsAsync` - groups test IDs by file and executes each
  - Configures `SpecRunnerBuilder` with filter middleware for requested specs
- **TestNodeMapper** - Converts between DraftSpec and MTP types:
  - `CreateDiscoveryNode` - for test enumeration
  - `CreateResultNode` - for execution results with timing
  - Maps Pass/Fail/Pending/Skipped to MTP state properties
  - Includes exception details for failed tests

### DraftSpecTestFramework Updates

- `DiscoverTestsAsync` - Uses `SpecDiscoverer` to find and enumerate all specs
- `RunTestsAsync` - Uses `MtpSpecExecutor`:
  - Supports `TestNodeUidListFilter` for running specific tests
  - Falls back to running all tests when no filter specified
  - Publishes results to MTP MessageBus

### Result State Mapping

| DraftSpec Status | MTP State |
|-----------------|-----------|
| Passed | `PassedTestNodeStateProperty` |
| Failed | `FailedTestNodeStateProperty` (with exception) |
| Pending | `SkippedTestNodeStateProperty` ("Pending - no implementation") |
| Skipped | `SkippedTestNodeStateProperty` ("Skipped") |

## Test Plan

- [x] All 1609 tests pass (8 new MtpSpecExecutor tests)
- [x] MTP integration tests pass (8 specs discovered and executed)
- [x] Tests verify:
  - Execution returns results for all specs
  - Failed specs captured with exception
  - Pending specs captured
  - Skipped specs captured
  - Filter runs only requested specs
  - Timing info included
  - Relative source file paths correct
  - ExecuteByIdsAsync groups by file

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)