### PR TITLE
feat: Add CancellationToken to ISpecRunner interface

### DIFF
--- a/src/DraftSpec/ISpecRunner.cs
+++ b/src/DraftSpec/ISpecRunner.cs
@@ -27,13 +27,15 @@ public interface ISpecRunner
     /// Runs all specs in the given spec class asynchronously.
     /// </summary>
     /// <param name="spec">The spec class instance containing the spec definitions.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <returns>Task that resolves to a list of results for each executed spec.</returns>
-    Task<List<SpecResult>> RunAsync(Spec spec);
+    Task<List<SpecResult>> RunAsync(Spec spec, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Runs all specs starting from the given root context asynchronously.
     /// </summary>
     /// <param name="rootContext">The root context of the spec tree.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <returns>Task that resolves to a list of results for each executed spec.</returns>
-    Task<List<SpecResult>> RunAsync(SpecContext rootContext);
+    Task<List<SpecResult>> RunAsync(SpecContext rootContext, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- Add `CancellationToken` parameter to `RunAsync` methods in `ISpecRunner` interface
- Pass token through context tree traversal with cancellation checks at key points
- Link external cancellation with bail cancellation in parallel execution using `CreateLinkedTokenSource`
- Properly propagate `OperationCanceledException` for external cancellation (vs bail which is handled internally)

This enables graceful cancellation of spec runs, useful for:
- IDE integration (stop button)
- Long-running test suites
- CI/CD timeout handling

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)