### PR TITLE
fix: Resolve MTP integration issues from review

### DIFF
--- a/examples/TodoApi.Specs/TodoApi.Specs.csproj
+++ b/examples/TodoApi.Specs/TodoApi.Specs.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- Import DraftSpec.TestingPlatform props (sets OutputType=Exe, enables MTP) -->
+  <Import Project="..\..\src\DraftSpec.TestingPlatform\build\DraftSpec.TestingPlatform.props" />
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -19,11 +22,7 @@
     <ProjectReference Include="..\..\src\DraftSpec.TestingPlatform\DraftSpec.TestingPlatform.csproj" />
   </ItemGroup>
 
-  <!-- Include spec files as content -->
-  <ItemGroup>
-    <None Update="**\*.spec.csx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+  <!-- Import DraftSpec.TestingPlatform targets (generates entry point, copies CSX files) -->
+  <Import Project="..\..\src\DraftSpec.TestingPlatform\build\DraftSpec.TestingPlatform.targets" />
 
 </Project>

--- a/src/DraftSpec.TestingPlatform/build/DraftSpec.TestingPlatform.targets
+++ b/src/DraftSpec.TestingPlatform/build/DraftSpec.TestingPlatform.targets
@@ -6,6 +6,12 @@
     <Content Include="@(DraftSpecFile)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <!-- Also include helper CSX files (loaded via #load) -->
+  <ItemGroup>
+    <DraftSpecHelperFile Include="**/*_helper.csx;**/spec_helper.csx" Exclude="**/bin/**;**/obj/**" />
+    <Content Include="@(DraftSpecHelperFile)" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
   <!-- Generate entry point by copying template -->
   <Target Name="GenerateDraftSpecEntryPoint"
           BeforeTargets="BeforeCompile"

--- a/tests/DraftSpec.Tests/Middleware/PipelineTests.cs
+++ b/tests/DraftSpec.Tests/Middleware/PipelineTests.cs
@@ -95,7 +95,7 @@ public class PipelineTests
         context.AddSpec(new SpecDefinition("test", async () =>
         {
             attempts++;
-            if (attempts == 1) await Task.Delay(1000); // First attempt times out (1s >> 50ms)
+            if (attempts == 1) await Task.Delay(5000); // First attempt times out (5s >> 50ms)
             // Second attempt succeeds quickly
         }));
 


### PR DESCRIPTION
## Summary

This PR fixes several issues discovered during the MTP integration epic review:

- **Flaky test fix**: `Pipeline_RetryWithIndividualTimeouts` was failing intermittently in CI due to timing race conditions. Increased delay from 1s to 5s (with 50ms timeout) to ensure reliable timeout triggering.

- **TodoApi.Specs IDE fix**: Example project was missing MSBuild imports for `DraftSpec.TestingPlatform` props/targets, preventing tests from appearing in IDE Test Explorer.

- **CSX #load directive fix**: Updated `CsxScriptHost` to extract and hoist `using` directives to the top of combined code, enabling proper handling of `#load` with helper files that contain code.

- **Helper file inclusion**: Added `spec_helper.csx` pattern to targets file so helper files are copied to output directory alongside spec files.

## Test Plan

- [x] All 1615 DraftSpec.Tests pass
- [x] MTP integration tests pass (22 tests)
- [x] TodoApi.Specs runs successfully with `dotnet run` (14 tests)
- [x] Ran tests multiple times to verify no flakiness

Fixes #131
Fixes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)