### PR TITLE
fix: Simplify DisplayName and preserve spaces in identifiers

### DIFF
--- a/src/DraftSpec.TestingPlatform/SpecDiscoverer.cs
+++ b/src/DraftSpec.TestingPlatform/SpecDiscoverer.cs
@@ -144,8 +144,8 @@ internal sealed class SpecDiscoverer
         // Process specs in this context
         foreach (var spec in context.Specs)
         {
-            var specId = GenerateStableId(relativeSourceFile, currentPath, spec.Description);
-            var displayName = GenerateDisplayName(currentPath, spec.Description);
+            var specId = TestNodeMapper.GenerateStableId(relativeSourceFile, currentPath, spec.Description);
+            var displayName = TestNodeMapper.GenerateDisplayName(currentPath, spec.Description);
 
             results.Add(new DiscoveredSpec
             {
@@ -172,33 +172,4 @@ internal sealed class SpecDiscoverer
         }
     }
 
-    /// <summary>
-    /// Generates a stable, unique ID for a spec.
-    /// Format: relative/path/file.spec.csx:Context/Path/spec description
-    /// </summary>
-    private static string GenerateStableId(
-        string relativeSourceFile,
-        IReadOnlyList<string> contextPath,
-        string specDescription)
-    {
-        // Normalize path separators to forward slashes for cross-platform consistency
-        var normalizedPath = relativeSourceFile.Replace('\\', '/');
-
-        // Build context path with forward slashes
-        var contextPathString = string.Join("/", contextPath);
-
-        return $"{normalizedPath}:{contextPathString}/{specDescription}";
-    }
-
-    /// <summary>
-    /// Generates a human-readable display name.
-    /// Format: Context > Path > spec description
-    /// </summary>
-    private static string GenerateDisplayName(
-        IReadOnlyList<string> contextPath,
-        string specDescription)
-    {
-        var parts = new List<string>(contextPath) { specDescription };
-        return string.Join(" > ", parts);
-    }
 }

--- a/tests/DraftSpec.Tests/TestingPlatform/SpecDiscovererTests.cs
+++ b/tests/DraftSpec.Tests/TestingPlatform/SpecDiscovererTests.cs
@@ -168,7 +168,8 @@ public class SpecDiscovererTests
         var specs = await discoverer.DiscoverFileAsync(csxPath);
 
         // Assert
-        await Assert.That(specs[0].DisplayName).IsEqualTo("Auth > Login > validates credentials");
+        // DisplayName is now just the spec description (tree view shows hierarchy)
+        await Assert.That(specs[0].DisplayName).IsEqualTo("validates credentials");
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- DisplayName now returns just the spec description (tree view shows hierarchy via TestMethodIdentifierProperty)
- Removed identifier sanitization - ECMA-335 allows spaces in identifiers and ManagedNameUtilities now supports them via escaping (see https://github.com/microsoft/vstest/issues/2733)
- Refactored to share `GenerateStableId`/`GenerateDisplayName` between SpecDiscoverer and TestNodeMapper (removed duplicates)

## Before/After

**Before:** `Root_Sample`, `nested_context`, `Invalid_puzzle_handling`
**After:** `Root Sample`, `nested context`, `Invalid puzzle handling`

## Test plan

- [x] All 1615 unit tests pass
- [x] All 4 integration tests pass
- [x] Verified in Rider Test Explorer - spaces display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)