### PR TITLE
feat(cli): Add line number filtering with file:line syntax

### DIFF
--- a/src/DraftSpec.Cli/CliOptions.cs
+++ b/src/DraftSpec.Cli/CliOptions.cs
@@ -2,6 +2,13 @@ using DraftSpec.Cli.Configuration;
 
 namespace DraftSpec.Cli;
 
+/// <summary>
+/// Represents a line number filter for running specs at specific lines.
+/// </summary>
+/// <param name="File">The spec file path.</param>
+/// <param name="Lines">The line numbers to run.</param>
+public record LineFilter(string File, int[] Lines);
+
 public class CliOptions
 {
     /// <summary>
@@ -134,6 +141,14 @@ public class CliOptions
     /// When set, only these files are validated instead of scanning directory.
     /// </summary>
     public List<string>? Files { get; set; }
+
+    // Run command line filtering
+
+    /// <summary>
+    /// Line number filters parsed from file:line syntax.
+    /// Used to run specific specs by line number (e.g., "file.spec.csx:15,23").
+    /// </summary>
+    public List<LineFilter>? LineFilters { get; set; }
 
     /// <summary>
     /// Apply default values from a project configuration file.


### PR DESCRIPTION
## Summary

Implement `file:line` syntax for running specs at specific line numbers, enabling IDE-style "run spec at cursor" workflows.

- Add `LineFilter` record and `LineFilters` property to `CliOptions`
- Parse `file:line` and `file:line1,line2` syntax in `CliOptionsParser`
- Handle Windows paths (`C:\`) correctly vs line number colons
- Use `StaticSpecParser` to discover specs at specified lines
- Generate regex filter patterns for matching specs by display name
- Add 10 tests covering various path/line parsing combinations

## Usage Examples

```bash
# Run spec at line 15
draftspec run TodoService.spec.csx:15

# Run specs at multiple lines
draftspec run TodoService.spec.csx:15,20,25

# Works with relative paths
draftspec run ./specs/TodoService.spec.csx:10
```

## Test plan

- [x] Unit tests for parsing `file:line` syntax
- [x] Unit tests for multiple line numbers (`file:line1,line2`)
- [x] Unit tests for Windows path handling (`C:\path\file.spec.csx`)
- [x] Unit tests for edge cases (zero, empty entries, non-digit suffixes)
- [x] All 2025 tests passing

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)