### PR TITLE
fix: Add Microsoft.Testing.Platform.MSBuild for IDE server mode

### DIFF
--- a/src/DraftSpec.TestingPlatform/DraftSpec.TestingPlatform.csproj
+++ b/src/DraftSpec.TestingPlatform/DraftSpec.TestingPlatform.csproj
@@ -19,7 +19,10 @@
         <!-- MTP SDK -->
         <PackageReference Include="Microsoft.Testing.Platform" Version="2.0.2" />
 
-        <!-- VSTest Bridge for IDE integration (VS, Rider, VS Code) -->
+        <!-- MSBuild integration for IDE server mode (VS, Rider, VS Code Test Explorers) -->
+        <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="2.0.2" />
+
+        <!-- VSTest Bridge for IDE integration -->
         <PackageReference Include="Microsoft.Testing.Extensions.VSTestBridge" Version="2.0.2" />
 
         <!-- Roslyn Scripting -->


### PR DESCRIPTION
## Summary

Adds `Microsoft.Testing.Platform.MSBuild` package reference to enable IDE server mode for test discovery.

The MSBuild package provides the `--server` capability that IDEs use for JSON-RPC communication with the test runner. Without this, Rider/VS/VS Code cannot discover tests via the Testing Platform protocol.

## Test plan

- [x] All unit tests pass (1615 tests)
- [x] MTP integration tests pass (4 tests)
- [x] Verified `--server` flag is now available in test executables
- [ ] Verify Rider discovers tests with Testing Platform support enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)