### PR TITLE
refactor: Extract ExecuteInContext helper to reduce duplication

### DIFF
--- a/src/DraftSpec/Dsl.Context.cs
+++ b/src/DraftSpec/Dsl.Context.cs
@@ -13,44 +13,36 @@ public static partial class Dsl
         {
             // First describe call - create root
             RootContext = new SpecContext(description) { LineNumber = lineNumber };
-            CurrentContext = RootContext;
-            try
-            {
-                body();
-            }
-            finally
-            {
-                CurrentContext = null;
-            }
+            ExecuteInContext(RootContext, restoreTo: null, body);
         }
         else if (CurrentContext is null)
         {
             // Another top-level describe - add as child of root
             var context = new SpecContext(description, RootContext) { LineNumber = lineNumber };
-            CurrentContext = context;
-            try
-            {
-                body();
-            }
-            finally
-            {
-                CurrentContext = null;
-            }
+            ExecuteInContext(context, restoreTo: null, body);
         }
         else
         {
             // Nested describe
             var parent = CurrentContext;
             var context = new SpecContext(description, parent) { LineNumber = lineNumber };
-            CurrentContext = context;
-            try
-            {
-                body();
-            }
-            finally
-            {
-                CurrentContext = parent;
-            }
+            ExecuteInContext(context, restoreTo: parent, body);
+        }
+    }
+
+    /// <summary>
+    /// Execute body within the given context, restoring CurrentContext afterward.
+    /// </summary>
+    private static void ExecuteInContext(SpecContext context, SpecContext? restoreTo, Action body)
+    {
+        CurrentContext = context;
+        try
+        {
+            body();
+        }
+        finally
+        {
+            CurrentContext = restoreTo;
         }
     }
 


### PR DESCRIPTION
## Summary

Extract the common try/finally pattern from `describe()` into a private `ExecuteInContext` helper method.

## Before

Three nearly identical try/finally blocks:
```csharp
CurrentContext = context;
try
{
    body();
}
finally
{
    CurrentContext = restoreTo;
}
```

## After

Single helper method called from each branch:
```csharp
private static void ExecuteInContext(SpecContext context, SpecContext? restoreTo, Action body)
{
    CurrentContext = context;
    try
    {
        body();
    }
    finally
    {
        CurrentContext = restoreTo;
    }
}
```

## Test Plan

- [x] All Dsl tests pass (26 tests)
- [x] All SpecContext tests pass (25 tests)
- [x] Build succeeds with no warnings

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)