### PR TITLE
fix: Add NotInParallel to AsyncSpec_ExceptionPropagates test

### DIFF
--- a/tests/DraftSpec.Tests/Dsl/StaticDslTests.cs
+++ b/tests/DraftSpec.Tests/Dsl/StaticDslTests.cs
@@ -410,6 +410,7 @@ public class StaticDslTests
     }
 
     [Test]
+    [NotInParallel(nameof(Environment.ExitCode))]
     public async Task AsyncSpec_ExceptionPropagates()
     {
         // Save original


### PR DESCRIPTION
## Summary

Fixes flaky test `AsyncSpec_ExceptionPropagates` that was failing in CI.

The test relies on `Environment.ExitCode` which is process-global state. When tests run in parallel, other tests can interfere with this shared state, causing the test to read stale or modified exit codes.

Other `ExitCode` tests in the same file already have the `[NotInParallel(nameof(Environment.ExitCode))]` attribute - this one was simply missed.

## Test plan

- [x] Build succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)