### PR TITLE
ci: Add CLI integration tests to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,8 +46,11 @@ jobs:
         env:
           MinVerVersionOverride: ${{ steps.version.outputs.version }}
 
-      - name: Run tests
+      - name: Run unit tests
         run: dotnet run --project tests/DraftSpec.Tests --no-build -c Release
+
+      - name: Run CLI integration tests
+        run: dotnet run --project tests/DraftSpec.Cli.IntegrationTests --no-build -c Release
 
       - name: Pack
         run: dotnet pack --no-build -c Release


### PR DESCRIPTION
## Summary

Adds CLI integration tests (44 tests) to the publish workflow to ensure they pass before NuGet packages are published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)