### PR TITLE
feat(cli): Add draftspec validate --static command

### DIFF
--- a/src/DraftSpec.Cli/CliOptions.cs
+++ b/src/DraftSpec.Cli/CliOptions.cs
@@ -115,6 +115,26 @@ public class CliOptions
     /// </summary>
     public bool SkippedOnly { get; set; }
 
+    // Validate command options
+
+    /// <summary>
+    /// Treat warnings as errors (exit code 2 instead of 0).
+    /// Used with validate command.
+    /// </summary>
+    public bool Strict { get; set; }
+
+    /// <summary>
+    /// Show only errors, suppress progress and warnings.
+    /// Used with validate command.
+    /// </summary>
+    public bool Quiet { get; set; }
+
+    /// <summary>
+    /// Specific files to validate (for pre-commit hooks).
+    /// When set, only these files are validated instead of scanning directory.
+    /// </summary>
+    public List<string>? Files { get; set; }
+
     /// <summary>
     /// Apply default values from a project configuration file.
     /// Only applies values that weren't explicitly set via CLI.

--- a/src/DraftSpec.Cli/CliOptionsParser.cs
+++ b/src/DraftSpec.Cli/CliOptionsParser.cs
@@ -189,6 +189,31 @@ public static class CliOptionsParser
                 options.SkippedOnly = true;
                 options.ExplicitlySet.Add(nameof(CliOptions.SkippedOnly));
             }
+            // Validate command options
+            else if (arg == "--strict")
+            {
+                options.Strict = true;
+                options.ExplicitlySet.Add(nameof(CliOptions.Strict));
+            }
+            else if (arg is "--quiet" or "-q")
+            {
+                options.Quiet = true;
+                options.ExplicitlySet.Add(nameof(CliOptions.Quiet));
+            }
+            else if (arg == "--files")
+            {
+                if (i + 1 >= args.Length)
+                {
+                    options.Error = "--files requires a value (comma-separated file paths)";
+                    return options;
+                }
+
+                var filesArg = args[++i];
+                options.Files = filesArg.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(f => f.Trim())
+                    .ToList();
+                options.ExplicitlySet.Add(nameof(CliOptions.Files));
+            }
             else if (!arg.StartsWith('-'))
             {
                 positional.Add(arg);

--- a/src/DraftSpec.Cli/CommandFactory.cs
+++ b/src/DraftSpec.Cli/CommandFactory.cs
@@ -22,6 +22,7 @@ public class CommandFactory : ICommandFactory
             "run" => _services.GetRequiredService<RunCommand>(),
             "watch" => _services.GetRequiredService<WatchCommand>(),
             "list" => _services.GetRequiredService<ListCommand>(),
+            "validate" => _services.GetRequiredService<ValidateCommand>(),
             "init" => _services.GetRequiredService<InitCommand>(),
             "new" => _services.GetRequiredService<NewCommand>(),
             _ => null

--- a/src/DraftSpec.Cli/Commands/ValidateCommand.cs
+++ b/src/DraftSpec.Cli/Commands/ValidateCommand.cs
@@ -1,0 +1,241 @@
+using DraftSpec.TestingPlatform;
+
+namespace DraftSpec.Cli.Commands;
+
+/// <summary>
+/// Validates spec structure without execution.
+/// Uses static parsing to detect issues in spec files.
+/// </summary>
+public class ValidateCommand : ICommand
+{
+    private readonly IConsole _console;
+    private readonly IFileSystem _fileSystem;
+
+    /// <summary>
+    /// Exit code when validation passes (no errors, warnings OK).
+    /// </summary>
+    public const int ExitSuccess = 0;
+
+    /// <summary>
+    /// Exit code when validation finds errors.
+    /// </summary>
+    public const int ExitErrors = 1;
+
+    /// <summary>
+    /// Exit code when validation finds warnings with --strict mode.
+    /// </summary>
+    public const int ExitWarnings = 2;
+
+    public ValidateCommand(IConsole console, IFileSystem fileSystem)
+    {
+        _console = console;
+        _fileSystem = fileSystem;
+    }
+
+    public async Task<int> ExecuteAsync(CliOptions options, CancellationToken ct = default)
+    {
+        // 1. Resolve path
+        var projectPath = Path.GetFullPath(options.Path);
+
+        if (!_fileSystem.DirectoryExists(projectPath) && !_fileSystem.FileExists(projectPath))
+            throw new ArgumentException($"Path not found: {projectPath}");
+
+        // 2. Find spec files (use --files if provided, otherwise scan directory)
+        var specFiles = GetSpecFiles(projectPath, options.Files);
+
+        if (specFiles.Count == 0)
+        {
+            if (!options.Quiet)
+                _console.WriteLine("No spec files found.");
+            return ExitSuccess;
+        }
+
+        // 3. Validate each file using static parser
+        if (!options.Quiet)
+            _console.WriteLine("Validating spec structure...\n");
+
+        var parser = new StaticSpecParser(projectPath);
+        var results = new List<FileValidationResult>();
+        var totalSpecs = 0;
+        var totalErrors = 0;
+        var totalWarnings = 0;
+
+        foreach (var specFile in specFiles)
+        {
+            var relativePath = Path.GetRelativePath(projectPath, specFile);
+            var fileResult = new FileValidationResult { FilePath = relativePath };
+
+            try
+            {
+                var parseResult = await parser.ParseFileAsync(specFile, ct);
+                fileResult.SpecCount = parseResult.Specs.Count;
+                totalSpecs += parseResult.Specs.Count;
+
+                // Categorize issues from warnings
+                foreach (var warning in parseResult.Warnings)
+                {
+                    var issue = ParseIssue(warning);
+
+                    if (IsError(issue))
+                    {
+                        fileResult.Errors.Add(issue);
+                        totalErrors++;
+                    }
+                    else
+                    {
+                        fileResult.Warnings.Add(issue);
+                        totalWarnings++;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                fileResult.Errors.Add(new ValidationIssue
+                {
+                    Message = $"Parse error: {ex.Message}",
+                    LineNumber = null
+                });
+                totalErrors++;
+            }
+
+            results.Add(fileResult);
+        }
+
+        // 4. Output results
+        OutputResults(results, options.Quiet);
+
+        // 5. Output summary
+        if (!options.Quiet)
+        {
+            _console.WriteLine("");
+            _console.WriteLine(new string('\u2501', 40)); // ━
+            _console.WriteLine($"Files: {results.Count} | Specs: {totalSpecs} | Errors: {totalErrors} | Warnings: {totalWarnings}");
+        }
+
+        // 6. Determine exit code
+        if (totalErrors > 0)
+            return ExitErrors;
+
+        if (totalWarnings > 0 && options.Strict)
+            return ExitWarnings;
+
+        return ExitSuccess;
+    }
+
+    private List<string> GetSpecFiles(string projectPath, List<string>? explicitFiles)
+    {
+        // If explicit files provided via --files, use those
+        if (explicitFiles is { Count: > 0 })
+        {
+            return explicitFiles
+                .Select(f => Path.IsPathRooted(f) ? f : Path.Combine(projectPath, f))
+                .Where(f => _fileSystem.FileExists(f))
+                .ToList();
+        }
+
+        // Otherwise, scan directory
+        if (_fileSystem.FileExists(projectPath) && projectPath.EndsWith(".spec.csx", StringComparison.OrdinalIgnoreCase))
+        {
+            return [projectPath];
+        }
+
+        if (_fileSystem.DirectoryExists(projectPath))
+        {
+            return Directory.EnumerateFiles(projectPath, "*.spec.csx", SearchOption.AllDirectories).ToList();
+        }
+
+        return [];
+    }
+
+    private static ValidationIssue ParseIssue(string warning)
+    {
+        // Parse warnings like "Line 15: 'describe' has dynamic description - cannot analyze statically"
+        var issue = new ValidationIssue { Message = warning };
+
+        if (warning.StartsWith("Line ", StringComparison.OrdinalIgnoreCase))
+        {
+            var colonIndex = warning.IndexOf(':');
+            if (colonIndex > 5)
+            {
+                var lineStr = warning[5..colonIndex];
+                if (int.TryParse(lineStr, out var lineNumber))
+                {
+                    issue.LineNumber = lineNumber;
+                    issue.Message = warning[(colonIndex + 1)..].Trim();
+                }
+            }
+        }
+
+        return issue;
+    }
+
+    private static bool IsError(ValidationIssue issue)
+    {
+        var msg = issue.Message.ToLowerInvariant();
+
+        // These are errors (always fail)
+        if (msg.Contains("missing description argument"))
+            return true;
+        if (msg.Contains("empty description"))
+            return true;
+        if (msg.Contains("parse error"))
+            return true;
+        if (msg.Contains("syntax error"))
+            return true;
+
+        // Everything else is a warning
+        return false;
+    }
+
+    private void OutputResults(List<FileValidationResult> results, bool quiet)
+    {
+        foreach (var result in results)
+        {
+            if (result.Errors.Count > 0)
+            {
+                // File with errors
+                _console.WriteError($"\u2717 {result.FilePath}");
+                foreach (var error in result.Errors)
+                {
+                    var location = error.LineNumber.HasValue ? $"Line {error.LineNumber}: " : "";
+                    _console.WriteError($"  {location}{error.Message}");
+                }
+            }
+            else if (result.Warnings.Count > 0)
+            {
+                // File with warnings only
+                if (!quiet)
+                {
+                    _console.WriteLine($"\u26a0 {result.FilePath} - {result.SpecCount} specs");
+                    foreach (var warning in result.Warnings)
+                    {
+                        var location = warning.LineNumber.HasValue ? $"Line {warning.LineNumber}: " : "";
+                        _console.WriteLine($"  {location}{warning.Message}");
+                    }
+                }
+            }
+            else
+            {
+                // Valid file
+                if (!quiet)
+                {
+                    _console.WriteSuccess($"\u2713 {result.FilePath} - {result.SpecCount} specs");
+                }
+            }
+        }
+    }
+
+    private class FileValidationResult
+    {
+        public string FilePath { get; set; } = "";
+        public int SpecCount { get; set; }
+        public List<ValidationIssue> Errors { get; } = [];
+        public List<ValidationIssue> Warnings { get; } = [];
+    }
+
+    private class ValidationIssue
+    {
+        public int? LineNumber { get; set; }
+        public string Message { get; set; } = "";
+    }
+}

--- a/src/DraftSpec.Cli/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/DraftSpec.Cli/DependencyInjection/ServiceCollectionExtensions.cs
@@ -43,6 +43,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<RunCommand>();
         services.AddTransient<WatchCommand>();
         services.AddTransient<ListCommand>();
+        services.AddTransient<ValidateCommand>();
         services.AddTransient<InitCommand>();
         services.AddTransient<NewCommand>();
 

--- a/tests/DraftSpec.Tests/Cli/Commands/ValidateCommandTests.cs
+++ b/tests/DraftSpec.Tests/Cli/Commands/ValidateCommandTests.cs
@@ -1,0 +1,375 @@
+using DraftSpec.Cli;
+using DraftSpec.Cli.Commands;
+
+namespace DraftSpec.Tests.Cli.Commands;
+
+/// <summary>
+/// Tests for ValidateCommand.
+/// These tests use the real file system for spec validation.
+/// </summary>
+[NotInParallel]
+public class ValidateCommandTests
+{
+    private string _tempDir = null!;
+    private MockConsole _console = null!;
+    private RealFileSystem _fileSystem = null!;
+
+    [Before(Test)]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"draftspec_validate_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _console = new MockConsole();
+        _fileSystem = new RealFileSystem();
+    }
+
+    [After(Test)]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    private ValidateCommand CreateCommand() => new(_console, _fileSystem);
+
+    #region Path Validation
+
+    [Test]
+    public async Task ExecuteAsync_NonexistentPath_ThrowsArgumentException()
+    {
+        var command = CreateCommand();
+        var options = new CliOptions { Path = "/nonexistent/path" };
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await command.ExecuteAsync(options));
+    }
+
+    [Test]
+    public async Task ExecuteAsync_EmptyDirectory_ReturnsSuccess()
+    {
+        var command = CreateCommand();
+        var options = new CliOptions { Path = _tempDir };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(ValidateCommand.ExitSuccess);
+        await Assert.That(_console.Output).Contains("No spec files found");
+    }
+
+    #endregion
+
+    #region Valid Specs
+
+    [Test]
+    public async Task ExecuteAsync_ValidSpecs_ReturnsSuccess()
+    {
+        CreateSpecFile("valid.spec.csx", """
+            describe("Calculator", () => {
+                it("adds numbers", () => { });
+                it("subtracts numbers", () => { });
+            });
+            """);
+        var command = CreateCommand();
+        var options = new CliOptions { Path = _tempDir };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(ValidateCommand.ExitSuccess);
+        await Assert.That(_console.Output).Contains("\u2713"); // checkmark
+        await Assert.That(_console.Output).Contains("valid.spec.csx");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_MultipleValidFiles_ReturnsSuccess()
+    {
+        CreateSpecFile("math.spec.csx", """
+            describe("Math", () => {
+                it("adds", () => { });
+            });
+            """);
+        CreateSpecFile("string.spec.csx", """
+            describe("String", () => {
+                it("concatenates", () => { });
+            });
+            """);
+        var command = CreateCommand();
+        var options = new CliOptions { Path = _tempDir };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(ValidateCommand.ExitSuccess);
+        await Assert.That(_console.Output).Contains("math.spec.csx");
+        await Assert.That(_console.Output).Contains("string.spec.csx");
+    }
+
+    #endregion
+
+    #region Warnings
+
+    [Test]
+    public async Task ExecuteAsync_DynamicDescription_ReturnsSuccessWithWarnings()
+    {
+        // Dynamic descriptions generate warnings, not errors
+        CreateSpecFile("dynamic.spec.csx", """
+            var name = "test";
+            describe("Feature", () => {
+                it($"dynamic {name}", () => { });
+            });
+            """);
+        var command = CreateCommand();
+        var options = new CliOptions { Path = _tempDir };
+
+        var result = await command.ExecuteAsync(options);
+
+        // Warnings don't cause failure by default
+        await Assert.That(result).IsEqualTo(ValidateCommand.ExitSuccess);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WarningsWithStrict_ReturnsExitWarnings()
+    {
+        CreateSpecFile("dynamic.spec.csx", """
+            var name = "test";
+            describe("Feature", () => {
+                it($"dynamic {name}", () => { });
+            });
+            """);
+        var command = CreateCommand();
+        var options = new CliOptions { Path = _tempDir, Strict = true };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(ValidateCommand.ExitWarnings);
+    }
+
+    #endregion
+
+    #region Errors
+
+    [Test]
+    public async Task ExecuteAsync_MissingDescription_ReturnsExitErrors()
+    {
+        // it() with no arguments triggers "missing description argument" error
+        CreateSpecFile("missing.spec.csx", """
+            describe("Feature", () => {
+                it();
+            });
+            """);
+        var command = CreateCommand();
+        var options = new CliOptions { Path = _tempDir };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(ValidateCommand.ExitErrors);
+        await Assert.That(_console.ErrorOutput).Contains("missing description");
+    }
+
+    #endregion
+
+    #region Quiet Mode
+
+    [Test]
+    public async Task ExecuteAsync_Quiet_SuppressesNonErrors()
+    {
+        CreateSpecFile("valid.spec.csx", """
+            describe("Feature", () => {
+                it("spec", () => { });
+            });
+            """);
+        var command = CreateCommand();
+        var options = new CliOptions { Path = _tempDir, Quiet = true };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(ValidateCommand.ExitSuccess);
+        // In quiet mode, valid files shouldn't produce output
+        await Assert.That(_console.Output).DoesNotContain("\u2713");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_QuietWithErrors_ShowsErrors()
+    {
+        // it() with no arguments triggers "missing description argument" error
+        CreateSpecFile("missing.spec.csx", """
+            describe("Feature", () => {
+                it();
+            });
+            """);
+        var command = CreateCommand();
+        var options = new CliOptions { Path = _tempDir, Quiet = true };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(ValidateCommand.ExitErrors);
+        // Errors should still be shown even in quiet mode
+        await Assert.That(_console.ErrorOutput).Contains("missing.spec.csx");
+    }
+
+    #endregion
+
+    #region Files Flag
+
+    [Test]
+    public async Task ExecuteAsync_FilesFlag_ValidatesOnlySpecifiedFiles()
+    {
+        CreateSpecFile("good.spec.csx", """
+            describe("Good", () => {
+                it("valid", () => { });
+            });
+            """);
+        CreateSpecFile("bad.spec.csx", """
+            describe("Bad", () => {
+                it(() => { });
+            });
+            """);
+        var command = CreateCommand();
+        var options = new CliOptions
+        {
+            Path = _tempDir,
+            Files = ["good.spec.csx"]
+        };
+
+        var result = await command.ExecuteAsync(options);
+
+        // Only good.spec.csx is validated, bad.spec.csx is ignored
+        await Assert.That(result).IsEqualTo(ValidateCommand.ExitSuccess);
+        await Assert.That(_console.Output).Contains("good.spec.csx");
+        await Assert.That(_console.Output).DoesNotContain("bad.spec.csx");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_FilesFlag_MultipleFiles()
+    {
+        CreateSpecFile("a.spec.csx", """
+            describe("A", () => {
+                it("spec a", () => { });
+            });
+            """);
+        CreateSpecFile("b.spec.csx", """
+            describe("B", () => {
+                it("spec b", () => { });
+            });
+            """);
+        CreateSpecFile("c.spec.csx", """
+            describe("C", () => {
+                it("spec c", () => { });
+            });
+            """);
+        var command = CreateCommand();
+        var options = new CliOptions
+        {
+            Path = _tempDir,
+            Files = ["a.spec.csx", "b.spec.csx"]
+        };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(ValidateCommand.ExitSuccess);
+        await Assert.That(_console.Output).Contains("a.spec.csx");
+        await Assert.That(_console.Output).Contains("b.spec.csx");
+        await Assert.That(_console.Output).DoesNotContain("c.spec.csx");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_FilesFlag_NonexistentFile_IgnoresIt()
+    {
+        CreateSpecFile("exists.spec.csx", """
+            describe("Exists", () => {
+                it("spec", () => { });
+            });
+            """);
+        var command = CreateCommand();
+        var options = new CliOptions
+        {
+            Path = _tempDir,
+            Files = ["exists.spec.csx", "nonexistent.spec.csx"]
+        };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(ValidateCommand.ExitSuccess);
+        await Assert.That(_console.Output).Contains("exists.spec.csx");
+    }
+
+    #endregion
+
+    #region Summary Output
+
+    [Test]
+    public async Task ExecuteAsync_ShowsSummary()
+    {
+        CreateSpecFile("summary.spec.csx", """
+            describe("Summary", () => {
+                it("spec1", () => { });
+                it("spec2", () => { });
+            });
+            """);
+        var command = CreateCommand();
+        var options = new CliOptions { Path = _tempDir };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(ValidateCommand.ExitSuccess);
+        await Assert.That(_console.Output).Contains("Files:");
+        await Assert.That(_console.Output).Contains("Specs:");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private string CreateSpecFile(string fileName, string content)
+    {
+        var filePath = Path.Combine(_tempDir, fileName);
+        File.WriteAllText(filePath, content);
+        return filePath;
+    }
+
+    #endregion
+
+    #region Mocks
+
+    private class MockConsole : IConsole
+    {
+        private readonly List<string> _output = [];
+        private readonly List<string> _errorOutput = [];
+
+        public string Output => string.Join("", _output);
+        public string ErrorOutput => string.Join("", _errorOutput);
+
+        public void Write(string text) => _output.Add(text);
+        public void WriteLine(string text) => _output.Add(text + "\n");
+        public void WriteLine() => _output.Add("\n");
+        public ConsoleColor ForegroundColor { get; set; }
+        public void ResetColor() { }
+        public void Clear() { }
+        public void WriteWarning(string text) => WriteLine(text);
+        public void WriteSuccess(string text) => WriteLine(text);
+        public void WriteError(string text)
+        {
+            _errorOutput.Add(text + "\n");
+            _output.Add(text + "\n");
+        }
+    }
+
+    private class RealFileSystem : IFileSystem
+    {
+        public bool FileExists(string path) => File.Exists(path);
+        public void WriteAllText(string path, string content) => File.WriteAllText(path, content);
+        public Task WriteAllTextAsync(string path, string content, CancellationToken ct = default) =>
+            File.WriteAllTextAsync(path, content, ct);
+        public string ReadAllText(string path) => File.ReadAllText(path);
+        public bool DirectoryExists(string path) => Directory.Exists(path);
+        public void CreateDirectory(string path) => Directory.CreateDirectory(path);
+        public string[] GetFiles(string path, string searchPattern) => Directory.GetFiles(path, searchPattern);
+        public string[] GetFiles(string path, string searchPattern, SearchOption searchOption) =>
+            Directory.GetFiles(path, searchPattern, searchOption);
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption) =>
+            Directory.EnumerateFiles(path, searchPattern, searchOption);
+        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern) =>
+            Directory.EnumerateDirectories(path, searchPattern);
+        public DateTime GetLastWriteTimeUtc(string path) => File.GetLastWriteTimeUtc(path);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Add `draftspec validate --static` command for pre-commit hooks and CI pipeline validation:

- Validates spec structure without execution using static parsing
- Detects errors: missing/empty descriptions, parse failures
- Warns on dynamic descriptions (interpolated strings)
- Supports `--strict` flag to treat warnings as errors
- Supports `--quiet` flag to suppress non-error output  
- Supports `--files` for specific file validation (pre-commit hooks)

## Usage

```bash
# Validate all specs in directory
draftspec validate --static specs/

# CI mode (strict, quiet)
draftspec validate --static --strict --quiet

# Pre-commit hook with specific files
draftspec validate --static --files changed1.spec.csx,changed2.spec.csx
```

## Exit Codes

- `0` - All valid (no errors, warnings OK)
- `1` - Errors found
- `2` - Warnings found (with `--strict`)

## Test plan

- [x] Tests for valid specs returning exit 0
- [x] Tests for errors returning exit 1
- [x] Tests for `--strict` with warnings returning exit 2
- [x] Tests for `--quiet` mode
- [x] Tests for `--files` flag
- [x] All 2016 tests pass

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)