### PR TITLE
chore: Update NuGet package tags for discoverability

### DIFF
--- a/src/DraftSpec.Cli/DraftSpec.Cli.csproj
+++ b/src/DraftSpec.Cli/DraftSpec.Cli.csproj
@@ -30,7 +30,7 @@
         <!-- NuGet Package Configuration -->
         <PackageId>DraftSpec.Cli</PackageId>
         <Description>CLI tool for running DraftSpec specs. Supports watch mode, multiple output formats (console, JSON, HTML, Markdown), and parallel execution.</Description>
-        <PackageTags>testing;bdd;rspec;cli;dotnet-tool;test-runner</PackageTags>
+        <PackageTags>testing;bdd;rspec;cli;dotnet-tool;test-runner;dotnet</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 

--- a/src/DraftSpec.Formatters.Abstractions/DraftSpec.Formatters.Abstractions.csproj
+++ b/src/DraftSpec.Formatters.Abstractions/DraftSpec.Formatters.Abstractions.csproj
@@ -8,7 +8,7 @@
         <!-- NuGet Package Configuration -->
         <PackageId>DraftSpec.Formatters.Abstractions</PackageId>
         <Description>Abstractions for DraftSpec formatters. Use this to create custom output formatters for test results.</Description>
-        <PackageTags>testing;bdd;formatters;abstractions</PackageTags>
+        <PackageTags>testing;bdd;formatters;extensibility</PackageTags>
     </PropertyGroup>
 
 </Project>

--- a/src/DraftSpec.Formatters.Console/DraftSpec.Formatters.Console.csproj
+++ b/src/DraftSpec.Formatters.Console/DraftSpec.Formatters.Console.csproj
@@ -12,7 +12,7 @@
         <!-- NuGet Package Configuration -->
         <PackageId>DraftSpec.Formatters.Console</PackageId>
         <Description>Console output formatter for DraftSpec with colored output and progress indicators.</Description>
-        <PackageTags>testing;bdd;formatters;console</PackageTags>
+        <PackageTags>testing;bdd;formatters;console;terminal</PackageTags>
     </PropertyGroup>
 
 </Project>

--- a/src/DraftSpec.Formatters.JUnit/DraftSpec.Formatters.JUnit.csproj
+++ b/src/DraftSpec.Formatters.JUnit/DraftSpec.Formatters.JUnit.csproj
@@ -12,7 +12,7 @@
         <!-- NuGet Package Configuration -->
         <PackageId>DraftSpec.Formatters.JUnit</PackageId>
         <Description>JUnit XML output formatter for DraftSpec test results. Integrates with CI/CD systems like Jenkins, Azure DevOps, and GitHub Actions.</Description>
-        <PackageTags>testing;bdd;formatters;junit;xml;ci-cd</PackageTags>
+        <PackageTags>testing;bdd;formatters;junit;xml;ci-cd;github-actions</PackageTags>
     </PropertyGroup>
 
 </Project>

--- a/src/DraftSpec.Formatters.Markdown/DraftSpec.Formatters.Markdown.csproj
+++ b/src/DraftSpec.Formatters.Markdown/DraftSpec.Formatters.Markdown.csproj
@@ -12,7 +12,7 @@
         <!-- NuGet Package Configuration -->
         <PackageId>DraftSpec.Formatters.Markdown</PackageId>
         <Description>Markdown output formatter for DraftSpec test results. Great for documentation and GitHub integration.</Description>
-        <PackageTags>testing;bdd;formatters;markdown</PackageTags>
+        <PackageTags>testing;bdd;formatters;markdown;documentation</PackageTags>
     </PropertyGroup>
 
 </Project>

--- a/src/DraftSpec.Mcp/DraftSpec.Mcp.csproj
+++ b/src/DraftSpec.Mcp/DraftSpec.Mcp.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
         <PackageId>DraftSpec.Mcp</PackageId>
         <Description>MCP server for DraftSpec - run specs from AI assistants</Description>
-        <PackageTags>testing;bdd;mcp;model-context-protocol;ai</PackageTags>
+        <PackageTags>testing;bdd;mcp;model-context-protocol;ai;llm</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/DraftSpec.Scripting/DraftSpec.Scripting.csproj
+++ b/src/DraftSpec.Scripting/DraftSpec.Scripting.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Roslyn-based CSX script host for DraftSpec spec execution</Description>
+    <PackageTags>testing;scripting;roslyn;csharp</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DraftSpec.TestingPlatform/DraftSpec.TestingPlatform.csproj
+++ b/src/DraftSpec.TestingPlatform/DraftSpec.TestingPlatform.csproj
@@ -8,7 +8,7 @@
         <!-- NuGet Package Configuration -->
         <PackageId>DraftSpec.TestingPlatform</PackageId>
         <Description>Microsoft.Testing.Platform adapter for DraftSpec. Enables running CSX specs via dotnet test with built-in coverage support.</Description>
-        <PackageTags>testing;bdd;rspec;mtp;dotnet-test;coverage</PackageTags>
+        <PackageTags>testing;bdd;mtp;microsoft-testing-platform;dotnet-test;test-explorer</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
         <!-- Override IsPackable=false set by Microsoft.Testing.Platform -->

--- a/src/DraftSpec/DraftSpec.csproj
+++ b/src/DraftSpec/DraftSpec.csproj
@@ -12,7 +12,7 @@
         <!-- NuGet Package Configuration -->
         <PackageId>DraftSpec</PackageId>
         <Description>RSpec-inspired testing framework for .NET 10. Write expressive specs with describe/it/expect syntax in CSX scripts or test classes.</Description>
-        <PackageTags>testing;bdd;rspec;specs;test-framework;csx;dotnet-script</PackageTags>
+        <PackageTags>testing;bdd;rspec;nspec;specs;test-framework;dotnet;unit-testing</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>


### PR DESCRIPTION
## Summary

- Remove `csx` and `dotnet-script` tags (pivoting away from CSX focus)
- Add `nspec`, `dotnet`, `unit-testing` to core package for NSpec users
- Add `microsoft-testing-platform`, `test-explorer` to MTP adapter
- Add `llm` to MCP package
- Add `github-actions` to JUnit formatter
- Add missing tags to DraftSpec.Scripting

Tags will take effect on next NuGet publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)