### PR TITLE
fix: Add regex timeout to prevent ReDoS attacks

### DIFF
--- a/src/DraftSpec/SpecRunnerBuilder.cs
+++ b/src/DraftSpec/SpecRunnerBuilder.cs
@@ -10,6 +10,11 @@ namespace DraftSpec;
 /// </summary>
 public class SpecRunnerBuilder
 {
+    /// <summary>
+    /// Default timeout for regex operations to prevent ReDoS attacks.
+    /// </summary>
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
     private readonly List<ISpecMiddleware> _middleware = [];
     private DraftSpecConfiguration? _configuration;
     private int _maxDegreeOfParallelism;
@@ -62,7 +67,7 @@ public class SpecRunnerBuilder
     /// <param name="options">Regex options (default: IgnoreCase)</param>
     public SpecRunnerBuilder WithNameFilter(string pattern, RegexOptions options = RegexOptions.IgnoreCase)
     {
-        var regex = new Regex(pattern, options);
+        var regex = new Regex(pattern, options, RegexTimeout);
         return Use(new FilterMiddleware(ctx =>
             {
                 var fullDescription = string.Join(" ", ctx.ContextPath.Append(ctx.Spec.Description));
@@ -78,7 +83,7 @@ public class SpecRunnerBuilder
     /// <param name="options">Regex options (default: IgnoreCase)</param>
     public SpecRunnerBuilder WithNameExcludeFilter(string pattern, RegexOptions options = RegexOptions.IgnoreCase)
     {
-        var regex = new Regex(pattern, options);
+        var regex = new Regex(pattern, options, RegexTimeout);
         return Use(new FilterMiddleware(ctx =>
             {
                 var fullDescription = string.Join(" ", ctx.ContextPath.Append(ctx.Spec.Description));


### PR DESCRIPTION
## Summary

- Add 1-second timeout to regex operations in `WithNameFilter` and `WithNameExcludeFilter`
- Prevents catastrophic backtracking (ReDoS) when malicious regex patterns are provided
- Throws `RegexMatchTimeoutException` instead of hanging indefinitely

## Changes

- Added `RegexTimeout` constant (1 second) to `SpecRunnerBuilder`
- Pass timeout to `Regex` constructor in both name filter methods
- Added 2 tests to verify timeout protection works with known-evil patterns

## Test Plan

- [x] All existing filter tests pass (23 tests)
- [x] New ReDoS protection tests pass (2 tests)
- [x] Build succeeds with no new warnings

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)