### PR TITLE
feat(cli): Add enhanced compilation error messages with source context

### DIFF
--- a/src/DraftSpec.Cli/Commands/RunCommand.cs
+++ b/src/DraftSpec.Cli/Commands/RunCommand.cs
@@ -132,6 +132,13 @@ public class RunCommand : ICommand
 
         foreach (var result in summary.Results)
         {
+            // Check for compilation errors with enhanced diagnostics
+            if (result.Error is CompilationDiagnosticException compilationError)
+            {
+                presenter.ShowCompilationError(compilationError);
+                continue;
+            }
+
             // Convert to legacy format for presenter
             var legacyResult = new SpecRunResult(
                 result.SpecFile,

--- a/src/DraftSpec.Cli/CompilationDiagnosticException.cs
+++ b/src/DraftSpec.Cli/CompilationDiagnosticException.cs
@@ -1,0 +1,45 @@
+using DraftSpec.TestingPlatform;
+using Microsoft.CodeAnalysis.Scripting;
+
+namespace DraftSpec.Cli;
+
+/// <summary>
+/// Exception that wraps compilation errors with enhanced diagnostic information
+/// and discovered specs from static parsing.
+/// </summary>
+public class CompilationDiagnosticException : Exception
+{
+    /// <summary>
+    /// The formatted error message with source context.
+    /// </summary>
+    public string FormattedMessage { get; }
+
+    /// <summary>
+    /// The file that failed to compile.
+    /// </summary>
+    public string SpecFile { get; }
+
+    /// <summary>
+    /// Specs discovered via static parsing despite the compilation error.
+    /// </summary>
+    public IReadOnlyList<StaticSpec> DiscoveredSpecs { get; }
+
+    /// <summary>
+    /// The original compilation error exception.
+    /// </summary>
+    public CompilationErrorException? CompilationError { get; }
+
+    public CompilationDiagnosticException(
+        string message,
+        string formattedMessage,
+        string specFile,
+        IReadOnlyList<StaticSpec> discoveredSpecs,
+        CompilationErrorException? compilationError = null)
+        : base(message)
+    {
+        FormattedMessage = formattedMessage;
+        SpecFile = specFile;
+        DiscoveredSpecs = discoveredSpecs;
+        CompilationError = compilationError;
+    }
+}

--- a/src/DraftSpec.Cli/CompilationDiagnosticFormatter.cs
+++ b/src/DraftSpec.Cli/CompilationDiagnosticFormatter.cs
@@ -1,0 +1,179 @@
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Scripting;
+
+namespace DraftSpec.Cli;
+
+/// <summary>
+/// Formats compilation diagnostics with source context for enhanced error display.
+/// Shows surrounding source lines with caret pointing to exact error location.
+/// </summary>
+public class CompilationDiagnosticFormatter : ICompilationDiagnosticFormatter
+{
+    private const int ContextLinesBefore = 3;
+    private const int ContextLinesAfter = 3;
+
+    private readonly IFileSystem _fileSystem;
+
+    public CompilationDiagnosticFormatter(IFileSystem? fileSystem = null)
+    {
+        _fileSystem = fileSystem ?? new FileSystem();
+    }
+
+    /// <summary>
+    /// Formats a CompilationErrorException with source context.
+    /// </summary>
+    /// <param name="exception">The compilation error exception.</param>
+    /// <param name="useColors">Whether to use ANSI color codes.</param>
+    /// <returns>Formatted error message with source context.</returns>
+    public string Format(CompilationErrorException exception, bool useColors = true)
+    {
+        var sb = new StringBuilder();
+
+        foreach (var diagnostic in exception.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error))
+        {
+            FormatDiagnostic(sb, diagnostic, useColors);
+            sb.AppendLine();
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// Formats a single diagnostic with source context.
+    /// </summary>
+    /// <param name="diagnostic">The diagnostic to format.</param>
+    /// <param name="useColors">Whether to use ANSI color codes.</param>
+    /// <returns>Formatted diagnostic with source context.</returns>
+    public string FormatDiagnostic(Diagnostic diagnostic, bool useColors = true)
+    {
+        var sb = new StringBuilder();
+        FormatDiagnostic(sb, diagnostic, useColors);
+        return sb.ToString().TrimEnd();
+    }
+
+    private void FormatDiagnostic(StringBuilder sb, Diagnostic diagnostic, bool useColors)
+    {
+        var location = diagnostic.Location;
+        var lineSpan = location.GetLineSpan();
+
+        if (!lineSpan.IsValid)
+        {
+            // No source location - just format the message
+            FormatError(sb, diagnostic.GetMessage(), diagnostic.Id, useColors);
+            return;
+        }
+
+        var filePath = lineSpan.Path;
+        var line = lineSpan.StartLinePosition.Line + 1; // Convert 0-based to 1-based
+        var column = lineSpan.StartLinePosition.Character + 1;
+
+        // Format the error header
+        FormatError(sb, $"{diagnostic.Id}: {diagnostic.GetMessage()}", $"Line {line}, Column {column}", useColors);
+        sb.AppendLine();
+
+        // Try to add source context
+        if (!string.IsNullOrEmpty(filePath) && _fileSystem.FileExists(filePath))
+        {
+            FormatSourceContext(sb, filePath, line, column, useColors);
+        }
+    }
+
+    private void FormatSourceContext(StringBuilder sb, string filePath, int errorLine, int errorColumn, bool useColors)
+    {
+        try
+        {
+            var content = _fileSystem.ReadAllText(filePath);
+            var lines = content.Split('\n');
+
+            // Calculate line range (1-based to 0-based conversion)
+            var startLine = Math.Max(0, errorLine - 1 - ContextLinesBefore);
+            var endLine = Math.Min(lines.Length - 1, errorLine - 1 + ContextLinesAfter);
+
+            // Find max line number width for padding
+            var maxLineNum = endLine + 1;
+            var lineNumWidth = maxLineNum.ToString().Length;
+
+            for (var i = startLine; i <= endLine; i++)
+            {
+                var lineNum = i + 1;
+                var lineContent = lines[i].TrimEnd('\r');
+                var isErrorLine = lineNum == errorLine;
+
+                // Format line number
+                var lineNumStr = lineNum.ToString().PadLeft(lineNumWidth);
+
+                if (isErrorLine)
+                {
+                    // Error line - highlighted
+                    if (useColors)
+                        sb.Append(AnsiColors.Red);
+                    sb.Append($"   {lineNumStr} | ");
+                    sb.Append(lineContent);
+                    if (useColors)
+                        sb.Append(AnsiColors.Reset);
+                    sb.AppendLine();
+
+                    // Add caret line
+                    var caretPadding = new string(' ', 3 + lineNumWidth + 3 + Math.Max(0, errorColumn - 1));
+                    if (useColors)
+                        sb.Append(AnsiColors.Red);
+                    sb.Append(caretPadding);
+                    sb.Append("^--- ");
+                    if (useColors)
+                        sb.Append(AnsiColors.Reset);
+                }
+                else
+                {
+                    // Context line - dimmed
+                    if (useColors)
+                        sb.Append(AnsiColors.Dim);
+                    sb.Append($"   {lineNumStr} | {lineContent}");
+                    if (useColors)
+                        sb.Append(AnsiColors.Reset);
+                    sb.AppendLine();
+                }
+            }
+        }
+        catch
+        {
+            // If we can't read the file, just skip source context
+        }
+    }
+
+    private static void FormatError(StringBuilder sb, string message, string? context, bool useColors)
+    {
+        if (useColors)
+            sb.Append(AnsiColors.Red);
+
+        sb.Append("  ");
+        sb.Append(message);
+
+        if (!string.IsNullOrEmpty(context))
+        {
+            if (useColors)
+            {
+                sb.Append(AnsiColors.Reset);
+                sb.Append(AnsiColors.Dim);
+            }
+            sb.Append($" ({context})");
+        }
+
+        if (useColors)
+            sb.Append(AnsiColors.Reset);
+    }
+}
+
+/// <summary>
+/// ANSI escape codes for terminal colors.
+/// </summary>
+public static class AnsiColors
+{
+    public const string Reset = "\x1b[0m";
+    public const string Red = "\x1b[31m";
+    public const string Green = "\x1b[32m";
+    public const string Yellow = "\x1b[33m";
+    public const string Cyan = "\x1b[36m";
+    public const string Dim = "\x1b[2m";
+    public const string Bold = "\x1b[1m";
+}

--- a/src/DraftSpec.Cli/ConsolePresenter.cs
+++ b/src/DraftSpec.Cli/ConsolePresenter.cs
@@ -96,6 +96,46 @@ public class ConsolePresenter
         }
     }
 
+    /// <summary>
+    /// Shows a compilation error with enhanced diagnostic information and discovered specs.
+    /// </summary>
+    public void ShowCompilationError(CompilationDiagnosticException exception)
+    {
+        var relativePath = Path.GetFileName(exception.SpecFile);
+
+        // Show file header with error indicator
+        _console.ForegroundColor = ConsoleColor.Red;
+        _console.WriteLine($"❌ {relativePath} - Compilation failed");
+        _console.ResetColor();
+        _console.WriteLine();
+
+        // Show formatted error with source context
+        _console.WriteLine(exception.FormattedMessage);
+        _console.WriteLine();
+
+        // Show discovered specs if any
+        if (exception.DiscoveredSpecs.Count > 0)
+        {
+            _console.ForegroundColor = ConsoleColor.Yellow;
+            _console.WriteLine($"Found {exception.DiscoveredSpecs.Count} spec(s) in this file (unable to execute due to compilation error):");
+            _console.ResetColor();
+
+            foreach (var spec in exception.DiscoveredSpecs)
+            {
+                var contextPath = spec.ContextPath.Count > 0
+                    ? string.Join(" > ", spec.ContextPath) + " > "
+                    : "";
+                var lineInfo = spec.LineNumber > 0 ? $" (line {spec.LineNumber})" : "";
+
+                _console.ForegroundColor = ConsoleColor.DarkGray;
+                _console.WriteLine($"  - {contextPath}{spec.Description}{lineInfo}");
+                _console.ResetColor();
+            }
+
+            _console.WriteLine();
+        }
+    }
+
     public void ShowSummary(RunSummary summary)
     {
         _console.WriteLine();

--- a/src/DraftSpec.Cli/ICompilationDiagnosticFormatter.cs
+++ b/src/DraftSpec.Cli/ICompilationDiagnosticFormatter.cs
@@ -1,0 +1,26 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Scripting;
+
+namespace DraftSpec.Cli;
+
+/// <summary>
+/// Formats compilation diagnostics with source context for enhanced error display.
+/// </summary>
+public interface ICompilationDiagnosticFormatter
+{
+    /// <summary>
+    /// Formats a CompilationErrorException with source context.
+    /// </summary>
+    /// <param name="exception">The compilation error exception.</param>
+    /// <param name="useColors">Whether to use ANSI color codes.</param>
+    /// <returns>Formatted error message with source context.</returns>
+    string Format(CompilationErrorException exception, bool useColors = true);
+
+    /// <summary>
+    /// Formats a single diagnostic with source context.
+    /// </summary>
+    /// <param name="diagnostic">The diagnostic to format.</param>
+    /// <param name="useColors">Whether to use ANSI color codes.</param>
+    /// <returns>Formatted diagnostic with source context.</returns>
+    string FormatDiagnostic(Diagnostic diagnostic, bool useColors = true);
+}

--- a/tests/DraftSpec.Tests/Cli/CompilationDiagnosticFormatterTests.cs
+++ b/tests/DraftSpec.Tests/Cli/CompilationDiagnosticFormatterTests.cs
@@ -1,0 +1,250 @@
+using System.Collections.Immutable;
+using DraftSpec.Cli;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
+
+namespace DraftSpec.Tests.Cli;
+
+/// <summary>
+/// Tests for CompilationDiagnosticFormatter class.
+/// </summary>
+public class CompilationDiagnosticFormatterTests
+{
+    #region Format Tests
+
+    [Test]
+    public async Task Format_WithCompilationError_IncludesErrorCode()
+    {
+        var exception = CreateCompilationError("var x = ");
+        var mockFileSystem = new MockFileSystem();
+        var formatter = new CompilationDiagnosticFormatter(mockFileSystem);
+
+        var result = formatter.Format(exception, useColors: false);
+
+        await Assert.That(result).Contains("CS");
+    }
+
+    [Test]
+    public async Task Format_WithCompilationError_IncludesErrorMessage()
+    {
+        var exception = CreateCompilationError("var x = ");
+        var mockFileSystem = new MockFileSystem();
+        var formatter = new CompilationDiagnosticFormatter(mockFileSystem);
+
+        var result = formatter.Format(exception, useColors: false);
+
+        // Error message should be included (specific message varies by error)
+        await Assert.That(result.Length).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task Format_WithColors_IncludesAnsiCodes()
+    {
+        var exception = CreateCompilationError("var x = ");
+        var mockFileSystem = new MockFileSystem();
+        var formatter = new CompilationDiagnosticFormatter(mockFileSystem);
+
+        var result = formatter.Format(exception, useColors: true);
+
+        await Assert.That(result).Contains(AnsiColors.Red);
+    }
+
+    [Test]
+    public async Task Format_WithoutColors_OmitsAnsiCodes()
+    {
+        var exception = CreateCompilationError("var x = ");
+        var mockFileSystem = new MockFileSystem();
+        var formatter = new CompilationDiagnosticFormatter(mockFileSystem);
+
+        var result = formatter.Format(exception, useColors: false);
+
+        await Assert.That(result).DoesNotContain("\x1b[");
+    }
+
+    #endregion
+
+    #region Line Information Tests
+
+    [Test]
+    public async Task Format_WithCompilationError_IncludesLineNumber()
+    {
+        var exception = CreateCompilationError("var x = ");
+        var mockFileSystem = new MockFileSystem();
+        var formatter = new CompilationDiagnosticFormatter(mockFileSystem);
+
+        var result = formatter.Format(exception, useColors: false);
+
+        // Should include "Line X" from diagnostic location
+        await Assert.That(result).Contains("Line");
+    }
+
+    [Test]
+    public async Task Format_WithCompilationError_IncludesColumnNumber()
+    {
+        var exception = CreateCompilationError("var x = ");
+        var mockFileSystem = new MockFileSystem();
+        var formatter = new CompilationDiagnosticFormatter(mockFileSystem);
+
+        var result = formatter.Format(exception, useColors: false);
+
+        // Should include "Column X" from diagnostic location
+        await Assert.That(result).Contains("Column");
+    }
+
+    [Test]
+    public async Task Format_WhenSourceFileNotAvailable_StillFormatsError()
+    {
+        // When the source file isn't available (file path doesn't match filesystem),
+        // the formatter should still show the error message without source context
+        var exception = CreateCompilationError("var x = ");
+        var mockFileSystem = new MockFileSystem(); // No files registered
+        var formatter = new CompilationDiagnosticFormatter(mockFileSystem);
+
+        var result = formatter.Format(exception, useColors: false);
+
+        // Should still contain error code and line info even without source context
+        await Assert.That(result).Contains("CS");
+        await Assert.That(result).Contains("Line");
+    }
+
+    #endregion
+
+    #region FormatDiagnostic Tests
+
+    [Test]
+    public async Task FormatDiagnostic_SingleDiagnostic_FormatsCorrectly()
+    {
+        var diagnostic = CreateDiagnostic("var x = ");
+        var mockFileSystem = new MockFileSystem();
+        var formatter = new CompilationDiagnosticFormatter(mockFileSystem);
+
+        var result = formatter.FormatDiagnostic(diagnostic, useColors: false);
+
+        await Assert.That(result.Length).IsGreaterThan(0);
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Test]
+    public async Task Format_WithMissingSourceFile_StillFormatsError()
+    {
+        var exception = CreateCompilationError("var x = ");
+        var mockFileSystem = new MockFileSystem(); // No files
+        var formatter = new CompilationDiagnosticFormatter(mockFileSystem);
+
+        var result = formatter.Format(exception, useColors: false);
+
+        // Should still format the error message without source context
+        await Assert.That(result).Contains("CS");
+    }
+
+    [Test]
+    public async Task Format_MultipleErrors_FormatsAll()
+    {
+        var exception = CreateCompilationError("var x = \nvar y = ");
+        var mockFileSystem = new MockFileSystem();
+        var formatter = new CompilationDiagnosticFormatter(mockFileSystem);
+
+        var result = formatter.Format(exception, useColors: false);
+
+        // Should contain error information (at least one error)
+        await Assert.That(result).Contains("CS");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static CompilationErrorException CreateCompilationError(string code)
+    {
+        try
+        {
+            var script = CSharpScript.Create(code);
+            var compilation = script.GetCompilation();
+            var diagnostics = compilation.GetDiagnostics()
+                .Where(d => d.Severity == DiagnosticSeverity.Error)
+                .ToList();
+
+            if (diagnostics.Count > 0)
+            {
+                return new CompilationErrorException(
+                    "Compilation failed",
+                    diagnostics.ToImmutableArray());
+            }
+
+            // Force evaluate to get runtime compilation errors
+            script.RunAsync().GetAwaiter().GetResult();
+            throw new InvalidOperationException("Expected compilation error");
+        }
+        catch (CompilationErrorException ex)
+        {
+            return ex;
+        }
+    }
+
+    private static CompilationErrorException CreateCompilationErrorFromCode(string code)
+    {
+        try
+        {
+            var script = CSharpScript.Create(code, ScriptOptions.Default);
+            script.RunAsync().GetAwaiter().GetResult();
+            throw new InvalidOperationException("Expected compilation error");
+        }
+        catch (CompilationErrorException ex)
+        {
+            return ex;
+        }
+    }
+
+    private static Diagnostic CreateDiagnostic(string code)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("test")
+            .AddSyntaxTrees(syntaxTree);
+
+        return compilation.GetDiagnostics()
+            .First(d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    #endregion
+
+    #region Mock Implementations
+
+    private class MockFileSystem : IFileSystem
+    {
+        private readonly Dictionary<string, string> _files = new(StringComparer.OrdinalIgnoreCase);
+
+        public MockFileSystem WithFile(string path, string content)
+        {
+            _files[path] = content;
+            return this;
+        }
+
+        public bool FileExists(string path) => _files.ContainsKey(path);
+
+        public string ReadAllText(string path) =>
+            _files.TryGetValue(path, out var content) ? content : throw new FileNotFoundException(path);
+
+        public void WriteAllText(string path, string content) => _files[path] = content;
+
+        public Task WriteAllTextAsync(string path, string content, CancellationToken ct = default)
+        {
+            _files[path] = content;
+            return Task.CompletedTask;
+        }
+
+        public bool DirectoryExists(string path) => true;
+        public void CreateDirectory(string path) { }
+        public string[] GetFiles(string path, string searchPattern) => [];
+        public string[] GetFiles(string path, string searchPattern, SearchOption searchOption) => [];
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption) => [];
+        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern) => [];
+        public DateTime GetLastWriteTimeUtc(string path) => DateTime.MinValue;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Add `ICompilationDiagnosticFormatter` interface and `CompilationDiagnosticFormatter` implementation
- Show surrounding source lines (3 before, 3 after) with error caret pointing to exact location
- Display statically-discovered specs even when compilation fails
- Use ANSI colors for error highlighting (red for errors, dim for context lines)
- Catch `CompilationErrorException` specifically in `InProcessSpecRunner`
- Add 10 tests for `CompilationDiagnosticFormatter`

## Example Output
```
❌ UserService.spec.csx - Compilation failed

  CS1002: ; expected (Line 23, Column 8)

     20 |     it("validates email format", async () => {
     21 |       var user = await service.CreateAsync(newUser);
     22 |       expect(user.Email).toBe(expectedEmail);
     23 |     }
             ^---

Found 3 spec(s) in this file (unable to execute due to compilation error):
  - UserService > CreateAsync > validates email format (line 20)
  - UserService > CreateAsync > creates user with valid data (line 15)
  - UserService > GetAsync > returns null for missing user (line 30)
```

## Test plan
- [x] All 2054 tests pass
- [x] Build succeeds with 0 warnings
- [x] New tests for `CompilationDiagnosticFormatter` cover formatting with/without colors
- [x] Verified error message includes error code, line, and column info

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)