### PR TITLE
feat(cli): Add spec count statistics before run

### DIFF
--- a/src/DraftSpec.Cli/CliOptions.cs
+++ b/src/DraftSpec.Cli/CliOptions.cs
@@ -166,6 +166,20 @@ public class CliOptions
     /// </summary>
     public List<LineFilter>? LineFilters { get; set; }
 
+    // Run command statistics options
+
+    /// <summary>
+    /// Disable pre-run statistics display.
+    /// By default, stats are shown before running specs.
+    /// </summary>
+    public bool NoStats { get; set; }
+
+    /// <summary>
+    /// Show spec statistics only, without running specs.
+    /// Displays discovered spec counts and exits.
+    /// </summary>
+    public bool StatsOnly { get; set; }
+
     /// <summary>
     /// Apply default values from a project configuration file.
     /// Only applies values that weren't explicitly set via CLI.

--- a/src/DraftSpec.Cli/CliOptionsParser.cs
+++ b/src/DraftSpec.Cli/CliOptionsParser.cs
@@ -238,6 +238,17 @@ public static class CliOptionsParser
                     .ToList();
                 options.ExplicitlySet.Add(nameof(CliOptions.Files));
             }
+            // Run command statistics options
+            else if (arg == "--no-stats")
+            {
+                options.NoStats = true;
+                options.ExplicitlySet.Add(nameof(CliOptions.NoStats));
+            }
+            else if (arg == "--stats-only")
+            {
+                options.StatsOnly = true;
+                options.ExplicitlySet.Add(nameof(CliOptions.StatsOnly));
+            }
             else if (!arg.StartsWith('-'))
             {
                 positional.Add(arg);

--- a/src/DraftSpec.Cli/ConsolePresenter.cs
+++ b/src/DraftSpec.Cli/ConsolePresenter.cs
@@ -34,6 +34,40 @@ public class ConsolePresenter
         _console.ResetColor();
     }
 
+    /// <summary>
+    /// Shows pre-run statistics about discovered specs.
+    /// </summary>
+    public void ShowPreRunStats(SpecStats stats)
+    {
+        _console.ForegroundColor = ConsoleColor.DarkGray;
+        _console.WriteLine($"Discovered {stats.Total} spec(s) in {stats.FileCount} file(s)");
+
+        // Build breakdown parts (only include non-zero counts)
+        var parts = new List<string>();
+        if (stats.Regular > 0) parts.Add($"{stats.Regular} regular");
+        if (stats.Focused > 0) parts.Add($"{stats.Focused} focused");
+        if (stats.Skipped > 0) parts.Add($"{stats.Skipped} skipped");
+        if (stats.Pending > 0) parts.Add($"{stats.Pending} pending");
+
+        if (parts.Count > 0)
+        {
+            _console.WriteLine($"  {string.Join(", ", parts)}");
+        }
+
+        _console.ResetColor();
+
+        // Show focus mode warning
+        if (stats.HasFocusMode)
+        {
+            _console.WriteLine();
+            _console.ForegroundColor = ConsoleColor.Yellow;
+            _console.WriteLine("Warning: Focus mode active - only focused specs (fit/fdescribe) will run");
+            _console.ResetColor();
+        }
+
+        _console.WriteLine();
+    }
+
     public void ShowBuilding(string project)
     {
         var name = Path.GetFileNameWithoutExtension(project);

--- a/src/DraftSpec.Cli/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/DraftSpec.Cli/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using DraftSpec.Cli.Commands;
 using DraftSpec.Cli.Configuration;
+using DraftSpec.Cli.Services;
 using DraftSpec.Formatters;
 using DraftSpec.Formatters.Html;
 using DraftSpec.Formatters.JUnit;
@@ -40,6 +41,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IPluginScanner, SystemPluginScanner>();
         services.AddSingleton<IAssemblyLoader, IsolatedAssemblyLoader>();
         services.AddSingleton<IPluginLoader, PluginLoader>();
+        services.AddSingleton<ISpecStatsCollector, SpecStatsCollector>();
 
         // Commands
         services.AddTransient<RunCommand>();

--- a/src/DraftSpec.Cli/Services/ISpecStatsCollector.cs
+++ b/src/DraftSpec.Cli/Services/ISpecStatsCollector.cs
@@ -1,0 +1,19 @@
+namespace DraftSpec.Cli.Services;
+
+/// <summary>
+/// Collects pre-run statistics about discovered specs using static parsing.
+/// </summary>
+public interface ISpecStatsCollector
+{
+    /// <summary>
+    /// Collects statistics from the specified spec files.
+    /// </summary>
+    /// <param name="specFiles">List of spec file paths.</param>
+    /// <param name="projectPath">Base project path for relative paths.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Statistics about discovered specs.</returns>
+    Task<SpecStats> CollectAsync(
+        IReadOnlyList<string> specFiles,
+        string projectPath,
+        CancellationToken ct = default);
+}

--- a/src/DraftSpec.Cli/Services/SpecStatsCollector.cs
+++ b/src/DraftSpec.Cli/Services/SpecStatsCollector.cs
@@ -1,0 +1,56 @@
+using DraftSpec.TestingPlatform;
+
+namespace DraftSpec.Cli.Services;
+
+/// <summary>
+/// Collects pre-run statistics about discovered specs using static parsing.
+/// </summary>
+public class SpecStatsCollector : ISpecStatsCollector
+{
+    /// <inheritdoc />
+    public async Task<SpecStats> CollectAsync(
+        IReadOnlyList<string> specFiles,
+        string projectPath,
+        CancellationToken ct = default)
+    {
+        if (specFiles.Count == 0)
+        {
+            return new SpecStats(
+                Total: 0,
+                Regular: 0,
+                Focused: 0,
+                Skipped: 0,
+                Pending: 0,
+                HasFocusMode: false,
+                FileCount: 0);
+        }
+
+        var parser = new StaticSpecParser(projectPath);
+        var allSpecs = new List<StaticSpec>();
+
+        foreach (var specFile in specFiles)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var result = await parser.ParseFileAsync(specFile, ct);
+            allSpecs.AddRange(result.Specs);
+        }
+
+        var focused = allSpecs.Count(s => s.Type == StaticSpecType.Focused);
+        var skipped = allSpecs.Count(s => s.Type == StaticSpecType.Skipped);
+        var pending = allSpecs.Count(s => s.IsPending);
+
+        // Regular = total - focused - skipped
+        // Note: pending is orthogonal to type (a pending spec can be regular, focused, or skipped)
+        var regular = allSpecs.Count - focused - skipped;
+
+        return new SpecStats(
+            Total: allSpecs.Count,
+            Regular: regular,
+            Focused: focused,
+            Skipped: skipped,
+            Pending: pending,
+            HasFocusMode: focused > 0,
+            FileCount: specFiles.Count);
+    }
+}

--- a/src/DraftSpec.Cli/SpecStats.cs
+++ b/src/DraftSpec.Cli/SpecStats.cs
@@ -1,0 +1,21 @@
+namespace DraftSpec.Cli;
+
+/// <summary>
+/// Pre-run statistics about discovered specs.
+/// Used to display summary before test execution.
+/// </summary>
+/// <param name="Total">Total number of specs discovered.</param>
+/// <param name="Regular">Number of regular specs (not focused, skipped, or pending).</param>
+/// <param name="Focused">Number of focused specs (fit/fdescribe).</param>
+/// <param name="Skipped">Number of skipped specs (xit/xdescribe).</param>
+/// <param name="Pending">Number of pending specs (no body).</param>
+/// <param name="HasFocusMode">True if any focused specs exist (focus mode active).</param>
+/// <param name="FileCount">Number of spec files.</param>
+public record SpecStats(
+    int Total,
+    int Regular,
+    int Focused,
+    int Skipped,
+    int Pending,
+    bool HasFocusMode,
+    int FileCount);

--- a/tests/DraftSpec.Cli.IntegrationTests/Infrastructure/SpecFixtureBuilder.cs
+++ b/tests/DraftSpec.Cli.IntegrationTests/Infrastructure/SpecFixtureBuilder.cs
@@ -67,6 +67,24 @@ public class SpecFixtureBuilder
     }
 
     /// <summary>
+    /// Adds a focused spec (fit) to the fixture.
+    /// </summary>
+    public SpecFixtureBuilder WithFocusedSpec(string name = "focused")
+    {
+        return WithSpec(name, """
+            using static DraftSpec.Dsl;
+
+            describe("FocusedTests", () =>
+            {
+                fit("is focused", () =>
+                {
+                    expect(true).toBeTrue();
+                });
+            });
+            """);
+    }
+
+    /// <summary>
     /// Adds a spec with multiple examples.
     /// </summary>
     public SpecFixtureBuilder WithMultipleSpecs(string name = "multiple", int passCount = 2, int failCount = 1)

--- a/tests/DraftSpec.Cli.IntegrationTests/Subprocess/CliExitCodeTests.cs
+++ b/tests/DraftSpec.Cli.IntegrationTests/Subprocess/CliExitCodeTests.cs
@@ -214,6 +214,66 @@ public class CliExitCodeTests : IntegrationTestBase
 
     #endregion
 
+    #region Stats Options
+
+    [Test]
+    public async Task Run_StatsOnly_ShowsStatsAndExits()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "run", ".", "--stats-only");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("--stats-only should return 0 when no focus mode");
+        await Assert.That(result.Output).Contains("Discovered")
+            .Because("Should show discovered specs message");
+        await Assert.That(result.Output).Contains("spec(s)")
+            .Because("Should show spec count");
+    }
+
+    [Test]
+    public async Task Run_StatsOnly_WithFocusedSpecs_ReturnsTwo()
+    {
+        var specDir = CreateFixture().WithFocusedSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "run", ".", "--stats-only");
+
+        await Assert.That(result.ExitCode).IsEqualTo(2)
+            .Because("--stats-only with focus mode should return exit code 2");
+        await Assert.That(result.Output).Contains("focused")
+            .Because("Should mention focused specs");
+        await Assert.That(result.Output).Contains("Focus mode active")
+            .Because("Should show focus mode warning");
+    }
+
+    [Test]
+    public async Task Run_NoStats_DoesNotShowStats()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "run", ".", "--no-stats");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Run should succeed");
+        await Assert.That(result.Output).DoesNotContain("Discovered")
+            .Because("--no-stats should suppress stats display");
+    }
+
+    [Test]
+    public async Task Run_Default_ShowsStats()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "run", ".");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Run should succeed");
+        await Assert.That(result.Output).Contains("Discovered")
+            .Because("Default run should show stats");
+    }
+
+    #endregion
+
     #region Error Handling
 
     [Test]

--- a/tests/DraftSpec.Tests/Cli/CliOptionsParserTests.cs
+++ b/tests/DraftSpec.Tests/Cli/CliOptionsParserTests.cs
@@ -842,4 +842,35 @@ public class CliOptionsParserTests
     }
 
     #endregion
+
+    #region Stats Options
+
+    [Test]
+    public async Task Parse_NoStatsOption_SetsNoStats()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--no-stats"]);
+
+        await Assert.That(options.NoStats).IsTrue();
+        await Assert.That(options.ExplicitlySet).Contains(nameof(CliOptions.NoStats));
+    }
+
+    [Test]
+    public async Task Parse_StatsOnlyOption_SetsStatsOnly()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--stats-only"]);
+
+        await Assert.That(options.StatsOnly).IsTrue();
+        await Assert.That(options.ExplicitlySet).Contains(nameof(CliOptions.StatsOnly));
+    }
+
+    [Test]
+    public async Task Parse_DefaultNoStatsIsFalse()
+    {
+        var options = CliOptionsParser.Parse(["run", "."]);
+
+        await Assert.That(options.NoStats).IsFalse();
+        await Assert.That(options.StatsOnly).IsFalse();
+    }
+
+    #endregion
 }

--- a/tests/DraftSpec.Tests/Cli/CommandFactoryTests.cs
+++ b/tests/DraftSpec.Tests/Cli/CommandFactoryTests.cs
@@ -2,6 +2,7 @@ using DraftSpec.Cli;
 using DraftSpec.Cli.Commands;
 using DraftSpec.Cli.Configuration;
 using DraftSpec.Cli.DependencyInjection;
+using DraftSpec.Cli.Services;
 using DraftSpec.Formatters;
 
 namespace DraftSpec.Tests.Cli;
@@ -259,7 +260,8 @@ public class CommandFactoryTests
             new NullFormatterRegistry(),
             new NullConfigLoader(),
             new NullFileSystem(),
-            new NullEnvironment())
+            new NullEnvironment(),
+            new NullStatsCollector())
         {
         }
     }
@@ -393,6 +395,17 @@ public class CommandFactoryTests
     {
         public string CurrentDirectory => Directory.GetCurrentDirectory();
         public string NewLine => System.Environment.NewLine;
+    }
+
+    private class NullStatsCollector : ISpecStatsCollector
+    {
+        public Task<SpecStats> CollectAsync(
+            IReadOnlyList<string> specFiles,
+            string projectPath,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult(new SpecStats(0, 0, 0, 0, 0, false, 0));
+        }
     }
 
     private class NullFileWatcherFactory : IFileWatcherFactory

--- a/tests/DraftSpec.Tests/Cli/Commands/RunCommandTests.cs
+++ b/tests/DraftSpec.Tests/Cli/Commands/RunCommandTests.cs
@@ -2,6 +2,7 @@ using DraftSpec.Cli;
 using DraftSpec.Cli.Commands;
 using DraftSpec.Cli.Configuration;
 using DraftSpec.Cli.DependencyInjection;
+using DraftSpec.Cli.Services;
 using DraftSpec.Formatters;
 using DraftSpec.Tests.TestHelpers;
 
@@ -404,7 +405,8 @@ public class RunCommandTests
             new MockFormatterRegistry(),
             configLoader ?? new MockConfigLoader(),
             fileSystem ?? new MockFileSystem(),
-            environment ?? new MockEnvironment());
+            environment ?? new MockEnvironment(),
+            new MockStatsCollector());
     }
 
     #endregion
@@ -576,6 +578,24 @@ public class RunCommandTests
         public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption) => [];
         public IEnumerable<string> EnumerateDirectories(string path, string searchPattern) => [];
         public DateTime GetLastWriteTimeUtc(string path) => DateTime.MinValue;
+    }
+
+    private class MockStatsCollector : ISpecStatsCollector
+    {
+        public Task<SpecStats> CollectAsync(
+            IReadOnlyList<string> specFiles,
+            string projectPath,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult(new SpecStats(
+                Total: 0,
+                Regular: 0,
+                Focused: 0,
+                Skipped: 0,
+                Pending: 0,
+                HasFocusMode: false,
+                FileCount: specFiles.Count));
+        }
     }
 
     #endregion

--- a/tests/DraftSpec.Tests/Cli/SpecStatsCollectorTests.cs
+++ b/tests/DraftSpec.Tests/Cli/SpecStatsCollectorTests.cs
@@ -1,0 +1,57 @@
+using DraftSpec.Cli;
+using DraftSpec.Cli.Services;
+
+namespace DraftSpec.Tests.Cli;
+
+/// <summary>
+/// Tests for SpecStatsCollector service.
+/// </summary>
+public class SpecStatsCollectorTests
+{
+    [Test]
+    public async Task CollectAsync_WithNoFiles_ReturnsZeroStats()
+    {
+        var collector = new SpecStatsCollector();
+
+        var stats = await collector.CollectAsync([], "/some/path");
+
+        await Assert.That(stats.Total).IsEqualTo(0);
+        await Assert.That(stats.Regular).IsEqualTo(0);
+        await Assert.That(stats.Focused).IsEqualTo(0);
+        await Assert.That(stats.Skipped).IsEqualTo(0);
+        await Assert.That(stats.Pending).IsEqualTo(0);
+        await Assert.That(stats.HasFocusMode).IsFalse();
+        await Assert.That(stats.FileCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SpecStats_Record_HasCorrectProperties()
+    {
+        var stats = new SpecStats(
+            Total: 10,
+            Regular: 5,
+            Focused: 2,
+            Skipped: 1,
+            Pending: 2,
+            HasFocusMode: true,
+            FileCount: 3);
+
+        await Assert.That(stats.Total).IsEqualTo(10);
+        await Assert.That(stats.Regular).IsEqualTo(5);
+        await Assert.That(stats.Focused).IsEqualTo(2);
+        await Assert.That(stats.Skipped).IsEqualTo(1);
+        await Assert.That(stats.Pending).IsEqualTo(2);
+        await Assert.That(stats.HasFocusMode).IsTrue();
+        await Assert.That(stats.FileCount).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task SpecStats_HasFocusMode_TrueWhenFocusedGreaterThanZero()
+    {
+        var statsWithFocus = new SpecStats(10, 8, 2, 0, 0, true, 1);
+        var statsWithoutFocus = new SpecStats(10, 10, 0, 0, 0, false, 1);
+
+        await Assert.That(statsWithFocus.HasFocusMode).IsTrue();
+        await Assert.That(statsWithoutFocus.HasFocusMode).IsFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Add pre-run statistics display showing discovered specs count and breakdown by type
- New `--stats-only` flag to show stats and exit without running (returns exit code 2 if focus mode detected)
- New `--no-stats` flag to suppress stats display
- Focus mode warning when `fit`/`fdescribe` specs are detected

### Example output

```
Discovered 42 spec(s) in 5 file(s)
  38 regular, 2 focused, 1 skipped, 1 pending

⚠ Focus mode active - only focused specs (fit/fdescribe) will run
```

### Implementation

| Component | Description |
|-----------|-------------|
| `SpecStats` record | Data record for stats counts |
| `ISpecStatsCollector` | Service interface |
| `SpecStatsCollector` | Implementation using `StaticSpecParser` |
| `ConsolePresenter.ShowPreRunStats()` | Console output formatting |
| `RunCommand` | Integration before spec execution |

## Test plan

- [x] Unit tests for `SpecStatsCollector`
- [x] Unit tests for CLI options parsing (`--no-stats`, `--stats-only`)
- [x] Integration tests for stats CLI behavior
- [x] All 2072 unit tests pass
- [x] All 48 integration tests pass

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)