### PR TITLE
fix: use FailedTestNodeStateProperty for discovery errors in IDE

### DIFF
--- a/src/DraftSpec.TestingPlatform/TestNodeMapper.cs
+++ b/src/DraftSpec.TestingPlatform/TestNodeMapper.cs
@@ -106,7 +106,9 @@ internal static class TestNodeMapper
     /// </summary>
     public static TestNode CreateErrorNode(DiscoveryError error)
     {
-        var stateProperty = new ErrorTestNodeStateProperty(
+        // Use FailedTestNodeStateProperty (not ErrorTestNodeStateProperty) so IDEs
+        // display discovery errors as failed tests in the test explorer
+        var stateProperty = new FailedTestNodeStateProperty(
             error.Exception ?? new Exception(error.Message),
             error.Message);
 


### PR DESCRIPTION
## Summary
- Use `FailedTestNodeStateProperty` instead of `ErrorTestNodeStateProperty` so that discovery errors appear as failed tests in IDE test explorers (Rider, VS)
- `ErrorTestNodeStateProperty` is for infrastructure errors and may not be displayed prominently in some IDEs

## Test plan
- [x] All tests pass
- [ ] Verify discovery errors appear as failed tests in Rider test explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)