### PR TITLE
refactor: Unify formatter interface hierarchy

### DIFF
--- a/src/DraftSpec.Formatters.Abstractions/IConsoleFormatter.cs
+++ b/src/DraftSpec.Formatters.Abstractions/IConsoleFormatter.cs
@@ -2,16 +2,20 @@ namespace DraftSpec.Formatters;
 
 /// <summary>
 /// Interface for formatters that write directly to console (supporting colors/styling).
-/// Unlike IFormatter which returns a string, IConsoleFormatter writes to a TextWriter
-/// to support ANSI color codes and interactive terminal features.
+/// Extends <see cref="IFormatter"/> with color support for interactive terminal output.
 /// </summary>
-public interface IConsoleFormatter
+/// <remarks>
+/// Use this interface when your formatter needs to output ANSI color codes or other
+/// terminal-specific features. The <see cref="Format(SpecReport, TextWriter, bool)"/> method
+/// provides control over whether colors are enabled.
+/// </remarks>
+public interface IConsoleFormatter : IFormatter
 {
     /// <summary>
-    /// Format and write a spec report to the provided TextWriter.
+    /// Format and write a spec report to the provided TextWriter with color control.
     /// </summary>
     /// <param name="report">The spec report to format</param>
     /// <param name="output">The TextWriter to write to (e.g., Console.Out)</param>
     /// <param name="useColors">Whether to include ANSI color codes</param>
-    void Format(SpecReport report, TextWriter output, bool useColors = true);
+    void Format(SpecReport report, TextWriter output, bool useColors);
 }

--- a/src/DraftSpec.Formatters.Abstractions/IFormatter.cs
+++ b/src/DraftSpec.Formatters.Abstractions/IFormatter.cs
@@ -3,12 +3,29 @@ namespace DraftSpec.Formatters;
 /// <summary>
 /// Interface for formatting spec reports into different output formats.
 /// </summary>
+/// <remarks>
+/// This is the base interface for all formatters. Implementations can override
+/// <see cref="Format(SpecReport, TextWriter)"/> for stream-based output, or just
+/// implement <see cref="Format(SpecReport)"/> and use the default stream implementation.
+/// </remarks>
 public interface IFormatter
 {
     /// <summary>
     /// Format a spec report into a string representation.
     /// </summary>
     string Format(SpecReport report);
+
+    /// <summary>
+    /// Format a spec report and write to the provided TextWriter.
+    /// </summary>
+    /// <remarks>
+    /// Default implementation calls <see cref="Format(SpecReport)"/> and writes the result.
+    /// Override for streaming output or when the formatter needs direct TextWriter access.
+    /// </remarks>
+    void Format(SpecReport report, TextWriter output)
+    {
+        output.Write(Format(report));
+    }
 
     /// <summary>
     /// The file extension typically used for this format (e.g., ".md", ".html").

--- a/src/DraftSpec.Formatters.Console/ConsoleFormatter.cs
+++ b/src/DraftSpec.Formatters.Console/ConsoleFormatter.cs
@@ -8,9 +8,32 @@ namespace DraftSpec.Formatters.Console;
 public class ConsoleFormatter : IConsoleFormatter
 {
     /// <summary>
-    /// Format and write a spec report to the provided TextWriter.
+    /// Console output doesn't have a typical file extension.
     /// </summary>
-    public void Format(SpecReport report, TextWriter output, bool useColors = true)
+    public string FileExtension => ".txt";
+
+    /// <summary>
+    /// Format a spec report to a string (without colors).
+    /// </summary>
+    public string Format(SpecReport report)
+    {
+        using var writer = new StringWriter();
+        Format(report, writer, useColors: false);
+        return writer.ToString();
+    }
+
+    /// <summary>
+    /// Format and write a spec report to the provided TextWriter (with colors by default).
+    /// </summary>
+    public void Format(SpecReport report, TextWriter output)
+    {
+        Format(report, output, useColors: true);
+    }
+
+    /// <summary>
+    /// Format and write a spec report to the provided TextWriter with color control.
+    /// </summary>
+    public void Format(SpecReport report, TextWriter output, bool useColors)
     {
         output.WriteLine();
 


### PR DESCRIPTION
## Summary
- Add `Format(SpecReport, TextWriter)` to `IFormatter` with default implementation that calls the string version
- Make `IConsoleFormatter` extend `IFormatter` for clear inheritance hierarchy
- Update `ConsoleFormatter` to implement the unified interface with `FileExtension`, `Format(string)`, and `Format(TextWriter)` methods

### Before
```
IFormatter          IConsoleFormatter
    │                      │
    ├── HtmlFormatter      └── ConsoleFormatter
    ├── JsonFormatter
    └── MarkdownFormatter
```

### After
```
IFormatter
    │
    ├── HtmlFormatter
    ├── JsonFormatter
    ├── MarkdownFormatter
    │
    └── IConsoleFormatter
            │
            └── ConsoleFormatter
```

This resolves the Interface Segregation Principle issue by creating a clear inheritance hierarchy.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)