### PR TITLE
refactor: Replace magic strings with SpecStatusNames constants

### DIFF
--- a/src/DraftSpec.Formatters.Abstractions/SpecReport.cs
+++ b/src/DraftSpec.Formatters.Abstractions/SpecReport.cs
@@ -83,11 +83,11 @@ public class SpecResultReport
     public double? DurationMs { get; set; }
     public string? Error { get; set; }
 
-    [JsonIgnore] public bool Passed => Status == "passed";
+    [JsonIgnore] public bool Passed => Status == SpecStatusNames.Passed;
 
-    [JsonIgnore] public bool Failed => Status == "failed";
+    [JsonIgnore] public bool Failed => Status == SpecStatusNames.Failed;
 
-    [JsonIgnore] public bool Pending => Status == "pending";
+    [JsonIgnore] public bool Pending => Status == SpecStatusNames.Pending;
 
-    [JsonIgnore] public bool Skipped => Status == "skipped";
+    [JsonIgnore] public bool Skipped => Status == SpecStatusNames.Skipped;
 }

--- a/src/DraftSpec.Formatters.Abstractions/SpecStatusNames.cs
+++ b/src/DraftSpec.Formatters.Abstractions/SpecStatusNames.cs
@@ -1,0 +1,28 @@
+namespace DraftSpec.Formatters;
+
+/// <summary>
+/// String constants for spec status values used in reports and formatters.
+/// These correspond to the SpecStatus enum values in the core library.
+/// </summary>
+public static class SpecStatusNames
+{
+    /// <summary>
+    /// The spec executed successfully without throwing an exception.
+    /// </summary>
+    public const string Passed = "passed";
+
+    /// <summary>
+    /// The spec threw an exception during execution.
+    /// </summary>
+    public const string Failed = "failed";
+
+    /// <summary>
+    /// The spec has no body defined (placeholder for future implementation).
+    /// </summary>
+    public const string Pending = "pending";
+
+    /// <summary>
+    /// The spec was skipped due to filtering, focus mode, or explicit skip.
+    /// </summary>
+    public const string Skipped = "skipped";
+}

--- a/src/DraftSpec.Formatters.Console/ConsoleFormatter.cs
+++ b/src/DraftSpec.Formatters.Console/ConsoleFormatter.cs
@@ -1,3 +1,5 @@
+using DraftSpec.Formatters;
+
 namespace DraftSpec.Formatters.Console;
 
 /// <summary>
@@ -57,10 +59,10 @@ public class ConsoleFormatter : IConsoleFormatter
         {
             var (symbol, color) = spec.Status switch
             {
-                "passed" => ("✓", ConsoleColor.Green),
-                "failed" => ("✗", ConsoleColor.Red),
-                "pending" => ("○", ConsoleColor.Yellow),
-                "skipped" => ("-", ConsoleColor.DarkGray),
+                SpecStatusNames.Passed => ("✓", ConsoleColor.Green),
+                SpecStatusNames.Failed => ("✗", ConsoleColor.Red),
+                SpecStatusNames.Pending => ("○", ConsoleColor.Yellow),
+                SpecStatusNames.Skipped => ("-", ConsoleColor.DarkGray),
                 _ => ("?", ConsoleColor.White)
             };
 
@@ -70,7 +72,7 @@ public class ConsoleFormatter : IConsoleFormatter
             output.Write(spec.Description);
 
             // Show duration for specs that ran
-            if (spec.Status is "passed" or "failed" && spec.DurationMs > 0)
+            if (spec.Status is SpecStatusNames.Passed or SpecStatusNames.Failed && spec.DurationMs > 0)
             {
                 if (useColors) System.Console.ForegroundColor = ConsoleColor.DarkGray;
                 output.Write($" ({FormatDuration(spec.DurationMs ?? 0)})");

--- a/src/DraftSpec.Formatters.Html/HtmlFormatter.cs
+++ b/src/DraftSpec.Formatters.Html/HtmlFormatter.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web;
+using DraftSpec.Formatters;
 
 namespace DraftSpec.Formatters.Html;
 
@@ -136,10 +137,10 @@ public class HtmlFormatter : IFormatter
             {
                 var symbol = spec.Status switch
                 {
-                    "passed" => "✓",
-                    "failed" => "✗",
-                    "pending" => "○",
-                    "skipped" => "−",
+                    SpecStatusNames.Passed => "✓",
+                    SpecStatusNames.Failed => "✗",
+                    SpecStatusNames.Pending => "○",
+                    SpecStatusNames.Skipped => "−",
                     _ => "?"
                 };
 

--- a/src/DraftSpec.Formatters.Markdown/MarkdownFormatter.cs
+++ b/src/DraftSpec.Formatters.Markdown/MarkdownFormatter.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using DraftSpec.Formatters;
 
 namespace DraftSpec.Formatters.Markdown;
 
@@ -90,9 +91,9 @@ public class MarkdownFormatter : IFormatter
             {
                 var symbol = spec.Status switch
                 {
-                    "passed" => "✓",
-                    "failed" => "✗",
-                    "pending" => "○",
+                    SpecStatusNames.Passed => "✓",
+                    SpecStatusNames.Failed => "✗",
+                    SpecStatusNames.Pending => "○",
                     _ => "?"
                 };
                 sb.AppendLine($"- {symbol} {spec.Description}");

--- a/src/DraftSpec/Internal/SpecExecutor.cs
+++ b/src/DraftSpec/Internal/SpecExecutor.cs
@@ -109,10 +109,10 @@ internal static class SpecExecutor
         {
             var status = spec.Status switch
             {
-                "passed" => "✓",
-                "failed" => "✗",
-                "pending" => "○",
-                "skipped" => "-",
+                SpecStatusNames.Passed => "✓",
+                SpecStatusNames.Failed => "✗",
+                SpecStatusNames.Pending => "○",
+                SpecStatusNames.Skipped => "-",
                 _ => "?"
             };
             output.WriteLine($"{indent}  {status} {spec.Description}");


### PR DESCRIPTION
## Summary
Add `SpecStatusNames` class with string constants for status values, eliminating magic strings throughout the formatters.

### Changes:
- **New**: `SpecStatusNames` class in `DraftSpec.Formatters.Abstractions` with constants:
  - `Passed = "passed"`
  - `Failed = "failed"`
  - `Pending = "pending"`
  - `Skipped = "skipped"`

- **Updated** to use constants:
  - `SpecReport.cs` - Status comparison properties
  - `ConsoleFormatter.cs` - Switch expression and condition
  - `MarkdownFormatter.cs` - Switch expression
  - `HtmlFormatter.cs` - Switch expression
  - `SpecExecutor.cs` - Switch expression

### Benefits:
- IntelliSense support for status values
- Compile-time checking for typos
- Single source of truth for status strings
- Easier refactoring if status names ever change

## Test plan
- [x] All tests pass (1654 tests)
- [x] Build succeeds

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)