### PR TITLE
fix: Make timeout middleware test more reliable with NotInParallel

### DIFF
--- a/tests/DraftSpec.Tests/Middleware/PipelineTests.cs
+++ b/tests/DraftSpec.Tests/Middleware/PipelineTests.cs
@@ -34,11 +34,12 @@ public class PipelineTests
     }
 
     [Test]
+    [NotInParallel]
     public async Task SpecRunnerBuilder_WithTimeout_ConfiguresTimeoutMiddleware()
     {
         var context = new SpecContext("test");
-        // Use a large gap (2000ms delay vs 100ms timeout) to avoid CI flakiness
-        context.AddSpec(new SpecDefinition("slow", async () => await Task.Delay(2000)));
+        // Use a large gap (10s delay vs 100ms timeout) to avoid CI flakiness
+        context.AddSpec(new SpecDefinition("slow", async () => await Task.Delay(10_000)));
 
         var runner = new SpecRunnerBuilder().WithTimeout(100).Build();
         var results = runner.Run(context);


### PR DESCRIPTION
## Summary

The `SpecRunnerBuilder_WithTimeout_ConfiguresTimeoutMiddleware` test was failing intermittently in CI due to parallel execution interference.

## Changes

- Add `[NotInParallel]` attribute to prevent concurrent execution with other tests
- Increase delay from 2s to 10s for more reliable timeout triggering (provides larger margin for CI variance)

## Test Results

All 1615 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)