### PR TITLE
test: Add regression tests for SpecContext validation order

### DIFF
--- a/tests/DraftSpec.Tests/Core/CoreEdgeCaseTests.cs
+++ b/tests/DraftSpec.Tests/Core/CoreEdgeCaseTests.cs
@@ -276,6 +276,42 @@ public class CoreEdgeCaseTests
     }
 
     [Test]
+    public async Task SpecContext_EmptyDescriptionWithParent_DoesNotModifyParent()
+    {
+        // Arrange
+        var parent = new SpecContext("parent");
+        var initialChildCount = parent.Children.Count;
+
+        // Act - attempt to create invalid child
+        Assert.Throws<ArgumentException>(() => new SpecContext("", parent));
+
+        // Assert - parent should not have been modified
+        await Assert.That(parent.Children.Count).IsEqualTo(initialChildCount);
+    }
+
+    [Test]
+    public async Task SpecContext_WhitespaceDescriptionWithParent_DoesNotModifyParent()
+    {
+        var parent = new SpecContext("parent");
+        var initialChildCount = parent.Children.Count;
+
+        Assert.Throws<ArgumentException>(() => new SpecContext("   ", parent));
+
+        await Assert.That(parent.Children.Count).IsEqualTo(initialChildCount);
+    }
+
+    [Test]
+    public async Task SpecContext_NullDescriptionWithParent_DoesNotModifyParent()
+    {
+        var parent = new SpecContext("parent");
+        var initialChildCount = parent.Children.Count;
+
+        Assert.Throws<ArgumentException>(() => new SpecContext(null!, parent));
+
+        await Assert.That(parent.Children.Count).IsEqualTo(initialChildCount);
+    }
+
+    [Test]
     public async Task SpecContext_AddChild_AddsToChildrenCollection()
     {
         var parent = new SpecContext("parent");


### PR DESCRIPTION
## Summary

Add regression tests verifying that parameter validation happens before any side-effects in the `SpecContext` constructor.

## TDD Investigation

Following TDD, I wrote tests to verify the expected behavior:

```csharp
[Test]
public async Task SpecContext_EmptyDescriptionWithParent_DoesNotModifyParent()
{
    var parent = new SpecContext("parent");
    var initialChildCount = parent.Children.Count;

    Assert.Throws<ArgumentException>(() => new SpecContext("", parent));

    // Parent should NOT be modified when validation fails
    await Assert.That(parent.Children.Count).IsEqualTo(initialChildCount);
}
```

**Result: Tests pass!** The code is already correct.

## Code Analysis

Looking at `SpecContext.cs:98-106`:
```csharp
public SpecContext(string description, SpecContext? parent = null)
{
    if (string.IsNullOrWhiteSpace(description))     // Line 100-101: Validation FIRST
        throw new ArgumentException(...);
    
    Description = description;                       // Line 103
    Parent = parent;                                 // Line 104
    parent?._children.Add(this);                     // Line 105: Side-effect LAST
}
```

The validation (line 100-101) happens **before** the side-effect (line 105), so the issue description was incorrect.

## Value Added

These 3 tests serve as **regression tests** to ensure this correct behavior is preserved in future refactoring.

## Test Plan

- [x] 3 new tests pass
- [x] All existing tests still pass
- [x] Build succeeds

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)