### PR TITLE
refactor: Extract shared environment variable constants

### DIFF
--- a/src/DraftSpec.Cli/SpecFileRunner.cs
+++ b/src/DraftSpec.Cli/SpecFileRunner.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using DraftSpec.Cli.Coverage;
+using DraftSpec.Formatters;
 
 namespace DraftSpec.Cli;
 
@@ -31,22 +32,22 @@ public partial class SpecFileRunner : ISpecFileRunner
     /// <summary>
     /// Environment variable name for tag filtering (comma-separated).
     /// </summary>
-    public const string FilterTagsEnvVar = "DRAFTSPEC_FILTER_TAGS";
+    public const string FilterTagsEnvVar = EnvironmentVariables.FilterTags;
 
     /// <summary>
     /// Environment variable name for tag exclusion (comma-separated).
     /// </summary>
-    public const string ExcludeTagsEnvVar = "DRAFTSPEC_EXCLUDE_TAGS";
+    public const string ExcludeTagsEnvVar = EnvironmentVariables.ExcludeTags;
 
     /// <summary>
     /// Environment variable name for name pattern filtering (regex).
     /// </summary>
-    public const string FilterNameEnvVar = "DRAFTSPEC_FILTER_NAME";
+    public const string FilterNameEnvVar = EnvironmentVariables.FilterName;
 
     /// <summary>
     /// Environment variable name for name pattern exclusion (regex).
     /// </summary>
-    public const string ExcludeNameEnvVar = "DRAFTSPEC_EXCLUDE_NAME";
+    public const string ExcludeNameEnvVar = EnvironmentVariables.ExcludeName;
 
     private readonly Dictionary<string, DateTime> _lastBuildTime = new();
     private readonly Dictionary<string, DateTime> _lastSourceModified = new();
@@ -534,7 +535,7 @@ public partial class SpecFileRunner : ISpecFileRunner
         // Create temp file path for JSON output
         var jsonOutputFile = Path.Combine(Path.GetTempPath(), $".draftspec-{Guid.NewGuid():N}.json");
         var envVars = GetFilterEnvironmentVariables();
-        envVars["DRAFTSPEC_JSON_OUTPUT_FILE"] = jsonOutputFile;
+        envVars[EnvironmentVariables.JsonOutputFile] = jsonOutputFile;
 
         // Use file-based if: .NET 10+ AND no #load directives
         if (_useFileBased && !UsesLoadDirective(fullPath))

--- a/src/DraftSpec.Formatters.Abstractions/EnvironmentVariables.cs
+++ b/src/DraftSpec.Formatters.Abstractions/EnvironmentVariables.cs
@@ -1,0 +1,43 @@
+namespace DraftSpec.Formatters;
+
+/// <summary>
+/// Environment variable names used by DraftSpec for configuration.
+/// </summary>
+public static class EnvironmentVariables
+{
+    /// <summary>
+    /// Environment variable name for CLI-based JSON output file path.
+    /// When set, run() automatically adds a FileReporter to write JSON to this file.
+    /// </summary>
+    public const string JsonOutputFile = "DRAFTSPEC_JSON_OUTPUT_FILE";
+
+    /// <summary>
+    /// Environment variable name for enabling progress streaming.
+    /// When set to "true" or "1", run() adds a ProgressStreamReporter for MCP integration.
+    /// </summary>
+    public const string ProgressStream = "DRAFTSPEC_PROGRESS_STREAM";
+
+    /// <summary>
+    /// Environment variable name for tag filtering (comma-separated).
+    /// Only specs with any of these tags will run.
+    /// </summary>
+    public const string FilterTags = "DRAFTSPEC_FILTER_TAGS";
+
+    /// <summary>
+    /// Environment variable name for tag exclusion (comma-separated).
+    /// Specs with any of these tags will be skipped.
+    /// </summary>
+    public const string ExcludeTags = "DRAFTSPEC_EXCLUDE_TAGS";
+
+    /// <summary>
+    /// Environment variable name for name pattern filtering (regex).
+    /// Only specs matching this pattern will run.
+    /// </summary>
+    public const string FilterName = "DRAFTSPEC_FILTER_NAME";
+
+    /// <summary>
+    /// Environment variable name for name pattern exclusion (regex).
+    /// Specs matching this pattern will be skipped.
+    /// </summary>
+    public const string ExcludeName = "DRAFTSPEC_EXCLUDE_NAME";
+}

--- a/src/DraftSpec/Dsl.Run.cs
+++ b/src/DraftSpec/Dsl.Run.cs
@@ -12,37 +12,37 @@ public static partial class Dsl
     /// Environment variable name for CLI-based JSON output file path.
     /// When set, run() automatically adds a FileReporter to write JSON to this file.
     /// </summary>
-    public const string JsonOutputFileEnvVar = "DRAFTSPEC_JSON_OUTPUT_FILE";
+    public const string JsonOutputFileEnvVar = EnvironmentVariables.JsonOutputFile;
 
     /// <summary>
     /// Environment variable name for enabling progress streaming.
     /// When set to "true" or "1", run() adds a ProgressStreamReporter for MCP integration.
     /// </summary>
-    public const string ProgressStreamEnvVar = "DRAFTSPEC_PROGRESS_STREAM";
+    public const string ProgressStreamEnvVar = EnvironmentVariables.ProgressStream;
 
     /// <summary>
     /// Environment variable name for tag filtering (comma-separated).
     /// Only specs with any of these tags will run.
     /// </summary>
-    public const string FilterTagsEnvVar = "DRAFTSPEC_FILTER_TAGS";
+    public const string FilterTagsEnvVar = EnvironmentVariables.FilterTags;
 
     /// <summary>
     /// Environment variable name for tag exclusion (comma-separated).
     /// Specs with any of these tags will be skipped.
     /// </summary>
-    public const string ExcludeTagsEnvVar = "DRAFTSPEC_EXCLUDE_TAGS";
+    public const string ExcludeTagsEnvVar = EnvironmentVariables.ExcludeTags;
 
     /// <summary>
     /// Environment variable name for name pattern filtering (regex).
     /// Only specs matching this pattern will run.
     /// </summary>
-    public const string FilterNameEnvVar = "DRAFTSPEC_FILTER_NAME";
+    public const string FilterNameEnvVar = EnvironmentVariables.FilterName;
 
     /// <summary>
     /// Environment variable name for name pattern exclusion (regex).
     /// Specs matching this pattern will be skipped.
     /// </summary>
-    public const string ExcludeNameEnvVar = "DRAFTSPEC_EXCLUDE_NAME";
+    public const string ExcludeNameEnvVar = EnvironmentVariables.ExcludeName;
 
     /// <summary>
     /// Run all collected specs and output results.


### PR DESCRIPTION
## Summary
- Create `EnvironmentVariables` class in `DraftSpec.Formatters.Abstractions` with all environment variable constants
- Update `Dsl.Run.cs` and `SpecFileRunner.cs` to reference shared constants instead of duplicate literals
- Both projects already depend on the abstractions package, making it the ideal shared location

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)