### PR TITLE
fix: Add missing MSBuild properties for IDE protocol support

### DIFF
--- a/src/DraftSpec.TestingPlatform/build/DraftSpec.TestingPlatform.props
+++ b/src/DraftSpec.TestingPlatform/build/DraftSpec.TestingPlatform.props
@@ -10,6 +10,11 @@
     <!-- Mark as MTP application for dotnet test recognition -->
     <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
 
+    <!-- Enable Testing Platform protocol for IDE communication -->
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <UseTestingPlatformProtocol>true</UseTestingPlatformProtocol>
+    <IsTestingPlatformEnabled>true</IsTestingPlatformEnabled>
+
     <!-- Disable MS's entry point generation - DraftSpec generates its own -->
     <GenerateMicrosoftTestingPlatformEntryPoint>false</GenerateMicrosoftTestingPlatformEntryPoint>
 


### PR DESCRIPTION
## Summary

Adds MSBuild properties that TUnit sets for IDE test discovery. These were identified by comparing our props file with TUnit.Engine's props file.

## Changes

Added to `DraftSpec.TestingPlatform.props`:
- `TestingPlatformDotnetTestSupport=true`
- `UseTestingPlatformProtocol=true`
- `IsTestingPlatformEnabled=true`

These properties help IDEs like Rider recognize the project as using the Testing Platform protocol for test discovery and execution.

## Reference

TUnit's props file sets these same properties and works correctly in Rider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)