### PR TITLE
fix: Resolve throw-lambda overload and thread-safe lazy init issues

### DIFF
--- a/examples/TodoApi/Specs/features_showcase.spec.csx
+++ b/examples/TodoApi/Specs/features_showcase.spec.csx
@@ -245,16 +245,16 @@ describe("3. Assertions", () =>
 
         it("toThrow<T> - returns exception for inspection", () =>
         {
-            var ex = expect(() => throw new InvalidOperationException("test error"))
-                .toThrow<InvalidOperationException>();
+            Action throwAction = () => throw new InvalidOperationException("test error");
+            var ex = expect(throwAction).toThrow<InvalidOperationException>();
 
             expect(ex.Message).toBe("test error");
         });
 
         it("toThrow - any exception", () =>
         {
-            var ex = expect(() => throw new Exception("something went wrong"))
-                .toThrow();
+            Action throwAction = () => throw new Exception("something went wrong");
+            var ex = expect(throwAction).toThrow();
 
             expect(ex.Message).toContain("wrong");
         });

--- a/src/DraftSpec/Middleware/SpecExecutionContext.cs
+++ b/src/DraftSpec/Middleware/SpecExecutionContext.cs
@@ -46,8 +46,15 @@ public class SpecExecutionContext
     /// Uses ConcurrentDictionary for safe parallel access.
     /// Lazy-initialized to avoid allocation when not used.
     /// </summary>
-    public ConcurrentDictionary<string, object> Items =>
-        _items ??= new ConcurrentDictionary<string, object>();
+    public ConcurrentDictionary<string, object> Items
+    {
+        get
+        {
+            if (_items is not null) return _items;
+            Interlocked.CompareExchange(ref _items, new ConcurrentDictionary<string, object>(), null);
+            return _items;
+        }
+    }
 
     /// <summary>
     /// Returns true if Items has been accessed and contains data.


### PR DESCRIPTION
## Summary
Two fixes discovered while verifying example specs:

### 1. Example fix: Throw-only lambda overload resolution
C# overload resolution incorrectly inferred `() => throw new Exception()` as `Func<Task>` instead of `Action`.

**Problem:**
```csharp
// Incorrectly resolved to AsyncActionExpectation
expect(() => throw new Exception("error")).toThrow();
```

**Solution:**
```csharp
// Explicit Action type ensures correct overload
Action throwAction = () => throw new Exception("error");
expect(throwAction).toThrow();
```

### 2. Thread-safety fix: Lazy Items initialization
The `??=` operator is not thread-safe for concurrent first-access of `SpecExecutionContext.Items`.

**Problem:**
```csharp
// Race condition: multiple threads could create separate dictionaries
public ConcurrentDictionary<string, object> Items =>
    _items ??= new ConcurrentDictionary<string, object>();
```

**Solution:**
```csharp
// Atomic compare-exchange ensures single-instance guarantee
public ConcurrentDictionary<string, object> Items
{
    get
    {
        if (_items is not null) return _items;
        Interlocked.CompareExchange(ref _items, new ConcurrentDictionary<string, object>(), null);
        return _items;
    }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)