### PR TITLE
feat(cli): Add JSON schema for static discovery output

### DIFF
--- a/docs/schemas/list-output.schema.json
+++ b/docs/schemas/list-output.schema.json
@@ -1,0 +1,133 @@
+{
+  "type": "object",
+  "properties": {
+    "specs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "contextPath": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sourceFile": {
+            "type": "string"
+          },
+          "relativeSourceFile": {
+            "type": "string"
+          },
+          "lineNumber": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string"
+          },
+          "isPending": {
+            "type": "boolean"
+          },
+          "isSkipped": {
+            "type": "boolean"
+          },
+          "isFocused": {
+            "type": "boolean"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "compilationError": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "description",
+          "displayName",
+          "contextPath",
+          "sourceFile",
+          "relativeSourceFile",
+          "lineNumber",
+          "type",
+          "isPending",
+          "isSkipped",
+          "isFocused",
+          "tags"
+        ]
+      }
+    },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "totalSpecs": {
+          "type": "integer"
+        },
+        "focusedCount": {
+          "type": "integer"
+        },
+        "skippedCount": {
+          "type": "integer"
+        },
+        "pendingCount": {
+          "type": "integer"
+        },
+        "errorCount": {
+          "type": "integer"
+        },
+        "totalFiles": {
+          "type": "integer"
+        },
+        "filesWithErrors": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "totalSpecs",
+        "focusedCount",
+        "skippedCount",
+        "pendingCount",
+        "errorCount",
+        "totalFiles",
+        "filesWithErrors"
+      ]
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "file",
+          "message"
+        ]
+      }
+    }
+  },
+  "required": [
+    "specs",
+    "summary",
+    "errors"
+  ]
+}

--- a/src/DraftSpec.Cli/CommandFactory.cs
+++ b/src/DraftSpec.Cli/CommandFactory.cs
@@ -25,6 +25,7 @@ public class CommandFactory : ICommandFactory
             "validate" => _services.GetRequiredService<ValidateCommand>(),
             "init" => _services.GetRequiredService<InitCommand>(),
             "new" => _services.GetRequiredService<NewCommand>(),
+            "schema" => _services.GetRequiredService<SchemaCommand>(),
             _ => null
         };
     }

--- a/src/DraftSpec.Cli/Commands/SchemaCommand.cs
+++ b/src/DraftSpec.Cli/Commands/SchemaCommand.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using System.Text.Json.Schema;
+using System.Text.Json.Serialization.Metadata;
+using DraftSpec.Cli.Formatters;
+
+namespace DraftSpec.Cli.Commands;
+
+/// <summary>
+/// Outputs the JSON schema for the `draftspec list --format json` output.
+/// Uses .NET's JsonSchemaExporter to generate the schema from DTOs.
+/// </summary>
+public class SchemaCommand : ICommand
+{
+    private readonly IConsole _console;
+    private readonly IFileSystem _fileSystem;
+
+    public SchemaCommand(IConsole console, IFileSystem fileSystem)
+    {
+        _console = console;
+        _fileSystem = fileSystem;
+    }
+
+    public async Task<int> ExecuteAsync(CliOptions options, CancellationToken ct = default)
+    {
+        // Use the same JSON options as JsonListFormatter for consistency
+        var serializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+        };
+
+        var exporterOptions = new JsonSchemaExporterOptions
+        {
+            TreatNullObliviousAsNonNullable = true
+        };
+
+        // Generate schema from the root DTO type
+        var schemaNode = serializerOptions.GetJsonSchemaAsNode(typeof(ListOutputDto), exporterOptions);
+
+        // Pretty-print the schema
+        var outputOptions = new JsonSerializerOptions { WriteIndented = true };
+        var schema = schemaNode.ToJsonString(outputOptions);
+
+        // Write to file or stdout
+        if (!string.IsNullOrEmpty(options.OutputFile))
+        {
+            await _fileSystem.WriteAllTextAsync(options.OutputFile, schema, ct);
+            _console.WriteLine($"Schema written to {options.OutputFile}");
+        }
+        else
+        {
+            _console.WriteLine(schema);
+        }
+
+        return 0;
+    }
+}

--- a/src/DraftSpec.Cli/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/DraftSpec.Cli/DependencyInjection/ServiceCollectionExtensions.cs
@@ -37,6 +37,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ICliFormatterRegistry, CliFormatterRegistry>();
         services.AddSingleton<IInProcessSpecRunnerFactory, InProcessSpecRunnerFactory>();
         services.AddSingleton<IFileWatcherFactory, FileWatcherFactory>();
+        services.AddSingleton<IPluginScanner, SystemPluginScanner>();
+        services.AddSingleton<IAssemblyLoader, IsolatedAssemblyLoader>();
         services.AddSingleton<IPluginLoader, PluginLoader>();
 
         // Commands
@@ -46,22 +48,10 @@ public static class ServiceCollectionExtensions
         services.AddTransient<ValidateCommand>();
         services.AddTransient<InitCommand>();
         services.AddTransient<NewCommand>();
+        services.AddTransient<SchemaCommand>();
 
         // Factory
         services.AddSingleton<ICommandFactory, CommandFactory>();
-
-        return services;
-    }
-
-    /// <summary>
-    /// Adds plugin discovery from the specified directories.
-    /// </summary>
-    public static IServiceCollection AddPluginDiscovery(
-        this IServiceCollection services,
-        params string[] pluginDirectories)
-    {
-        services.AddSingleton<IPluginLoader>(sp =>
-            new PluginLoader(pluginDirectories));
 
         return services;
     }

--- a/src/DraftSpec.Cli/Formatters/JsonListFormatter.cs
+++ b/src/DraftSpec.Cli/Formatters/JsonListFormatter.cs
@@ -16,10 +16,10 @@ public sealed class JsonListFormatter : IListFormatter
 
     public string Format(IReadOnlyList<DiscoveredSpec> specs, IReadOnlyList<DiscoveryError> errors)
     {
-        var output = new ListOutput
+        var output = new ListOutputDto
         {
             Specs = specs.Select(MapSpec).ToList(),
-            Summary = new ListSummary
+            Summary = new ListSummaryDto
             {
                 TotalSpecs = specs.Count,
                 FocusedCount = specs.Count(s => s.IsFocused),
@@ -29,7 +29,7 @@ public sealed class JsonListFormatter : IListFormatter
                 TotalFiles = specs.Select(s => s.RelativeSourceFile).Distinct().Count(),
                 FilesWithErrors = errors.Count
             },
-            Errors = errors.Select(e => new ListError
+            Errors = errors.Select(e => new ListErrorDto
             {
                 File = e.RelativeSourceFile,
                 Message = e.Message
@@ -39,7 +39,7 @@ public sealed class JsonListFormatter : IListFormatter
         return JsonSerializer.Serialize(output, JsonOptions);
     }
 
-    private static SpecInfo MapSpec(DiscoveredSpec spec) => new()
+    private static SpecInfoDto MapSpec(DiscoveredSpec spec) => new()
     {
         Id = spec.Id,
         Description = spec.Description,
@@ -63,47 +63,5 @@ public sealed class JsonListFormatter : IListFormatter
         if (spec.IsSkipped) return "skipped";
         if (spec.IsPending) return "pending";
         return "regular";
-    }
-
-    // DTO classes for JSON serialization
-    private sealed class ListOutput
-    {
-        public required List<SpecInfo> Specs { get; init; }
-        public required ListSummary Summary { get; init; }
-        public required List<ListError> Errors { get; init; }
-    }
-
-    private sealed class SpecInfo
-    {
-        public required string Id { get; init; }
-        public required string Description { get; init; }
-        public required string DisplayName { get; init; }
-        public required List<string> ContextPath { get; init; }
-        public required string SourceFile { get; init; }
-        public required string RelativeSourceFile { get; init; }
-        public required int LineNumber { get; init; }
-        public required string Type { get; init; }
-        public required bool IsPending { get; init; }
-        public required bool IsSkipped { get; init; }
-        public required bool IsFocused { get; init; }
-        public required List<string> Tags { get; init; }
-        public string? CompilationError { get; init; }
-    }
-
-    private sealed class ListSummary
-    {
-        public required int TotalSpecs { get; init; }
-        public required int FocusedCount { get; init; }
-        public required int SkippedCount { get; init; }
-        public required int PendingCount { get; init; }
-        public required int ErrorCount { get; init; }
-        public required int TotalFiles { get; init; }
-        public required int FilesWithErrors { get; init; }
-    }
-
-    private sealed class ListError
-    {
-        public required string File { get; init; }
-        public required string Message { get; init; }
     }
 }

--- a/src/DraftSpec.Cli/Formatters/ListOutputDto.cs
+++ b/src/DraftSpec.Cli/Formatters/ListOutputDto.cs
@@ -1,0 +1,157 @@
+using System.ComponentModel;
+
+namespace DraftSpec.Cli.Formatters;
+
+/// <summary>
+/// Root DTO for the JSON output of `draftspec list --format json`.
+/// </summary>
+/// <remarks>
+/// This type is used for JSON schema generation. Changes to this type
+/// will affect the published schema at docs/schemas/list-output.schema.json.
+/// </remarks>
+public sealed class ListOutputDto
+{
+    /// <summary>
+    /// List of discovered spec definitions.
+    /// </summary>
+    public required List<SpecInfoDto> Specs { get; init; }
+
+    /// <summary>
+    /// Summary statistics for the discovery run.
+    /// </summary>
+    public required ListSummaryDto Summary { get; init; }
+
+    /// <summary>
+    /// List of files that failed to parse.
+    /// </summary>
+    public required List<ListErrorDto> Errors { get; init; }
+}
+
+/// <summary>
+/// A discovered spec definition.
+/// </summary>
+public sealed class SpecInfoDto
+{
+    /// <summary>
+    /// Unique identifier for the spec, derived from context path and description.
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// The spec's description string (from `it("...")`).
+    /// </summary>
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// Full display name including context path (e.g., "UserService > CreateAsync > validates email").
+    /// </summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Array of parent context descriptions (from nested `describe()`/`context()` blocks).
+    /// </summary>
+    public required List<string> ContextPath { get; init; }
+
+    /// <summary>
+    /// Absolute path to the source file containing this spec.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Relative path from the project root to the source file.
+    /// </summary>
+    public required string RelativeSourceFile { get; init; }
+
+    /// <summary>
+    /// Line number where the spec is defined (1-based).
+    /// </summary>
+    public required int LineNumber { get; init; }
+
+    /// <summary>
+    /// The spec type: regular, focused (fit), skipped (xit), pending (no body), or error (compilation failed).
+    /// </summary>
+    [Description("regular, focused, skipped, pending, or error")]
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// Whether the spec is pending (has no body).
+    /// </summary>
+    public required bool IsPending { get; init; }
+
+    /// <summary>
+    /// Whether the spec is explicitly skipped (xit).
+    /// </summary>
+    public required bool IsSkipped { get; init; }
+
+    /// <summary>
+    /// Whether the spec is focused (fit).
+    /// </summary>
+    public required bool IsFocused { get; init; }
+
+    /// <summary>
+    /// Tags applied to this spec via `.tag()` or inherited from parent contexts.
+    /// </summary>
+    public required List<string> Tags { get; init; }
+
+    /// <summary>
+    /// Compilation error message if the file failed to compile, null otherwise.
+    /// </summary>
+    public string? CompilationError { get; init; }
+}
+
+/// <summary>
+/// Summary statistics for the discovery run.
+/// </summary>
+public sealed class ListSummaryDto
+{
+    /// <summary>
+    /// Total number of specs discovered.
+    /// </summary>
+    public required int TotalSpecs { get; init; }
+
+    /// <summary>
+    /// Number of focused specs (fit).
+    /// </summary>
+    public required int FocusedCount { get; init; }
+
+    /// <summary>
+    /// Number of skipped specs (xit).
+    /// </summary>
+    public required int SkippedCount { get; init; }
+
+    /// <summary>
+    /// Number of pending specs (no body).
+    /// </summary>
+    public required int PendingCount { get; init; }
+
+    /// <summary>
+    /// Number of specs with compilation errors.
+    /// </summary>
+    public required int ErrorCount { get; init; }
+
+    /// <summary>
+    /// Total number of spec files discovered.
+    /// </summary>
+    public required int TotalFiles { get; init; }
+
+    /// <summary>
+    /// Number of files that failed to parse.
+    /// </summary>
+    public required int FilesWithErrors { get; init; }
+}
+
+/// <summary>
+/// A file that failed to parse.
+/// </summary>
+public sealed class ListErrorDto
+{
+    /// <summary>
+    /// Relative path to the file that failed.
+    /// </summary>
+    public required string File { get; init; }
+
+    /// <summary>
+    /// Error message describing why parsing failed.
+    /// </summary>
+    public required string Message { get; init; }
+}

--- a/tests/DraftSpec.Tests/Cli/DependencyInjection/PluginLoaderTests.cs
+++ b/tests/DraftSpec.Tests/Cli/DependencyInjection/PluginLoaderTests.cs
@@ -37,9 +37,9 @@ public class PluginLoaderTests
         var console = new MockConsole();
 
         var customDir = "/custom/plugins";
-        var loader = new PluginLoader(scanner, assemblyLoader, console, customDir);
+        var loader = new PluginLoader(scanner, assemblyLoader, console);
 
-        loader.DiscoverPlugins();
+        loader.DiscoverPlugins([customDir]);
 
         await Assert.That(scanner.CheckedDirectories).Contains(customDir);
     }
@@ -55,9 +55,9 @@ public class PluginLoaderTests
         var assemblyLoader = new MockAssemblyLoader();
         var console = new MockConsole();
 
-        var loader = new PluginLoader(scanner, assemblyLoader, console, "/nonexistent");
+        var loader = new PluginLoader(scanner, assemblyLoader, console);
 
-        var plugins = loader.DiscoverPlugins();
+        var plugins = loader.DiscoverPlugins(["/nonexistent"]);
 
         await Assert.That(plugins.Count()).IsEqualTo(0);
     }
@@ -72,9 +72,9 @@ public class PluginLoaderTests
         var assemblyLoader = new MockAssemblyLoader();
         var console = new MockConsole();
 
-        var loader = new PluginLoader(scanner, assemblyLoader, console, "/plugins");
+        var loader = new PluginLoader(scanner, assemblyLoader, console);
 
-        var plugins = loader.DiscoverPlugins();
+        var plugins = loader.DiscoverPlugins(["/plugins"]);
 
         await Assert.That(plugins.Count()).IsEqualTo(0);
     }
@@ -90,17 +90,17 @@ public class PluginLoaderTests
         assemblyLoader.AddRealType("/plugins/DraftSpec.MyPlugin.dll", typeof(TestFormatterWithAttribute));
 
         var console = new MockConsole();
-        var loader = new PluginLoader(scanner, assemblyLoader, console, "/plugins");
+        var loader = new PluginLoader(scanner, assemblyLoader, console);
 
         // First call
-        var plugins1 = loader.DiscoverPlugins().ToList();
+        var plugins1 = loader.DiscoverPlugins(["/plugins"]).ToList();
 
         // Reset counters
         scanner.CheckedDirectories.Clear();
         scanner.ScannedDirectories.Clear();
 
         // Second call
-        var plugins2 = loader.DiscoverPlugins().ToList();
+        var plugins2 = loader.DiscoverPlugins(["/plugins"]).ToList();
 
         // Should return cached results without scanning again
         await Assert.That(scanner.CheckedDirectories.Count).IsEqualTo(0);
@@ -123,9 +123,9 @@ public class PluginLoaderTests
         assemblyLoader.AddRealType("/plugins/DraftSpec.GoodPlugin.dll", typeof(TestFormatterWithAttribute));
 
         var console = new MockConsole();
-        var loader = new PluginLoader(scanner, assemblyLoader, console, "/plugins");
+        var loader = new PluginLoader(scanner, assemblyLoader, console);
 
-        var plugins = loader.DiscoverPlugins().ToList();
+        var plugins = loader.DiscoverPlugins(["/plugins"]).ToList();
 
         // Should have logged error for BadPlugin
         await Assert.That(console.Errors).Contains("DraftSpec.BadPlugin.dll");
@@ -152,9 +152,9 @@ public class PluginLoaderTests
         assemblyLoader.AddRealType("/plugins/DraftSpec.MyPlugin.dll", typeof(TestFormatterWithAttribute));
 
         var console = new MockConsole();
-        var loader = new PluginLoader(scanner, assemblyLoader, console, "/plugins");
+        var loader = new PluginLoader(scanner, assemblyLoader, console);
 
-        var plugins = loader.DiscoverPlugins().ToList();
+        var plugins = loader.DiscoverPlugins(["/plugins"]).ToList();
 
         await Assert.That(plugins.Count).IsEqualTo(1);
         await Assert.That(plugins[0].Name).IsEqualTo("testformatter");
@@ -173,9 +173,9 @@ public class PluginLoaderTests
         assemblyLoader.AddRealType("/plugins/DraftSpec.MyPlugin.dll", typeof(FormatterWithoutAttribute));
 
         var console = new MockConsole();
-        var loader = new PluginLoader(scanner, assemblyLoader, console, "/plugins");
+        var loader = new PluginLoader(scanner, assemblyLoader, console);
 
-        var plugins = loader.DiscoverPlugins().ToList();
+        var plugins = loader.DiscoverPlugins(["/plugins"]).ToList();
 
         await Assert.That(plugins.Count).IsEqualTo(0);
     }
@@ -191,9 +191,9 @@ public class PluginLoaderTests
         assemblyLoader.AddRealType("/plugins/DraftSpec.MyPlugin.dll", typeof(TestFormatterWithAttribute));
 
         var console = new MockConsole();
-        var loader = new PluginLoader(scanner, assemblyLoader, console, "/plugins");
+        var loader = new PluginLoader(scanner, assemblyLoader, console);
 
-        var plugins = loader.DiscoverPlugins().ToList();
+        var plugins = loader.DiscoverPlugins(["/plugins"]).ToList();
 
         await Assert.That(plugins.Count).IsEqualTo(1);
         await Assert.That(plugins[0].Kind).IsEqualTo(PluginKind.Formatter);
@@ -211,9 +211,9 @@ public class PluginLoaderTests
         assemblyLoader.AddRealType("/plugins/DraftSpec.MyPlugin.dll", typeof(NonFormatterWithAttribute));
 
         var console = new MockConsole();
-        var loader = new PluginLoader(scanner, assemblyLoader, console, "/plugins");
+        var loader = new PluginLoader(scanner, assemblyLoader, console);
 
-        var plugins = loader.DiscoverPlugins().ToList();
+        var plugins = loader.DiscoverPlugins(["/plugins"]).ToList();
 
         // Should be skipped because it doesn't implement known plugin interfaces
         await Assert.That(plugins.Count).IsEqualTo(0);
@@ -234,7 +234,10 @@ public class PluginLoaderTests
         assemblyLoader.AddRealType("/plugins/DraftSpec.JsonFormatter.dll", typeof(TestFormatterWithAttribute));
 
         var console = new MockConsole();
-        var loader = new PluginLoader(scanner, assemblyLoader, console, "/plugins");
+        var loader = new PluginLoader(scanner, assemblyLoader, console);
+
+        // Discover plugins first with directories
+        loader.DiscoverPlugins(["/plugins"]);
 
         var registry = new MockFormatterRegistry();
         loader.RegisterFormatters(registry);

--- a/tests/DraftSpec.Tests/Cli/SchemaGenerationTests.cs
+++ b/tests/DraftSpec.Tests/Cli/SchemaGenerationTests.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+using System.Text.Json.Schema;
+using System.Text.Json.Serialization.Metadata;
+using DraftSpec.Cli.Formatters;
+
+namespace DraftSpec.Tests.Cli;
+
+/// <summary>
+/// Tests to ensure the committed JSON schema matches the generated schema from DTOs.
+/// This prevents drift between the schema documentation and the actual output format.
+/// </summary>
+public class SchemaGenerationTests
+{
+    private static readonly string SchemaPath = Path.Combine(
+        GetRepositoryRoot(),
+        "docs", "schemas", "list-output.schema.json");
+
+    [Test]
+    public async Task GeneratedSchema_MatchesCommittedSchema()
+    {
+        // Generate schema from DTOs using the same settings as SchemaCommand
+        var serializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+        };
+
+        var exporterOptions = new JsonSchemaExporterOptions
+        {
+            TreatNullObliviousAsNonNullable = true
+        };
+
+        var schemaNode = serializerOptions.GetJsonSchemaAsNode(typeof(ListOutputDto), exporterOptions);
+
+        var outputOptions = new JsonSerializerOptions { WriteIndented = true };
+        var generated = schemaNode.ToJsonString(outputOptions);
+
+        // Read committed schema
+        await Assert.That(File.Exists(SchemaPath))
+            .IsTrue()
+            .Because($"Schema file should exist at {SchemaPath}");
+
+        var committed = await File.ReadAllTextAsync(SchemaPath);
+
+        // Compare - normalize line endings for cross-platform compatibility
+        var normalizedGenerated = generated.Replace("\r\n", "\n").Trim();
+        var normalizedCommitted = committed.Replace("\r\n", "\n").Trim();
+
+        await Assert.That(normalizedGenerated)
+            .IsEqualTo(normalizedCommitted)
+            .Because("Generated schema should match committed schema. If DTOs changed, run 'draftspec schema > docs/schemas/list-output.schema.json' to update.");
+    }
+
+    [Test]
+    public async Task SchemaFile_IsValidJson()
+    {
+        await Assert.That(File.Exists(SchemaPath))
+            .IsTrue()
+            .Because($"Schema file should exist at {SchemaPath}");
+
+        var content = await File.ReadAllTextAsync(SchemaPath);
+
+        // Should parse without throwing
+        var document = JsonDocument.Parse(content);
+
+        // Should have expected top-level structure
+        await Assert.That(document.RootElement.TryGetProperty("type", out var typeElement)).IsTrue();
+        await Assert.That(typeElement.GetString()).IsEqualTo("object");
+
+        await Assert.That(document.RootElement.TryGetProperty("properties", out _)).IsTrue();
+        await Assert.That(document.RootElement.TryGetProperty("required", out _)).IsTrue();
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var directory = AppContext.BaseDirectory;
+
+        // Walk up until we find the .git directory or solution file
+        while (directory != null)
+        {
+            if (Directory.Exists(Path.Combine(directory, ".git")) ||
+                File.Exists(Path.Combine(directory, "DraftSpec.sln")))
+            {
+                return directory;
+            }
+
+            directory = Path.GetDirectoryName(directory);
+        }
+
+        throw new InvalidOperationException("Could not find repository root");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `draftspec schema` command that generates JSON schema from DTOs
- Use .NET's built-in `JsonSchemaExporter` for code-generated schema (prevents drift)
- Add drift detection test that compares generated schema to committed file
- Generate `docs/schemas/list-output.schema.json`

Also fixes PluginLoader DI bug discovered during implementation:
- Remove `params string[]` from constructor (broke DI resolution)  
- Move directories parameter to `DiscoverPlugins()` method
- Follow established codebase pattern (like ConfigLoader, SpecFinder)
- Register `IPluginScanner` and `IAssemblyLoader` in DI container

## Usage

```bash
# Output schema to stdout
draftspec schema

# Write schema to file  
draftspec schema -o schema.json
```

## Test plan

- [x] All 2056 tests pass
- [x] `draftspec schema` outputs valid JSON schema
- [x] `draftspec list --format json` works with fixed DI
- [x] Drift detection test verifies schema matches DTOs

Closes #191
Fixes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)