### PR TITLE
refactor: Introduce SpecSession abstraction to reduce static state

### DIFF
--- a/src/DraftSpec/Dsl.Configuration.cs
+++ b/src/DraftSpec/Dsl.Configuration.cs
@@ -4,19 +4,16 @@ namespace DraftSpec;
 
 public static partial class Dsl
 {
-    private static readonly AsyncLocal<SpecRunnerBuilder?> RunnerBuilderLocal = new();
-    private static readonly AsyncLocal<DraftSpecConfiguration?> ConfigurationLocal = new();
-
     internal static SpecRunnerBuilder? RunnerBuilder
     {
-        get => RunnerBuilderLocal.Value;
-        set => RunnerBuilderLocal.Value = value;
+        get => Session.RunnerBuilder;
+        set => Session.RunnerBuilder = value;
     }
 
     internal static DraftSpecConfiguration? Configuration
     {
-        get => ConfigurationLocal.Value;
-        set => ConfigurationLocal.Value = value;
+        get => Session.Configuration;
+        set => Session.Configuration = value;
     }
 
     /// <summary>

--- a/src/DraftSpec/Dsl.Run.cs
+++ b/src/DraftSpec/Dsl.Run.cs
@@ -123,21 +123,11 @@ public static partial class Dsl
         }
     }
 
-    private static void ResetState()
-    {
-        RootContext = null;
-        CurrentContext = null;
-        RunnerBuilder = null;
-        Configuration?.Dispose();
-        Configuration = null;
-    }
+    private static void ResetState() => Session.Reset();
 
     /// <summary>
     /// Reset all DSL state for a clean execution context.
     /// Used primarily for in-process execution modes.
     /// </summary>
-    public static void Reset()
-    {
-        ResetState();
-    }
+    public static void Reset() => Session.Reset();
 }

--- a/src/DraftSpec/Dsl.Tags.cs
+++ b/src/DraftSpec/Dsl.Tags.cs
@@ -1,18 +1,14 @@
-using DraftSpec.Internal;
-
 namespace DraftSpec;
 
 public static partial class Dsl
 {
-    private static readonly AsyncLocal<List<string>?> CurrentTagsLocal = new();
-
     /// <summary>
     /// Current tags in scope. Specs created within a tag() block inherit these tags.
     /// </summary>
     internal static List<string>? CurrentTags
     {
-        get => CurrentTagsLocal.Value;
-        set => CurrentTagsLocal.Value = value;
+        get => Session.CurrentTags;
+        set => Session.CurrentTags = value;
     }
 
     /// <summary>

--- a/src/DraftSpec/Dsl.cs
+++ b/src/DraftSpec/Dsl.cs
@@ -5,18 +5,23 @@ namespace DraftSpec;
 /// Usage: using static DraftSpec.Dsl;
 /// </summary>
 /// <remarks>
-/// This partial class contains state management.
+/// This partial class contains the session accessor and core state properties.
 /// See also: Dsl.Context.cs, Dsl.Specs.cs, Dsl.Hooks.cs, Dsl.Expect.cs, Dsl.Run.cs
 /// </remarks>
 public static partial class Dsl
 {
-    private static readonly AsyncLocal<SpecContext?> CurrentContextLocal = new();
-    private static readonly AsyncLocal<SpecContext?> RootContextLocal = new();
+    private static readonly AsyncLocal<SpecSession?> SessionLocal = new();
+
+    /// <summary>
+    /// Gets the current spec session for this async execution context.
+    /// A new session is created automatically if one doesn't exist.
+    /// </summary>
+    public static SpecSession Session => SessionLocal.Value ??= new SpecSession();
 
     internal static SpecContext? CurrentContext
     {
-        get => CurrentContextLocal.Value;
-        set => CurrentContextLocal.Value = value;
+        get => Session.CurrentContext;
+        set => Session.CurrentContext = value;
     }
 
     /// <summary>
@@ -25,7 +30,7 @@ public static partial class Dsl
     /// </summary>
     public static SpecContext? RootContext
     {
-        get => RootContextLocal.Value;
-        internal set => RootContextLocal.Value = value;
+        get => Session.RootContext;
+        internal set => Session.RootContext = value;
     }
 }

--- a/src/DraftSpec/SpecSession.cs
+++ b/src/DraftSpec/SpecSession.cs
@@ -1,0 +1,70 @@
+using DraftSpec.Configuration;
+
+namespace DraftSpec;
+
+/// <summary>
+/// Encapsulates all state for a spec execution session.
+/// Replaces scattered AsyncLocal fields with a single cohesive state container.
+/// </summary>
+/// <remarks>
+/// A SpecSession tracks:
+/// - The spec tree (RootContext, CurrentContext)
+/// - Tags being applied to specs (CurrentTags)
+/// - Execution configuration (RunnerBuilder, Configuration)
+///
+/// Each async execution context (CSX script, test method) gets its own session
+/// via the static Dsl.Session property which uses AsyncLocal for isolation.
+/// </remarks>
+public class SpecSession : IDisposable
+{
+    /// <summary>
+    /// Gets or sets the root context containing the spec tree.
+    /// Created when the first describe() block is executed.
+    /// </summary>
+    public SpecContext? RootContext { get; set; }
+
+    /// <summary>
+    /// Gets or sets the currently active context during spec tree construction.
+    /// Used by describe(), it(), before(), after() to know where to add specs/hooks.
+    /// </summary>
+    public SpecContext? CurrentContext { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current tags in scope.
+    /// Specs created within tag() blocks inherit these tags.
+    /// </summary>
+    public List<string>? CurrentTags { get; set; }
+
+    /// <summary>
+    /// Gets or sets the runner builder for configuring middleware.
+    /// </summary>
+    public SpecRunnerBuilder? RunnerBuilder { get; set; }
+
+    /// <summary>
+    /// Gets or sets the configuration for plugins, formatters, and reporters.
+    /// </summary>
+    public DraftSpecConfiguration? Configuration { get; set; }
+
+    /// <summary>
+    /// Resets all session state for a clean execution context.
+    /// Called after run() completes or when explicitly resetting.
+    /// </summary>
+    public void Reset()
+    {
+        RootContext = null;
+        CurrentContext = null;
+        CurrentTags = null;
+        RunnerBuilder = null;
+        Configuration?.Dispose();
+        Configuration = null;
+    }
+
+    /// <summary>
+    /// Disposes the session by resetting all state.
+    /// </summary>
+    public void Dispose()
+    {
+        Reset();
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
## Summary
Replace 5 scattered `AsyncLocal<T>` fields across 4 partial Dsl files with a single `AsyncLocal<SpecSession>` that encapsulates all execution state in one cohesive class.

**Changes:**
- Create `SpecSession` class with `RootContext`, `CurrentContext`, `CurrentTags`, `RunnerBuilder`, and `Configuration` properties
- Update `Dsl.cs` to use Session accessor pattern
- Update `Dsl.Configuration.cs` to delegate to Session
- Update `Dsl.Tags.cs` to delegate to Session
- Simplify `Dsl.Run.cs` `Reset()` to call `Session.Reset()`

**Bug fix:** `CurrentTags` is now properly reset (was missing from `ResetState()`)

**Benefits:**
- Single source of truth for all session state
- Centralized `Reset()` handles all state clearing
- Easier to extend (add state to SpecSession, Reset handles it)
- Better testability (can inject/mock sessions)
- New public `Dsl.Session` property for advanced scenarios

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)