### PR TITLE
feat: Add IDE navigation support with line number capture

### DIFF
--- a/src/DraftSpec.TestingPlatform/DiscoveredSpec.cs
+++ b/src/DraftSpec.TestingPlatform/DiscoveredSpec.cs
@@ -72,6 +72,12 @@ public sealed class DiscoveredSpec
     public IReadOnlyList<string> Tags { get; init; } = [];
 
     /// <summary>
+    /// Line number in the source file where this spec was defined.
+    /// Used for IDE navigation support.
+    /// </summary>
+    public int LineNumber { get; init; }
+
+    /// <summary>
     /// Reference to the original spec definition for execution.
     /// </summary>
     internal SpecDefinition? SpecDefinition { get; init; }

--- a/src/DraftSpec.TestingPlatform/DraftSpecTestFramework.cs
+++ b/src/DraftSpec.TestingPlatform/DraftSpecTestFramework.cs
@@ -174,7 +174,10 @@ internal sealed class DraftSpecTestFramework : ITestFramework, IDataProducer
         {
             foreach (var specResult in execResult.Results)
             {
-                var testNode = TestNodeMapper.CreateResultNode(execResult.RelativeSourceFile, specResult);
+                var testNode = TestNodeMapper.CreateResultNode(
+                    execResult.RelativeSourceFile,
+                    execResult.AbsoluteSourceFile,
+                    specResult);
 
                 await context.MessageBus.PublishAsync(
                     this,

--- a/src/DraftSpec.TestingPlatform/MtpSpecExecutor.cs
+++ b/src/DraftSpec.TestingPlatform/MtpSpecExecutor.cs
@@ -58,7 +58,7 @@ internal sealed class MtpSpecExecutor
 
             if (rootContext == null)
             {
-                return new ExecutionResult(relativePath, []);
+                return new ExecutionResult(relativePath, absolutePath, []);
             }
 
             // Create result capture reporter
@@ -92,7 +92,7 @@ internal sealed class MtpSpecExecutor
             var report = SpecReportBuilder.Build(rootContext, results);
             await captureReporter.OnRunCompletedAsync(report);
 
-            return new ExecutionResult(relativePath, captureReporter.Results);
+            return new ExecutionResult(relativePath, absolutePath, captureReporter.Results);
         }
         finally
         {
@@ -161,7 +161,9 @@ internal sealed class MtpSpecExecutor
 /// Result of executing specs from a single file.
 /// </summary>
 /// <param name="RelativeSourceFile">Relative path to the source file.</param>
+/// <param name="AbsoluteSourceFile">Absolute path to the source file.</param>
 /// <param name="Results">Spec results from execution.</param>
 internal sealed record ExecutionResult(
     string RelativeSourceFile,
+    string AbsoluteSourceFile,
     IReadOnlyList<SpecResult> Results);

--- a/src/DraftSpec.TestingPlatform/SpecDiscoverer.cs
+++ b/src/DraftSpec.TestingPlatform/SpecDiscoverer.cs
@@ -159,6 +159,7 @@ internal sealed class SpecDiscoverer
                 IsSkipped = spec.IsSkipped,
                 IsFocused = spec.IsFocused,
                 Tags = spec.Tags,
+                LineNumber = spec.LineNumber,
                 SpecDefinition = spec,
                 Context = context
             });

--- a/src/DraftSpec/Dsl.Context.cs
+++ b/src/DraftSpec/Dsl.Context.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace DraftSpec;
 
 public static partial class Dsl
@@ -5,12 +7,12 @@ public static partial class Dsl
     /// <summary>
     /// Define a spec group. Creates root context on first call.
     /// </summary>
-    public static void describe(string description, Action body)
+    public static void describe(string description, Action body, [CallerLineNumber] int lineNumber = 0)
     {
         if (RootContext is null)
         {
             // First describe call - create root
-            RootContext = new SpecContext(description);
+            RootContext = new SpecContext(description) { LineNumber = lineNumber };
             CurrentContext = RootContext;
             try
             {
@@ -24,7 +26,7 @@ public static partial class Dsl
         else if (CurrentContext is null)
         {
             // Another top-level describe - add as child of root
-            var context = new SpecContext(description, RootContext);
+            var context = new SpecContext(description, RootContext) { LineNumber = lineNumber };
             CurrentContext = context;
             try
             {
@@ -39,7 +41,7 @@ public static partial class Dsl
         {
             // Nested describe
             var parent = CurrentContext;
-            var context = new SpecContext(description, parent);
+            var context = new SpecContext(description, parent) { LineNumber = lineNumber };
             CurrentContext = context;
             try
             {
@@ -55,8 +57,8 @@ public static partial class Dsl
     /// <summary>
     /// Alias for describe - used for sub-groupings.
     /// </summary>
-    public static void context(string description, Action body)
+    public static void context(string description, Action body, [CallerLineNumber] int lineNumber = 0)
     {
-        describe(description, body);
+        describe(description, body, lineNumber);
     }
 }

--- a/src/DraftSpec/Dsl.Specs.cs
+++ b/src/DraftSpec/Dsl.Specs.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using DraftSpec.Internal;
 
 namespace DraftSpec;
@@ -7,56 +8,56 @@ public static partial class Dsl
     /// <summary>
     /// Define a spec with a sync implementation.
     /// </summary>
-    public static void it(string description, Action body)
+    public static void it(string description, Action body, [CallerLineNumber] int lineNumber = 0)
     {
-        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreateSpec(description, body, CurrentTags));
+        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreateSpec(description, body, CurrentTags, lineNumber));
     }
 
     /// <summary>
     /// Define a spec with an async implementation.
     /// </summary>
-    public static void it(string description, Func<Task> body)
+    public static void it(string description, Func<Task> body, [CallerLineNumber] int lineNumber = 0)
     {
-        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreateSpec(description, body, CurrentTags));
+        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreateSpec(description, body, CurrentTags, lineNumber));
     }
 
     /// <summary>
     /// Define a pending spec (no implementation yet).
     /// </summary>
-    public static void it(string description)
+    public static void it(string description, [CallerLineNumber] int lineNumber = 0)
     {
-        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreatePendingSpec(description, CurrentTags));
+        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreatePendingSpec(description, CurrentTags, lineNumber));
     }
 
     /// <summary>
     /// Define a focused spec with a sync implementation - only focused specs run when any exist.
     /// </summary>
-    public static void fit(string description, Action body)
+    public static void fit(string description, Action body, [CallerLineNumber] int lineNumber = 0)
     {
-        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreateFocusedSpec(description, body, CurrentTags));
+        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreateFocusedSpec(description, body, CurrentTags, lineNumber));
     }
 
     /// <summary>
     /// Define a focused spec with an async implementation - only focused specs run when any exist.
     /// </summary>
-    public static void fit(string description, Func<Task> body)
+    public static void fit(string description, Func<Task> body, [CallerLineNumber] int lineNumber = 0)
     {
-        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreateFocusedSpec(description, body, CurrentTags));
+        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreateFocusedSpec(description, body, CurrentTags, lineNumber));
     }
 
     /// <summary>
     /// Define a skipped spec with a sync body.
     /// </summary>
-    public static void xit(string description, Action? body = null)
+    public static void xit(string description, Action? body = null, [CallerLineNumber] int lineNumber = 0)
     {
-        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreateSkippedSpec(description, body, CurrentTags));
+        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreateSkippedSpec(description, body, CurrentTags, lineNumber));
     }
 
     /// <summary>
     /// Define a skipped spec with an async body.
     /// </summary>
-    public static void xit(string description, Func<Task>? body)
+    public static void xit(string description, Func<Task>? body, [CallerLineNumber] int lineNumber = 0)
     {
-        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreateSkippedSpec(description, body, CurrentTags));
+        ContextBuilder.AddSpec(CurrentContext, ContextBuilder.CreateSkippedSpec(description, body, CurrentTags, lineNumber));
     }
 }

--- a/src/DraftSpec/Internal/ContextBuilder.cs
+++ b/src/DraftSpec/Internal/ContextBuilder.cs
@@ -25,61 +25,61 @@ internal static class ContextBuilder
     /// <summary>
     /// Create a regular spec definition with a sync body.
     /// </summary>
-    public static SpecDefinition CreateSpec(string description, Action body, IReadOnlyList<string>? tags = null)
+    public static SpecDefinition CreateSpec(string description, Action body, IReadOnlyList<string>? tags = null, int lineNumber = 0)
     {
-        return new SpecDefinition(description, body) { Tags = tags ?? [] };
+        return new SpecDefinition(description, body) { Tags = tags ?? [], LineNumber = lineNumber };
     }
 
     /// <summary>
     /// Create a regular spec definition with an async body.
     /// </summary>
-    public static SpecDefinition CreateSpec(string description, Func<Task> body, IReadOnlyList<string>? tags = null)
+    public static SpecDefinition CreateSpec(string description, Func<Task> body, IReadOnlyList<string>? tags = null, int lineNumber = 0)
     {
-        return new SpecDefinition(description, body) { Tags = tags ?? [] };
+        return new SpecDefinition(description, body) { Tags = tags ?? [], LineNumber = lineNumber };
     }
 
     /// <summary>
     /// Create a pending spec definition (no body).
     /// </summary>
-    public static SpecDefinition CreatePendingSpec(string description, IReadOnlyList<string>? tags = null)
+    public static SpecDefinition CreatePendingSpec(string description, IReadOnlyList<string>? tags = null, int lineNumber = 0)
     {
-        return new SpecDefinition(description) { Tags = tags ?? [] };
+        return new SpecDefinition(description) { Tags = tags ?? [], LineNumber = lineNumber };
     }
 
     /// <summary>
     /// Create a focused spec definition with a sync body.
     /// </summary>
-    public static SpecDefinition CreateFocusedSpec(string description, Action body, IReadOnlyList<string>? tags = null)
+    public static SpecDefinition CreateFocusedSpec(string description, Action body, IReadOnlyList<string>? tags = null, int lineNumber = 0)
     {
-        return new SpecDefinition(description, body) { IsFocused = true, Tags = tags ?? [] };
+        return new SpecDefinition(description, body) { IsFocused = true, Tags = tags ?? [], LineNumber = lineNumber };
     }
 
     /// <summary>
     /// Create a focused spec definition with an async body.
     /// </summary>
     public static SpecDefinition CreateFocusedSpec(string description, Func<Task> body,
-        IReadOnlyList<string>? tags = null)
+        IReadOnlyList<string>? tags = null, int lineNumber = 0)
     {
-        return new SpecDefinition(description, body) { IsFocused = true, Tags = tags ?? [] };
+        return new SpecDefinition(description, body) { IsFocused = true, Tags = tags ?? [], LineNumber = lineNumber };
     }
 
     /// <summary>
     /// Create a skipped spec definition with a sync body.
     /// </summary>
-    public static SpecDefinition CreateSkippedSpec(string description, Action? body, IReadOnlyList<string>? tags = null)
+    public static SpecDefinition CreateSkippedSpec(string description, Action? body, IReadOnlyList<string>? tags = null, int lineNumber = 0)
     {
         return body == null
-            ? new SpecDefinition(description) { IsSkipped = true, Tags = tags ?? [] }
-            : new SpecDefinition(description, body) { IsSkipped = true, Tags = tags ?? [] };
+            ? new SpecDefinition(description) { IsSkipped = true, Tags = tags ?? [], LineNumber = lineNumber }
+            : new SpecDefinition(description, body) { IsSkipped = true, Tags = tags ?? [], LineNumber = lineNumber };
     }
 
     /// <summary>
     /// Create a skipped spec definition with an async body.
     /// </summary>
     public static SpecDefinition CreateSkippedSpec(string description, Func<Task>? body,
-        IReadOnlyList<string>? tags = null)
+        IReadOnlyList<string>? tags = null, int lineNumber = 0)
     {
-        return new SpecDefinition(description, body) { IsSkipped = true, Tags = tags ?? [] };
+        return new SpecDefinition(description, body) { IsSkipped = true, Tags = tags ?? [], LineNumber = lineNumber };
     }
 
     /// <summary>

--- a/src/DraftSpec/SpecContext.cs
+++ b/src/DraftSpec/SpecContext.cs
@@ -28,6 +28,12 @@ public class SpecContext
     /// </summary>
     public SpecContext? Parent { get; }
 
+    /// <summary>
+    /// Line number in the source file where this context was defined.
+    /// Used for IDE navigation support.
+    /// </summary>
+    public int LineNumber { get; init; }
+
     // Internal mutable lists
     private readonly List<SpecContext> _children = [];
     private readonly List<SpecDefinition> _specs = [];

--- a/src/DraftSpec/SpecDefinition.cs
+++ b/src/DraftSpec/SpecDefinition.cs
@@ -48,6 +48,12 @@ public class SpecDefinition
     public IReadOnlyList<string> Tags { get; init; } = [];
 
     /// <summary>
+    /// Line number in the source file where this spec was defined.
+    /// Used for IDE navigation support.
+    /// </summary>
+    public int LineNumber { get; init; }
+
+    /// <summary>
     /// Creates a spec with an async body.
     /// </summary>
     /// <param name="description">Description of what the spec tests.</param>

--- a/tests/DraftSpec.Tests/TestingPlatform/LineNumberCaptureTests.cs
+++ b/tests/DraftSpec.Tests/TestingPlatform/LineNumberCaptureTests.cs
@@ -1,0 +1,202 @@
+using DraftSpec.TestingPlatform;
+
+namespace DraftSpec.Tests.TestingPlatform;
+
+public class LineNumberCaptureTests
+{
+    private string _tempDir = null!;
+
+    [Before(Test)]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"draftspec_linenumber_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        global::DraftSpec.Dsl.Reset();
+    }
+
+    [After(Test)]
+    public void Cleanup()
+    {
+        global::DraftSpec.Dsl.Reset();
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task SpecDiscoverer_CapturesLineNumbersForSpecs()
+    {
+        // Arrange - Note: Line numbers are 1-based
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Calculator", () =>
+            {
+                it("adds numbers", () => expect(1 + 1).toBe(2));
+                it("subtracts numbers", () => expect(5 - 3).toBe(2));
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "calc.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert - specs should have line numbers captured
+        await Assert.That(specs.Count).IsEqualTo(2);
+
+        // The "adds numbers" spec is on line 5
+        var addsSpec = specs.First(s => s.Description == "adds numbers");
+        await Assert.That(addsSpec.LineNumber).IsGreaterThan(0);
+
+        // The "subtracts numbers" spec is on line 6
+        var subtractsSpec = specs.First(s => s.Description == "subtracts numbers");
+        await Assert.That(subtractsSpec.LineNumber).IsGreaterThan(0);
+
+        // The subtract spec should be on a later line than the adds spec
+        await Assert.That(subtractsSpec.LineNumber).IsGreaterThan(addsSpec.LineNumber);
+    }
+
+    [Test]
+    public async Task SpecDiscoverer_CapturesLineNumbersForNestedDescribes()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Outer", () =>
+            {
+                describe("Inner", () =>
+                {
+                    it("nested spec", () => { });
+                });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "nested.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(1);
+        await Assert.That(specs[0].LineNumber).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task SpecExecutor_CapturesLineNumbersInResults()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Test", () =>
+            {
+                it("first spec", () => { });
+                it("second spec", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "test.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var executor = new MtpSpecExecutor(_tempDir);
+
+        // Act
+        var result = await executor.ExecuteFileAsync(csxPath);
+
+        // Assert - execution results should also have line numbers
+        await Assert.That(result.Results.Count).IsEqualTo(2);
+        await Assert.That(result.Results[0].Spec.LineNumber).IsGreaterThan(0);
+        await Assert.That(result.Results[1].Spec.LineNumber).IsGreaterThan(0);
+        await Assert.That(result.Results[1].Spec.LineNumber).IsGreaterThan(result.Results[0].Spec.LineNumber);
+    }
+
+    [Test]
+    public async Task SpecDiscoverer_CapturesLineNumbersForFocusedSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Focused", () =>
+            {
+                fit("focused spec", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "focused.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(1);
+        await Assert.That(specs[0].IsFocused).IsTrue();
+        await Assert.That(specs[0].LineNumber).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task SpecDiscoverer_CapturesLineNumbersForSkippedSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Skipped", () =>
+            {
+                xit("skipped spec", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "skipped.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(1);
+        await Assert.That(specs[0].IsSkipped).IsTrue();
+        await Assert.That(specs[0].LineNumber).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task SpecDiscoverer_CapturesLineNumbersForPendingSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+
+            describe("Pending", () =>
+            {
+                it("pending spec");
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "pending.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var discoverer = new SpecDiscoverer(_tempDir);
+
+        // Act
+        var specs = await discoverer.DiscoverFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(specs.Count).IsEqualTo(1);
+        await Assert.That(specs[0].IsPending).IsTrue();
+        await Assert.That(specs[0].LineNumber).IsGreaterThan(0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds IDE navigation support for MTP integration, enabling click-to-navigate from Test Explorer to source code:

- Add `LineNumber` property to `SpecDefinition` and `SpecContext` for capturing source locations
- Add `[CallerLineNumber]` to `it()`, `fit()`, `xit()`, `describe()`, and `context()` methods
- Update `ContextBuilder` to pass line numbers through the call chain
- Add `LineNumber` to `DiscoveredSpec` for MTP test enumeration
- Add `TestFileLocationProperty` to `TestNodeMapper` for IDE click-to-navigate
- Update `ExecutionResult` to include absolute source file path for file location properties
- Add comprehensive unit tests for line number capture

## Test Plan

- [x] All 1615 tests pass
- [x] Line numbers captured for `it()` specs
- [x] Line numbers captured for `fit()` focused specs
- [x] Line numbers captured for `xit()` skipped specs
- [x] Line numbers captured for pending specs
- [x] Line numbers captured in nested describe blocks
- [x] Line numbers included in execution results

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)