### PR TITLE
docs: Rewrite README for .NET 10 and CLI-first approach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-DraftSpec is an RSpec-inspired testing framework for .NET 10, filling the gap left by abandoned frameworks like NSpec. Supports both CSX scripts (recommended) and class-based specs.
+DraftSpec is an RSpec-inspired BDD testing framework for .NET 10, filling the gap left by abandoned frameworks like NSpec. Run specs via the CLI tool (`draftspec run`) or `dotnet test` with MTP integration.
 
 ## Build and Test Commands
 
@@ -12,8 +12,9 @@ DraftSpec is an RSpec-inspired testing framework for .NET 10, filling the gap le
 dotnet build                                          # Build all projects
 dotnet run --project tests/DraftSpec.Tests            # Run TUnit tests
 
-# Run CSX specs
-cd examples/TodoApi && dotnet script Specs/features_showcase.spec.csx
+# Run specs via CLI
+draftspec run examples/TodoApi/Specs                  # Run all specs in directory
+draftspec run examples/TodoApi/Specs/TodoService.spec.csx  # Run single file
 ```
 
 ## Project Structure
@@ -22,15 +23,17 @@ cd examples/TodoApi && dotnet script Specs/features_showcase.spec.csx
 DraftSpec.sln
 src/
   DraftSpec/                      # Core library
-    Dsl.cs                        # Static DSL for CSX: describe/it/expect
+    Dsl.cs                        # Static DSL: describe/it/expect
     Spec.cs                       # Class-based DSL (alternative)
     Expectations/                 # Jest-style assertions (Expectation<T>, etc.)
     SpecContext.cs                # Nested block with children, specs, hooks
     SpecDefinition.cs             # Single spec: description, body, flags
     SpecResult.cs                 # Execution result with ContextPath
     SpecRunner.cs                 # Tree walker, executes specs
-  DraftSpec.Cli/                  # CLI tool (dotnet tool)
-  DraftSpec.Formatters.*/         # Output formatters (Console, Html, Markdown)
+  DraftSpec.Cli/                  # CLI tool: draftspec run/watch/list
+  DraftSpec.TestingPlatform/      # MTP adapter for dotnet test integration
+  DraftSpec.Mcp/                  # MCP server for AI-assisted testing
+  DraftSpec.Formatters.*/         # Output formatters (Console, Html, Markdown, Json)
 examples/
   TodoApi/                        # Comprehensive example project
     spec_helper.csx               # Shared setup + fixtures
@@ -43,7 +46,7 @@ tests/
   DraftSpec.Tests/                # TUnit tests for internals
 ```
 
-## CSX Specs (Recommended)
+## Spec File Format
 
 ```csharp
 // TodoService.spec.csx
@@ -67,7 +70,7 @@ describe("TodoService", () =>
 });
 ```
 
-Run with: `draftspec run Specs/TodoService.spec.csx`
+Run with: `draftspec run TodoService.spec.csx`
 
 ## Assertions (expect API)
 


### PR DESCRIPTION
## Summary

Complete rewrite of README.md to accurately reflect DraftSpec's current state:

### Key Changes

**Removed:**
- All `dotnet-script` references (no longer the recommended approach)
- `.NET 8+` requirement - now just `.NET 10 SDK`
- `run()` call from examples (specs are declarative now)
- "built in roughly a day with AI assistance" from Status section
- Detailed MCP examples (moved to docs)
- Middleware & Plugins section (linked to docs instead)

**Updated:**
- **Requirements**: Single clear requirement - .NET 10 SDK
- **Quick Start**: CLI tool (`draftspec run`) as primary method, `dotnet test` as secondary
- **Status**: "Alpha (v0.4.x) - Core functionality is stable with 2000+ tests and 80%+ coverage"
- **Structure**: Cleaner, more scannable sections

**CLAUDE.md alignment:**
- Updated Project Overview to mention CLI and MTP
- Changed build commands to use `draftspec run`
- Added TestingPlatform and Mcp to project structure
- Renamed "CSX Specs (Recommended)" to "Spec File Format"

### Before/After

| Aspect | Before | After |
|--------|--------|-------|
| .NET version | ".NET 8+ for CSX scripts, or .NET 10+" | ".NET 10 SDK" |
| Primary method | `dotnet script` | `draftspec run` |
| Secondary method | buried MTP section | Prominent `dotnet test` option |
| Examples | Included `run()` call | Declarative (no `run()`) |
| Status | "built in roughly a day" | "2000+ tests and 80%+ coverage" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)