### PR TITLE
feat: Static CSX parsing for spec discovery from broken files

### DIFF
--- a/src/DraftSpec.TestingPlatform/DiscoveredSpec.cs
+++ b/src/DraftSpec.TestingPlatform/DiscoveredSpec.cs
@@ -78,6 +78,17 @@ public sealed class DiscoveredSpec
     public int LineNumber { get; init; }
 
     /// <summary>
+    /// Compilation error message if this spec was discovered via static parsing
+    /// from a file that failed to compile. Null for normally discovered specs.
+    /// </summary>
+    public string? CompilationError { get; init; }
+
+    /// <summary>
+    /// True if this spec has a compilation error and cannot be executed.
+    /// </summary>
+    public bool HasCompilationError => CompilationError != null;
+
+    /// <summary>
     /// Reference to the original spec definition for execution.
     /// </summary>
     internal SpecDefinition? SpecDefinition { get; init; }

--- a/src/DraftSpec.TestingPlatform/SpecSyntaxWalker.cs
+++ b/src/DraftSpec.TestingPlatform/SpecSyntaxWalker.cs
@@ -1,0 +1,199 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Roslyn syntax walker that discovers spec definitions by analyzing syntax trees.
+/// </summary>
+/// <remarks>
+/// This walker finds describe/context/it/fit/xit method calls without executing the code,
+/// allowing spec discovery even when files have compilation errors.
+/// </remarks>
+internal sealed class SpecSyntaxWalker : CSharpSyntaxWalker
+{
+    private readonly Stack<string> _contextStack = new();
+    private readonly List<StaticSpec> _specs = [];
+    private readonly List<string> _warnings = [];
+    private bool _isComplete = true;
+
+    /// <summary>
+    /// Gets the discovered specs.
+    /// </summary>
+    public IReadOnlyList<StaticSpec> Specs => _specs;
+
+    /// <summary>
+    /// Gets warnings about patterns that couldn't be fully analyzed.
+    /// </summary>
+    public IReadOnlyList<string> Warnings => _warnings;
+
+    /// <summary>
+    /// Gets whether all spec patterns were successfully analyzed.
+    /// </summary>
+    public bool IsComplete => _isComplete;
+
+    public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+    {
+        var methodName = GetMethodName(node);
+
+        if (methodName is "describe" or "context" or "fdescribe" or "xdescribe")
+        {
+            ProcessDescribeBlock(node, methodName);
+            return; // Don't auto-descend - we manually visit the lambda
+        }
+
+        if (methodName is "it" or "fit" or "xit")
+        {
+            ProcessSpecDefinition(node, methodName);
+            return; // Don't descend into spec body
+        }
+
+        // Continue normal traversal for other invocations
+        base.VisitInvocationExpression(node);
+    }
+
+    private void ProcessDescribeBlock(InvocationExpressionSyntax node, string methodName)
+    {
+        var arguments = node.ArgumentList.Arguments;
+        if (arguments.Count < 1)
+        {
+            AddWarning(node, $"'{methodName}' call missing description argument");
+            return;
+        }
+
+        // Extract description from first argument
+        var description = ExtractStringLiteral(arguments[0].Expression);
+        if (description == null)
+        {
+            AddWarning(node, $"'{methodName}' has dynamic description - cannot analyze statically");
+            _isComplete = false;
+            // Still try to visit children in case there are nested specs we can find
+            description = $"<dynamic at line {GetLineNumber(node)}>";
+        }
+
+        _contextStack.Push(description);
+
+        // Find and visit the lambda body (second argument)
+        if (arguments.Count >= 2)
+        {
+            var lambdaArg = arguments[1].Expression;
+            VisitLambdaBody(lambdaArg);
+        }
+
+        _contextStack.Pop();
+    }
+
+    private void ProcessSpecDefinition(InvocationExpressionSyntax node, string methodName)
+    {
+        var arguments = node.ArgumentList.Arguments;
+        if (arguments.Count < 1)
+        {
+            AddWarning(node, $"'{methodName}' call missing description argument");
+            return;
+        }
+
+        // Extract description from first argument
+        var description = ExtractStringLiteral(arguments[0].Expression);
+        if (description == null)
+        {
+            AddWarning(node, $"'{methodName}' has dynamic description - cannot analyze statically");
+            _isComplete = false;
+            return; // Skip specs with dynamic descriptions
+        }
+
+        var specType = methodName switch
+        {
+            "fit" => StaticSpecType.Focused,
+            "xit" => StaticSpecType.Skipped,
+            _ => StaticSpecType.Regular
+        };
+
+        // Check if pending (no body argument)
+        var isPending = arguments.Count == 1;
+
+        _specs.Add(new StaticSpec
+        {
+            Description = description,
+            ContextPath = _contextStack.Reverse().ToList(),
+            LineNumber = GetLineNumber(node),
+            Type = specType,
+            IsPending = isPending
+        });
+    }
+
+    private void VisitLambdaBody(ExpressionSyntax expression)
+    {
+        switch (expression)
+        {
+            case ParenthesizedLambdaExpressionSyntax lambda:
+                if (lambda.Body != null)
+                {
+                    Visit(lambda.Body);
+                }
+                break;
+
+            case SimpleLambdaExpressionSyntax simpleLambda:
+                if (simpleLambda.Body != null)
+                {
+                    Visit(simpleLambda.Body);
+                }
+                break;
+
+            case AnonymousMethodExpressionSyntax anonymousMethod:
+                if (anonymousMethod.Body != null)
+                {
+                    Visit(anonymousMethod.Body);
+                }
+                break;
+
+            case IdentifierNameSyntax:
+                // Method group - can't analyze
+                _isComplete = false;
+                break;
+        }
+    }
+
+    private static string? ExtractStringLiteral(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            // Simple string literal: "description"
+            LiteralExpressionSyntax { RawKind: (int)SyntaxKind.StringLiteralExpression } literal
+                => literal.Token.ValueText,
+
+            // Verbatim string: @"description"
+            LiteralExpressionSyntax { Token.RawKind: (int)SyntaxKind.StringLiteralToken } verbatim
+                => verbatim.Token.ValueText,
+
+            // Parenthesized: ("description")
+            ParenthesizedExpressionSyntax paren
+                => ExtractStringLiteral(paren.Expression),
+
+            // For interpolated strings, const expressions, etc. - return null
+            _ => null
+        };
+    }
+
+    private static string? GetMethodName(InvocationExpressionSyntax node)
+    {
+        return node.Expression switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.Text,
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.Text,
+            _ => null
+        };
+    }
+
+    private static int GetLineNumber(SyntaxNode node)
+    {
+        // Returns 1-based line number
+        return node.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+    }
+
+    private void AddWarning(SyntaxNode node, string message)
+    {
+        var lineNumber = GetLineNumber(node);
+        _warnings.Add($"Line {lineNumber}: {message}");
+    }
+}

--- a/src/DraftSpec.TestingPlatform/StaticParseResult.cs
+++ b/src/DraftSpec.TestingPlatform/StaticParseResult.cs
@@ -1,0 +1,31 @@
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Result of statically parsing a CSX spec file.
+/// </summary>
+/// <remarks>
+/// Contains specs discovered via syntax tree analysis, along with
+/// any warnings about patterns that couldn't be fully analyzed
+/// (e.g., dynamic descriptions, loop-generated specs).
+/// </remarks>
+public sealed class StaticParseResult
+{
+    /// <summary>
+    /// Specs discovered via static parsing.
+    /// </summary>
+    public IReadOnlyList<StaticSpec> Specs { get; init; } = [];
+
+    /// <summary>
+    /// Warnings about patterns that couldn't be fully analyzed.
+    /// </summary>
+    /// <remarks>
+    /// Examples: dynamic descriptions, loop-generated specs, conditional specs.
+    /// </remarks>
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+
+    /// <summary>
+    /// True if all spec patterns in the file were successfully analyzed.
+    /// False if some patterns couldn't be parsed (dynamic descriptions, loops, etc.).
+    /// </summary>
+    public bool IsComplete { get; init; } = true;
+}

--- a/src/DraftSpec.TestingPlatform/StaticSpec.cs
+++ b/src/DraftSpec.TestingPlatform/StaticSpec.cs
@@ -1,0 +1,52 @@
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Type of spec (normal, focused, or skipped).
+/// </summary>
+public enum StaticSpecType
+{
+    /// <summary>Regular spec (it).</summary>
+    Regular,
+
+    /// <summary>Focused spec (fit).</summary>
+    Focused,
+
+    /// <summary>Skipped spec (xit).</summary>
+    Skipped
+}
+
+/// <summary>
+/// Represents a spec discovered via static syntax parsing.
+/// </summary>
+/// <remarks>
+/// Static specs are discovered by parsing CSX files without execution.
+/// This allows discovering spec structure even when files have compilation errors.
+/// </remarks>
+public sealed class StaticSpec
+{
+    /// <summary>
+    /// The spec description (the "it should..." text).
+    /// </summary>
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// The context path as a list of context descriptions.
+    /// Does not include the spec description itself.
+    /// </summary>
+    public required IReadOnlyList<string> ContextPath { get; init; }
+
+    /// <summary>
+    /// Line number in the source file where this spec was defined (1-based).
+    /// </summary>
+    public required int LineNumber { get; init; }
+
+    /// <summary>
+    /// The type of spec (regular, focused, or skipped).
+    /// </summary>
+    public required StaticSpecType Type { get; init; }
+
+    /// <summary>
+    /// True if the spec has no body (placeholder for future implementation).
+    /// </summary>
+    public bool IsPending { get; init; }
+}

--- a/src/DraftSpec.TestingPlatform/StaticSpecParser.cs
+++ b/src/DraftSpec.TestingPlatform/StaticSpecParser.cs
@@ -1,0 +1,151 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Parses CSX spec files using static syntax analysis (no execution).
+/// </summary>
+/// <remarks>
+/// This parser discovers spec structure by analyzing Roslyn syntax trees,
+/// allowing discovery even when files have compilation errors.
+/// </remarks>
+internal sealed partial class StaticSpecParser
+{
+    private readonly string _baseDirectory;
+
+    /// <summary>
+    /// Regex to match #load directives for file includes.
+    /// </summary>
+    [GeneratedRegex(@"^\s*#load\s+""([^""]+)""\s*$", RegexOptions.Multiline)]
+    private static partial Regex LoadDirectiveRegex();
+
+    /// <summary>
+    /// Creates a new static spec parser.
+    /// </summary>
+    /// <param name="baseDirectory">Base directory for resolving relative paths.</param>
+    public StaticSpecParser(string baseDirectory)
+    {
+        _baseDirectory = baseDirectory;
+    }
+
+    /// <summary>
+    /// Parses a CSX file and returns discovered specs.
+    /// </summary>
+    /// <param name="csxFilePath">Path to the CSX spec file.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing discovered specs and any warnings.</returns>
+    public async Task<StaticParseResult> ParseFileAsync(
+        string csxFilePath,
+        CancellationToken cancellationToken = default)
+    {
+        var absolutePath = Path.GetFullPath(csxFilePath, _baseDirectory);
+
+        if (!File.Exists(absolutePath))
+        {
+            return new StaticParseResult
+            {
+                Specs = [],
+                Warnings = [$"File not found: {absolutePath}"],
+                IsComplete = false
+            };
+        }
+
+        try
+        {
+            // Get combined source with #load files inlined
+            var combinedSource = await GetCombinedSourceAsync(absolutePath, cancellationToken);
+
+            // Parse the syntax tree (without compilation)
+            var syntaxTree = CSharpSyntaxTree.ParseText(
+                combinedSource,
+                CSharpParseOptions.Default.WithKind(Microsoft.CodeAnalysis.SourceCodeKind.Script),
+                cancellationToken: cancellationToken);
+
+            // Walk the tree to find specs
+            var walker = new SpecSyntaxWalker();
+            walker.Visit(syntaxTree.GetRoot(cancellationToken));
+
+            return new StaticParseResult
+            {
+                Specs = walker.Specs,
+                Warnings = walker.Warnings,
+                IsComplete = walker.IsComplete
+            };
+        }
+        catch (Exception ex)
+        {
+            return new StaticParseResult
+            {
+                Specs = [],
+                Warnings = [$"Failed to parse: {ex.Message}"],
+                IsComplete = false
+            };
+        }
+    }
+
+    /// <summary>
+    /// Gets the combined source with #load files inlined.
+    /// </summary>
+    private async Task<string> GetCombinedSourceAsync(
+        string absolutePath,
+        CancellationToken cancellationToken)
+    {
+        var processedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var codeBuilder = new StringBuilder();
+
+        await ProcessFileAsync(absolutePath, processedFiles, codeBuilder, cancellationToken);
+
+        return codeBuilder.ToString();
+    }
+
+    /// <summary>
+    /// Recursively processes a CSX file and its #load dependencies.
+    /// </summary>
+    private async Task ProcessFileAsync(
+        string filePath,
+        HashSet<string> processedFiles,
+        StringBuilder codeBuilder,
+        CancellationToken cancellationToken)
+    {
+        var absolutePath = Path.GetFullPath(filePath);
+
+        // Prevent circular dependencies
+        if (!processedFiles.Add(absolutePath))
+        {
+            return;
+        }
+
+        string content;
+        try
+        {
+            content = await File.ReadAllTextAsync(absolutePath, cancellationToken);
+        }
+        catch
+        {
+            // Skip files that can't be read
+            return;
+        }
+
+        var fileDirectory = Path.GetDirectoryName(absolutePath)!;
+
+        // Process #load directives first (inline the loaded files)
+        var loadMatches = LoadDirectiveRegex().Matches(content);
+        foreach (Match match in loadMatches)
+        {
+            var loadPath = match.Groups[1].Value;
+            var loadAbsolutePath = Path.GetFullPath(loadPath, fileDirectory);
+
+            // Recursively process the loaded file
+            await ProcessFileAsync(loadAbsolutePath, processedFiles, codeBuilder, cancellationToken);
+        }
+
+        // Remove #load and #r directives from code (they're not valid in parsed source)
+        var cleanedCode = LoadDirectiveRegex().Replace(content, "");
+        cleanedCode = Regex.Replace(cleanedCode, @"^\s*#r\s+""[^""]+"".*$", "", RegexOptions.Multiline);
+
+        // Append the code (keep usings and other directives for proper parsing)
+        codeBuilder.AppendLine(cleanedCode);
+    }
+}

--- a/tests/DraftSpec.Tests/TestingPlatform/StaticSpecParserTests.cs
+++ b/tests/DraftSpec.Tests/TestingPlatform/StaticSpecParserTests.cs
@@ -1,0 +1,323 @@
+using DraftSpec.TestingPlatform;
+
+namespace DraftSpec.Tests.TestingPlatform;
+
+public class StaticSpecParserTests
+{
+    private string _tempDir = null!;
+
+    [Before(Test)]
+    public void Setup()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"draftspec_static_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [After(Test)]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ParseFileAsync_FindsSimpleSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+            describe("Calculator", () =>
+            {
+                it("adds numbers", () => { });
+                it("subtracts numbers", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "calc.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var parser = new StaticSpecParser(_tempDir);
+
+        // Act
+        var result = await parser.ParseFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.Specs.Count).IsEqualTo(2);
+        await Assert.That(result.Specs[0].Description).IsEqualTo("adds numbers");
+        await Assert.That(result.Specs[1].Description).IsEqualTo("subtracts numbers");
+        await Assert.That(result.IsComplete).IsTrue();
+    }
+
+    [Test]
+    public async Task ParseFileAsync_CapturesContextPath()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+            describe("Parent", () =>
+            {
+                describe("Child", () =>
+                {
+                    it("grandchild spec", () => { });
+                });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "nested.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var parser = new StaticSpecParser(_tempDir);
+
+        // Act
+        var result = await parser.ParseFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.Specs.Count).IsEqualTo(1);
+        await Assert.That(result.Specs[0].ContextPath.Count).IsEqualTo(2);
+        await Assert.That(result.Specs[0].ContextPath[0]).IsEqualTo("Parent");
+        await Assert.That(result.Specs[0].ContextPath[1]).IsEqualTo("Child");
+    }
+
+    [Test]
+    public async Task ParseFileAsync_IdentifiesFocusedSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+            describe("Focused", () =>
+            {
+                it("normal spec", () => { });
+                fit("focused spec", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "focused.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var parser = new StaticSpecParser(_tempDir);
+
+        // Act
+        var result = await parser.ParseFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.Specs.Count).IsEqualTo(2);
+        await Assert.That(result.Specs[0].Type).IsEqualTo(StaticSpecType.Regular);
+        await Assert.That(result.Specs[1].Type).IsEqualTo(StaticSpecType.Focused);
+    }
+
+    [Test]
+    public async Task ParseFileAsync_IdentifiesSkippedSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+            describe("Skipped", () =>
+            {
+                it("normal spec", () => { });
+                xit("skipped spec", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "skipped.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var parser = new StaticSpecParser(_tempDir);
+
+        // Act
+        var result = await parser.ParseFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.Specs.Count).IsEqualTo(2);
+        await Assert.That(result.Specs[0].Type).IsEqualTo(StaticSpecType.Regular);
+        await Assert.That(result.Specs[1].Type).IsEqualTo(StaticSpecType.Skipped);
+    }
+
+    [Test]
+    public async Task ParseFileAsync_IdentifiesPendingSpecs()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+            describe("Pending", () =>
+            {
+                it("implemented spec", () => { });
+                it("pending spec without body");
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "pending.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var parser = new StaticSpecParser(_tempDir);
+
+        // Act
+        var result = await parser.ParseFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.Specs.Count).IsEqualTo(2);
+        await Assert.That(result.Specs[0].IsPending).IsFalse();
+        await Assert.That(result.Specs[1].IsPending).IsTrue();
+    }
+
+    [Test]
+    public async Task ParseFileAsync_CapturesLineNumbers()
+    {
+        // Arrange
+        var csxContent = """
+            using static DraftSpec.Dsl;
+            describe("Test", () =>
+            {
+                it("first spec", () => { });
+                it("second spec", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "lines.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var parser = new StaticSpecParser(_tempDir);
+
+        // Act
+        var result = await parser.ParseFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.Specs.Count).IsEqualTo(2);
+        await Assert.That(result.Specs[0].LineNumber).IsGreaterThan(0);
+        await Assert.That(result.Specs[1].LineNumber).IsGreaterThan(result.Specs[0].LineNumber);
+    }
+
+    [Test]
+    public async Task ParseFileAsync_ParsesFileWithCompilationError()
+    {
+        // Arrange - file with invalid code
+        var csxContent = """
+            using static DraftSpec.Dsl;
+            describe("Broken", () =>
+            {
+                it("has error", () =>
+                {
+                    thisMethodDoesNotExist();
+                });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "broken.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var parser = new StaticSpecParser(_tempDir);
+
+        // Act
+        var result = await parser.ParseFileAsync(csxPath);
+
+        // Assert - should still find the spec structure
+        await Assert.That(result.Specs.Count).IsEqualTo(1);
+        await Assert.That(result.Specs[0].Description).IsEqualTo("has error");
+        await Assert.That(result.Specs[0].ContextPath[0]).IsEqualTo("Broken");
+    }
+
+    [Test]
+    public async Task ParseFileAsync_WarnsOnDynamicDescriptions()
+    {
+        // Arrange - file with interpolated string description
+        var csxContent = """
+            using static DraftSpec.Dsl;
+            var name = "test";
+            describe("Static context", () =>
+            {
+                it($"dynamic {name}", () => { });
+                it("static spec", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "dynamic.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var parser = new StaticSpecParser(_tempDir);
+
+        // Act
+        var result = await parser.ParseFileAsync(csxPath);
+
+        // Assert - should find the static spec and warn about dynamic one
+        await Assert.That(result.Specs.Count).IsEqualTo(1);
+        await Assert.That(result.Specs[0].Description).IsEqualTo("static spec");
+        await Assert.That(result.IsComplete).IsFalse();
+        await Assert.That(result.Warnings.Count).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task ParseFileAsync_HandlesLoadDirectives()
+    {
+        // Arrange
+        var helperContent = """
+            using static DraftSpec.Dsl;
+            // Helper file
+            """;
+
+        var helperPath = Path.Combine(_tempDir, "helper.csx");
+        await File.WriteAllTextAsync(helperPath, helperContent);
+
+        var csxContent = """
+            #load "helper.csx"
+            using static DraftSpec.Dsl;
+            describe("Main", () =>
+            {
+                it("uses helper", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "main.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var parser = new StaticSpecParser(_tempDir);
+
+        // Act
+        var result = await parser.ParseFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.Specs.Count).IsEqualTo(1);
+        await Assert.That(result.Specs[0].Description).IsEqualTo("uses helper");
+    }
+
+    [Test]
+    public async Task ParseFileAsync_HandlesContextAlias()
+    {
+        // Arrange - context is an alias for describe
+        var csxContent = """
+            using static DraftSpec.Dsl;
+            context("Feature", () =>
+            {
+                it("works", () => { });
+            });
+            """;
+
+        var csxPath = Path.Combine(_tempDir, "context.spec.csx");
+        await File.WriteAllTextAsync(csxPath, csxContent);
+
+        var parser = new StaticSpecParser(_tempDir);
+
+        // Act
+        var result = await parser.ParseFileAsync(csxPath);
+
+        // Assert
+        await Assert.That(result.Specs.Count).IsEqualTo(1);
+        await Assert.That(result.Specs[0].ContextPath[0]).IsEqualTo("Feature");
+    }
+
+    [Test]
+    public async Task ParseFileAsync_FileNotFound_ReturnsEmptyWithWarning()
+    {
+        // Arrange
+        var nonExistentPath = Path.Combine(_tempDir, "nonexistent.spec.csx");
+        var parser = new StaticSpecParser(_tempDir);
+
+        // Act
+        var result = await parser.ParseFileAsync(nonExistentPath);
+
+        // Assert
+        await Assert.That(result.Specs.Count).IsEqualTo(0);
+        await Assert.That(result.IsComplete).IsFalse();
+        await Assert.That(result.Warnings.Count).IsGreaterThan(0);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Roslyn-based static parsing to discover spec structure without executing CSX files. When a file fails to compile, falls back to parsing the syntax tree to extract describe/context/it blocks.

This allows Rider and other IDEs to:
- Show specs from files that don't compile
- Navigate to spec definitions in broken files  
- Display compilation error messages alongside specs

## Changes

- Add `StaticSpec`, `StaticParseResult` models for statically-discovered specs
- Add `SpecSyntaxWalker` (CSharpSyntaxWalker) to find spec invocations
- Add `StaticSpecParser` to parse CSX files without execution
- Add `CompilationError` property to `DiscoveredSpec` for tracking broken files
- Update `SpecDiscoverer` to fallback to static parsing on compilation errors
- Update `TestNodeMapper` to show specs with errors as failed tests
- Update `DraftSpecTestFramework` to report broken specs without execution

## Test plan

- [x] Run existing SpecDiscovererTests (updated for new behavior)
- [x] Add 11 new tests for StaticSpecParser
- [x] All 1667 tests pass
- [ ] Test in Rider with broken.spec.csx to verify IDE integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)