### PR TITLE
fix(mtp): Remove hardcoded DraftSpec.Specs namespace prefix

### DIFF
--- a/src/DraftSpec.TestingPlatform/TestNodeMapper.cs
+++ b/src/DraftSpec.TestingPlatform/TestNodeMapper.cs
@@ -257,7 +257,7 @@ internal static class TestNodeMapper
 
         return new TestMethodIdentifierProperty(
             assemblyFullName: assemblyName,
-            @namespace: "DraftSpec.Specs",
+            @namespace: "",
             typeName: typeName,
             methodName: methodName,
             methodArity: 0,


### PR DESCRIPTION
## Summary

Test Explorer was showing specs as `DraftSpec.Specs.TodoService` instead of just `TodoService`.

The namespace was hardcoded in `TestNodeMapper.cs` and should be empty since CSX files don't have real namespaces.

**Before:** `DraftSpec.Specs.TodoService`
**After:** `TodoService`

🤖 Generated with [Claude Code](https://claude.com/claude-code)