### PR TITLE
fix: surface spec discovery errors through MTP as error nodes

### DIFF
--- a/src/DraftSpec.TestingPlatform/DiscoveryError.cs
+++ b/src/DraftSpec.TestingPlatform/DiscoveryError.cs
@@ -1,0 +1,42 @@
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Represents an error that occurred during spec discovery.
+/// </summary>
+/// <remarks>
+/// Discovery errors typically occur when a CSX file fails to compile
+/// (e.g., missing methods, syntax errors, missing references).
+/// These are surfaced as failed test nodes in the MTP UI.
+/// </remarks>
+public sealed class DiscoveryError
+{
+    /// <summary>
+    /// Absolute path to the source file that failed.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Relative path to the source file from the project root.
+    /// </summary>
+    public required string RelativeSourceFile { get; init; }
+
+    /// <summary>
+    /// The error message from the compiler or runtime.
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// The full exception that caused the error, if available.
+    /// </summary>
+    public Exception? Exception { get; init; }
+
+    /// <summary>
+    /// Generates a stable ID for this error node.
+    /// </summary>
+    public string Id => $"{RelativeSourceFile}:DISCOVERY_ERROR";
+
+    /// <summary>
+    /// Display name for the error node.
+    /// </summary>
+    public string DisplayName => $"[Discovery Error] {RelativeSourceFile}";
+}

--- a/src/DraftSpec.TestingPlatform/DiscoveryResult.cs
+++ b/src/DraftSpec.TestingPlatform/DiscoveryResult.cs
@@ -1,0 +1,27 @@
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Result of spec discovery, containing both discovered specs and any errors.
+/// </summary>
+public sealed class DiscoveryResult
+{
+    /// <summary>
+    /// Successfully discovered specs.
+    /// </summary>
+    public IReadOnlyList<DiscoveredSpec> Specs { get; init; } = [];
+
+    /// <summary>
+    /// Errors that occurred during discovery.
+    /// </summary>
+    public IReadOnlyList<DiscoveryError> Errors { get; init; } = [];
+
+    /// <summary>
+    /// True if there were any discovery errors.
+    /// </summary>
+    public bool HasErrors => Errors.Count > 0;
+
+    /// <summary>
+    /// Total count of specs plus errors (for UI display).
+    /// </summary>
+    public int TotalCount => Specs.Count + Errors.Count;
+}

--- a/src/DraftSpec.TestingPlatform/TestNodeMapper.cs
+++ b/src/DraftSpec.TestingPlatform/TestNodeMapper.cs
@@ -102,6 +102,28 @@ internal static class TestNodeMapper
     }
 
     /// <summary>
+    /// Creates a TestNode for a discovery error (failed compilation or script error).
+    /// </summary>
+    public static TestNode CreateErrorNode(DiscoveryError error)
+    {
+        var stateProperty = new ErrorTestNodeStateProperty(
+            error.Exception ?? new Exception(error.Message),
+            error.Message);
+
+        var propertyList = new List<IProperty> { stateProperty };
+
+        // Add file location pointing to line 1 of the failed file
+        propertyList.Add(CreateFileLocationProperty(error.SourceFile, 1));
+
+        return new TestNode
+        {
+            Uid = new TestNodeUid(error.Id),
+            DisplayName = error.DisplayName,
+            Properties = new PropertyBag(propertyList.ToArray())
+        };
+    }
+
+    /// <summary>
     /// Gets the appropriate state property for a spec result.
     /// </summary>
     private static TestNodeStateProperty GetStateProperty(SpecResult result)


### PR DESCRIPTION
## Summary
- Previously, compilation failures during spec discovery were only logged to Console.Error and were easy to miss by both users and AI agents
- Discovery errors now appear as failed tests in the IDE test explorer, making compilation issues immediately visible

## Changes
- Add `DiscoveryError` to represent compilation/script execution failures
- Add `DiscoveryResult` to return both specs and errors from discovery
- Update `SpecDiscoverer` to collect errors instead of writing to Console.Error
- Add `TestNodeMapper.CreateErrorNode()` to create error-state test nodes
- Update `DraftSpecTestFramework` to publish errors via IMessageBus

## Test plan
- [x] Build succeeds
- [x] All 1656 tests pass including new tests for error collection
- [ ] Verify in IDE that discovery errors appear as failed test nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)