### PR TITLE
feat: Add VSTestBridge support for IDE integration

### DIFF
--- a/src/DraftSpec.TestingPlatform/DraftSpec.TestingPlatform.csproj
+++ b/src/DraftSpec.TestingPlatform/DraftSpec.TestingPlatform.csproj
@@ -19,7 +19,10 @@
         <!-- MTP SDK -->
         <PackageReference Include="Microsoft.Testing.Platform" Version="2.0.2" />
 
-        <!-- Roslyn Scripting (for future use) -->
+        <!-- VSTest Bridge for IDE integration (VS, Rider, VS Code) -->
+        <PackageReference Include="Microsoft.Testing.Extensions.VSTestBridge" Version="2.0.2" />
+
+        <!-- Roslyn Scripting -->
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.14.0" />
 
         <!-- DraftSpec Core -->

--- a/src/DraftSpec.TestingPlatform/TestingPlatformBuilderHook.cs
+++ b/src/DraftSpec.TestingPlatform/TestingPlatformBuilderHook.cs
@@ -1,0 +1,18 @@
+using Microsoft.Testing.Platform.Builder;
+
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Hook class discovered by Microsoft.Testing.Platform.MSBuild source generator.
+/// This enables auto-registration of DraftSpec when using the generated entry point.
+/// </summary>
+public static class TestingPlatformBuilderHook
+{
+    /// <summary>
+    /// Called by the MSBuild-generated SelfRegisteredExtensions to register DraftSpec.
+    /// </summary>
+    public static void AddExtensions(ITestApplicationBuilder builder, string[] args)
+    {
+        builder.AddDraftSpec();
+    }
+}

--- a/src/DraftSpec.TestingPlatform/build/DraftSpec.TestingPlatform.props
+++ b/src/DraftSpec.TestingPlatform/build/DraftSpec.TestingPlatform.props
@@ -7,8 +7,14 @@
     <!-- Enable Microsoft.Testing.Platform -->
     <EnableMicrosoftTestingPlatform Condition="'$(EnableMicrosoftTestingPlatform)' == ''">true</EnableMicrosoftTestingPlatform>
 
-    <!-- Generate entry point automatically -->
-    <GenerateTestingPlatformEntryPoint Condition="'$(GenerateTestingPlatformEntryPoint)' == ''">true</GenerateTestingPlatformEntryPoint>
+    <!-- Mark as MTP application for dotnet test recognition -->
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+
+    <!-- Disable MS's entry point generation - DraftSpec generates its own -->
+    <GenerateMicrosoftTestingPlatformEntryPoint>false</GenerateMicrosoftTestingPlatformEntryPoint>
+
+    <!-- Generate DraftSpec's custom entry point -->
+    <GenerateDraftSpecEntryPoint Condition="'$(GenerateDraftSpecEntryPoint)' == ''">true</GenerateDraftSpecEntryPoint>
 
     <!-- Output as executable for dotnet test -->
     <OutputType>Exe</OutputType>
@@ -16,6 +22,11 @@
     <!-- Enable reflection for JSON serialization (required for DraftSpec) -->
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
+
+  <!-- Add TestContainer capability for IDE Test Explorer discovery -->
+  <ItemGroup>
+    <ProjectCapability Include="TestContainer" />
+  </ItemGroup>
 
   <!-- Default spec file pattern -->
   <PropertyGroup Condition="'$(DraftSpecPattern)' == ''">

--- a/src/DraftSpec.TestingPlatform/build/DraftSpec.TestingPlatform.targets
+++ b/src/DraftSpec.TestingPlatform/build/DraftSpec.TestingPlatform.targets
@@ -9,7 +9,7 @@
   <!-- Generate entry point by copying template -->
   <Target Name="GenerateDraftSpecEntryPoint"
           BeforeTargets="BeforeCompile"
-          Condition="'$(GenerateTestingPlatformEntryPoint)' == 'true'">
+          Condition="'$(GenerateDraftSpecEntryPoint)' == 'true'">
 
     <PropertyGroup>
       <DraftSpecEntryPointDir>$(IntermediateOutputPath)generated/</DraftSpecEntryPointDir>

--- a/src/DraftSpec.TestingPlatform/build/EntryPoint.template.cs
+++ b/src/DraftSpec.TestingPlatform/build/EntryPoint.template.cs
@@ -4,6 +4,9 @@ using DraftSpec.TestingPlatform;
 using Microsoft.Testing.Platform.Builder;
 
 var builder = await TestApplication.CreateBuilderAsync(args);
+
+// Register DraftSpec test framework
 builder.AddDraftSpec();
+
 using var app = await builder.BuildAsync();
 return await app.RunAsync();


### PR DESCRIPTION
## Summary

- Inherit DraftSpecTestFramework from VSTestBridgedTestFrameworkBase
- Add Microsoft.Testing.Extensions.VSTestBridge package reference
- Fix IsTestingPlatformApplication=true for dotnet test MTP recognition
- Add TestContainer ProjectCapability for IDE discovery
- Rename GenerateTestingPlatformEntryPoint to GenerateDraftSpecEntryPoint
- Add TestingPlatformBuilderHook for auto-registration

Enables test discovery in IDEs that support Microsoft.Testing.Platform (Visual Studio, VS Code, Rider with Testing Platform support enabled).

## Test plan

- [x] All unit tests pass (1615 tests)
- [x] MTP integration tests pass (4 tests)
- [x] `dotnet test` works with .NET 10 native MTP mode
- [x] `dotnet run --list-tests` shows discovered tests
- [ ] Verify Rider shows tests with "Testing Platform support" enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)