### PR TITLE
feat(cli): Add parallel test partitioning for CI

### DIFF
--- a/src/DraftSpec.Cli/CliOptions.cs
+++ b/src/DraftSpec.Cli/CliOptions.cs
@@ -180,6 +180,26 @@ public class CliOptions
     /// </summary>
     public bool StatsOnly { get; set; }
 
+    // Partitioning options for CI parallelism
+
+    /// <summary>
+    /// Total number of partitions to divide specs into.
+    /// Used with --partition-index for CI parallel execution.
+    /// </summary>
+    public int? Partition { get; set; }
+
+    /// <summary>
+    /// Zero-based index of this partition (0 to Partition-1).
+    /// </summary>
+    public int? PartitionIndex { get; set; }
+
+    /// <summary>
+    /// Strategy for partitioning: "file" (default) or "spec-count".
+    /// - file: Round-robin by sorted file path (fast, deterministic)
+    /// - spec-count: Balance by spec count per file (requires parsing)
+    /// </summary>
+    public string PartitionStrategy { get; set; } = "file";
+
     /// <summary>
     /// Apply default values from a project configuration file.
     /// Only applies values that weren't explicitly set via CLI.

--- a/src/DraftSpec.Cli/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/DraftSpec.Cli/DependencyInjection/ServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAssemblyLoader, IsolatedAssemblyLoader>();
         services.AddSingleton<IPluginLoader, PluginLoader>();
         services.AddSingleton<ISpecStatsCollector, SpecStatsCollector>();
+        services.AddSingleton<ISpecPartitioner, SpecPartitioner>();
 
         // Commands
         services.AddTransient<RunCommand>();

--- a/src/DraftSpec.Cli/Services/ISpecPartitioner.cs
+++ b/src/DraftSpec.Cli/Services/ISpecPartitioner.cs
@@ -1,0 +1,39 @@
+namespace DraftSpec.Cli.Services;
+
+/// <summary>
+/// Partitions spec files for distributed CI execution.
+/// </summary>
+public interface ISpecPartitioner
+{
+    /// <summary>
+    /// Partitions the given spec files into the specified number of partitions
+    /// and returns the files for the requested partition index.
+    /// </summary>
+    /// <param name="specFiles">All discovered spec files.</param>
+    /// <param name="totalPartitions">Total number of partitions.</param>
+    /// <param name="partitionIndex">Zero-based index of the partition to return.</param>
+    /// <param name="strategy">Partitioning strategy: "file" or "spec-count".</param>
+    /// <param name="projectPath">Base project path for spec parsing (needed for spec-count strategy).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The partition result containing assigned files.</returns>
+    Task<PartitionResult> PartitionAsync(
+        IReadOnlyList<string> specFiles,
+        int totalPartitions,
+        int partitionIndex,
+        string strategy,
+        string projectPath,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Result of partitioning spec files.
+/// </summary>
+/// <param name="Files">The spec files assigned to this partition.</param>
+/// <param name="TotalFiles">Total files across all partitions.</param>
+/// <param name="TotalSpecs">Total specs across all partitions (only for spec-count strategy).</param>
+/// <param name="PartitionSpecs">Specs in this partition (only for spec-count strategy).</param>
+public record PartitionResult(
+    IReadOnlyList<string> Files,
+    int TotalFiles,
+    int? TotalSpecs = null,
+    int? PartitionSpecs = null);

--- a/src/DraftSpec.Cli/Services/SpecPartitioner.cs
+++ b/src/DraftSpec.Cli/Services/SpecPartitioner.cs
@@ -1,0 +1,111 @@
+using DraftSpec.TestingPlatform;
+
+namespace DraftSpec.Cli.Services;
+
+/// <summary>
+/// Partitions spec files for distributed CI execution.
+/// Supports two strategies:
+/// - file: Round-robin by sorted file path (fast, deterministic)
+/// - spec-count: Balance by spec count per file (requires parsing)
+/// </summary>
+public class SpecPartitioner : ISpecPartitioner
+{
+    /// <inheritdoc />
+    public async Task<PartitionResult> PartitionAsync(
+        IReadOnlyList<string> specFiles,
+        int totalPartitions,
+        int partitionIndex,
+        string strategy,
+        string projectPath,
+        CancellationToken ct = default)
+    {
+        if (specFiles.Count == 0)
+        {
+            return new PartitionResult([], 0);
+        }
+
+        // Sort files for deterministic partitioning
+        var sortedFiles = specFiles.OrderBy(f => f, StringComparer.Ordinal).ToList();
+
+        return strategy.ToLowerInvariant() switch
+        {
+            "spec-count" => await PartitionBySpecCountAsync(sortedFiles, totalPartitions, partitionIndex, projectPath, ct),
+            _ => PartitionByFile(sortedFiles, totalPartitions, partitionIndex)
+        };
+    }
+
+    /// <summary>
+    /// Round-robin partitioning by file path (fast, deterministic).
+    /// Files are assigned to partitions in sorted order: file[i] goes to partition i % totalPartitions.
+    /// </summary>
+    private static PartitionResult PartitionByFile(
+        IReadOnlyList<string> sortedFiles,
+        int totalPartitions,
+        int partitionIndex)
+    {
+        var partitionFiles = sortedFiles
+            .Where((_, i) => i % totalPartitions == partitionIndex)
+            .ToList();
+
+        return new PartitionResult(partitionFiles, sortedFiles.Count);
+    }
+
+    /// <summary>
+    /// Greedy partitioning by spec count (balanced, requires parsing).
+    /// Assigns files to the partition with the lowest current spec count.
+    /// </summary>
+    private static async Task<PartitionResult> PartitionBySpecCountAsync(
+        IReadOnlyList<string> sortedFiles,
+        int totalPartitions,
+        int partitionIndex,
+        string projectPath,
+        CancellationToken ct)
+    {
+        // Parse each file to get spec count
+        var parser = new StaticSpecParser(projectPath);
+        var fileSpecCounts = new List<(string File, int Count)>();
+
+        foreach (var file in sortedFiles)
+        {
+            ct.ThrowIfCancellationRequested();
+            var result = await parser.ParseFileAsync(file, ct);
+            fileSpecCounts.Add((file, result.Specs.Count));
+        }
+
+        // Sort by spec count descending (largest first for better balancing)
+        var sortedByCount = fileSpecCounts
+            .OrderByDescending(f => f.Count)
+            .ThenBy(f => f.File, StringComparer.Ordinal) // Secondary sort for determinism
+            .ToList();
+
+        // Greedy assignment: give each file to the partition with lowest current total
+        var partitionTotals = new int[totalPartitions];
+        var partitionAssignments = new List<string>[totalPartitions];
+        for (var i = 0; i < totalPartitions; i++)
+            partitionAssignments[i] = [];
+
+        foreach (var (file, count) in sortedByCount)
+        {
+            // Find partition with lowest total
+            var minPartition = 0;
+            for (var i = 1; i < totalPartitions; i++)
+            {
+                if (partitionTotals[i] < partitionTotals[minPartition])
+                    minPartition = i;
+            }
+
+            partitionAssignments[minPartition].Add(file);
+            partitionTotals[minPartition] += count;
+        }
+
+        var totalSpecs = fileSpecCounts.Sum(f => f.Count);
+        var partitionSpecs = partitionTotals[partitionIndex];
+
+        // Return files for requested partition, sorted for consistent ordering
+        var resultFiles = partitionAssignments[partitionIndex]
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+
+        return new PartitionResult(resultFiles, sortedFiles.Count, totalSpecs, partitionSpecs);
+    }
+}

--- a/tests/DraftSpec.Tests/Cli/CliOptionsParserTests.cs
+++ b/tests/DraftSpec.Tests/Cli/CliOptionsParserTests.cs
@@ -873,4 +873,140 @@ public class CliOptionsParserTests
     }
 
     #endregion
+
+    #region Partition Options
+
+    [Test]
+    public async Task Parse_PartitionOptions_SetsValues()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition", "4", "--partition-index", "2"]);
+
+        await Assert.That(options.Partition).IsEqualTo(4);
+        await Assert.That(options.PartitionIndex).IsEqualTo(2);
+        await Assert.That(options.PartitionStrategy).IsEqualTo("file");
+        await Assert.That(options.Error).IsNull();
+    }
+
+    [Test]
+    public async Task Parse_PartitionWithStrategy_SetsValues()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition", "4", "--partition-index", "0", "--partition-strategy", "spec-count"]);
+
+        await Assert.That(options.Partition).IsEqualTo(4);
+        await Assert.That(options.PartitionIndex).IsEqualTo(0);
+        await Assert.That(options.PartitionStrategy).IsEqualTo("spec-count");
+        await Assert.That(options.Error).IsNull();
+    }
+
+    [Test]
+    public async Task Parse_PartitionWithoutIndex_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition", "4"]);
+
+        await Assert.That(options.Error).IsEqualTo("--partition and --partition-index must be used together");
+    }
+
+    [Test]
+    public async Task Parse_PartitionIndexWithoutPartition_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition-index", "0"]);
+
+        await Assert.That(options.Error).IsEqualTo("--partition and --partition-index must be used together");
+    }
+
+    [Test]
+    public async Task Parse_PartitionIndexTooLarge_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition", "4", "--partition-index", "4"]);
+
+        await Assert.That(options.Error).IsEqualTo("--partition-index (4) must be less than --partition (4)");
+    }
+
+    [Test]
+    public async Task Parse_PartitionIndexEqualToPartition_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition", "4", "--partition-index", "5"]);
+
+        await Assert.That(options.Error).IsEqualTo("--partition-index (5) must be less than --partition (4)");
+    }
+
+    [Test]
+    public async Task Parse_PartitionInvalid_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition", "abc"]);
+
+        await Assert.That(options.Error).IsEqualTo("--partition must be a positive integer");
+    }
+
+    [Test]
+    public async Task Parse_PartitionZero_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition", "0"]);
+
+        await Assert.That(options.Error).IsEqualTo("--partition must be a positive integer");
+    }
+
+    [Test]
+    public async Task Parse_PartitionNegative_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition", "-1"]);
+
+        await Assert.That(options.Error).IsEqualTo("--partition must be a positive integer");
+    }
+
+    [Test]
+    public async Task Parse_PartitionIndexNegative_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition-index", "-1"]);
+
+        await Assert.That(options.Error).IsEqualTo("--partition-index must be a non-negative integer");
+    }
+
+    [Test]
+    public async Task Parse_PartitionStrategyInvalid_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition-strategy", "invalid"]);
+
+        await Assert.That(options.Error).IsEqualTo("--partition-strategy must be 'file' or 'spec-count'");
+    }
+
+    [Test]
+    public async Task Parse_PartitionStrategyFileValid()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition", "2", "--partition-index", "0", "--partition-strategy", "file"]);
+
+        await Assert.That(options.PartitionStrategy).IsEqualTo("file");
+        await Assert.That(options.Error).IsNull();
+    }
+
+    [Test]
+    public async Task Parse_PartitionStrategyIsCaseInsensitive()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition", "2", "--partition-index", "0", "--partition-strategy", "SPEC-COUNT"]);
+
+        await Assert.That(options.PartitionStrategy).IsEqualTo("spec-count");
+        await Assert.That(options.Error).IsNull();
+    }
+
+    [Test]
+    public async Task Parse_PartitionOptionsMarkedAsExplicitlySet()
+    {
+        var options = CliOptionsParser.Parse(["run", ".", "--partition", "4", "--partition-index", "2", "--partition-strategy", "spec-count"]);
+
+        await Assert.That(options.ExplicitlySet).Contains(nameof(CliOptions.Partition));
+        await Assert.That(options.ExplicitlySet).Contains(nameof(CliOptions.PartitionIndex));
+        await Assert.That(options.ExplicitlySet).Contains(nameof(CliOptions.PartitionStrategy));
+    }
+
+    [Test]
+    public async Task Parse_DefaultPartitionValues()
+    {
+        var options = CliOptionsParser.Parse(["run", "."]);
+
+        await Assert.That(options.Partition).IsNull();
+        await Assert.That(options.PartitionIndex).IsNull();
+        await Assert.That(options.PartitionStrategy).IsEqualTo("file");
+    }
+
+    #endregion
 }

--- a/tests/DraftSpec.Tests/Cli/Commands/ListCommandTests.cs
+++ b/tests/DraftSpec.Tests/Cli/Commands/ListCommandTests.cs
@@ -1,6 +1,7 @@
 using DraftSpec.Cli;
 using DraftSpec.Cli.Commands;
 using DraftSpec.Cli.Formatters;
+using DraftSpec.Cli.Services;
 using DraftSpec.TestingPlatform;
 
 namespace DraftSpec.Tests.Cli.Commands;
@@ -15,6 +16,7 @@ public class ListCommandTests
     private string _tempDir = null!;
     private MockConsole _console = null!;
     private RealFileSystem _fileSystem = null!;
+    private MockPartitioner _partitioner = null!;
 
     [Before(Test)]
     public void SetUp()
@@ -23,6 +25,7 @@ public class ListCommandTests
         Directory.CreateDirectory(_tempDir);
         _console = new MockConsole();
         _fileSystem = new RealFileSystem();
+        _partitioner = new MockPartitioner();
     }
 
     [After(Test)]
@@ -32,7 +35,7 @@ public class ListCommandTests
             Directory.Delete(_tempDir, recursive: true);
     }
 
-    private ListCommand CreateCommand() => new(_console, _fileSystem);
+    private ListCommand CreateCommand() => new(_console, _fileSystem, _partitioner);
 
     #region Path Validation
 
@@ -618,23 +621,11 @@ public class ListCommandTests
 
     #region Mocks
 
-    private class MockConsole : IConsole
-    {
-        private readonly List<string> _output = [];
+    // Aliases and specific implementations
+    private class MockConsole : TestMocks.MockConsole { }
+    private class MockPartitioner : TestMocks.NullPartitioner { }
 
-        public string Output => string.Join("", _output);
-
-        public void Write(string text) => _output.Add(text);
-        public void WriteLine(string text) => _output.Add(text + "\n");
-        public void WriteLine() => _output.Add("\n");
-        public ConsoleColor ForegroundColor { get; set; }
-        public void ResetColor() { }
-        public void Clear() { }
-        public void WriteWarning(string text) => WriteLine(text);
-        public void WriteSuccess(string text) => WriteLine(text);
-        public void WriteError(string text) => WriteLine(text);
-    }
-
+    // RealFileSystem is specific to these tests - uses actual file system for integration testing
     private class RealFileSystem : IFileSystem
     {
         public bool FileExists(string path) => File.Exists(path);

--- a/tests/DraftSpec.Tests/Cli/Commands/RunCommandTests.cs
+++ b/tests/DraftSpec.Tests/Cli/Commands/RunCommandTests.cs
@@ -406,7 +406,8 @@ public class RunCommandTests
             configLoader ?? new MockConfigLoader(),
             fileSystem ?? new MockFileSystem(),
             environment ?? new MockEnvironment(),
-            new MockStatsCollector());
+            new MockStatsCollector(),
+            new MockPartitioner());
     }
 
     #endregion
@@ -505,98 +506,18 @@ public class RunCommandTests
         public void ClearBuildCache() { }
     }
 
-    private class MockConsole : IConsole
+    // Aliases for shared mocks from TestMocks
+    private class MockConsole : TestMocks.MockConsole { }
+    private class MockFormatterRegistry : TestMocks.NullFormatterRegistry { }
+    private class MockConfigLoader : TestMocks.NullConfigLoader
     {
-        private readonly List<string> _output = [];
-
-        public string Output => string.Join("", _output);
-
-        public void Write(string text) => _output.Add(text);
-        public void WriteLine(string text) => _output.Add(text + "\n");
-        public void WriteLine() => _output.Add("\n");
-        public ConsoleColor ForegroundColor { get; set; }
-        public void ResetColor() { }
-        public void Clear() { }
-        public void WriteWarning(string text) => WriteLine(text);
-        public void WriteSuccess(string text) => WriteLine(text);
-        public void WriteError(string text) => WriteLine(text);
+        public MockConfigLoader(string? error = null) : base(error) { }
     }
-
-    private class MockFormatterRegistry : ICliFormatterRegistry
-    {
-        public IFormatter? GetFormatter(string name, CliOptions? options = null) => null;
-        public void Register(string name, Func<CliOptions?, IFormatter> factory) { }
-        public IEnumerable<string> Names => [];
-    }
-
-    private class MockConfigLoader : IConfigLoader
-    {
-        private readonly string? _error;
-
-        public MockConfigLoader(string? error = null) => _error = error;
-
-        public ConfigLoadResult Load(string? path = null)
-        {
-            if (_error != null)
-                return new ConfigLoadResult(null, _error, null);
-
-            return new ConfigLoadResult(null, null, null);
-        }
-    }
-
-    private class MockFileSystem : IFileSystem
-    {
-        public bool FileExists(string path) => false;
-        public void WriteAllText(string path, string content) { }
-        public Task WriteAllTextAsync(string path, string content, CancellationToken ct = default) => Task.CompletedTask;
-        public string ReadAllText(string path) => "";
-        public bool DirectoryExists(string path) => true;
-        public void CreateDirectory(string path) { }
-        public string[] GetFiles(string path, string searchPattern) => [];
-        public string[] GetFiles(string path, string searchPattern, SearchOption searchOption) => [];
-        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption) => [];
-        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern) => [];
-        public DateTime GetLastWriteTimeUtc(string path) => DateTime.MinValue;
-    }
-
-    private class TrackingFileSystem : IFileSystem
-    {
-        public List<(string Path, string Content)> WrittenFiles { get; } = [];
-
-        public bool FileExists(string path) => false;
-        public void WriteAllText(string path, string content) => WrittenFiles.Add((path, content));
-        public Task WriteAllTextAsync(string path, string content, CancellationToken ct = default)
-        {
-            WrittenFiles.Add((path, content));
-            return Task.CompletedTask;
-        }
-        public string ReadAllText(string path) => "";
-        public bool DirectoryExists(string path) => true;
-        public void CreateDirectory(string path) { }
-        public string[] GetFiles(string path, string searchPattern) => [];
-        public string[] GetFiles(string path, string searchPattern, SearchOption searchOption) => [];
-        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption) => [];
-        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern) => [];
-        public DateTime GetLastWriteTimeUtc(string path) => DateTime.MinValue;
-    }
-
-    private class MockStatsCollector : ISpecStatsCollector
-    {
-        public Task<SpecStats> CollectAsync(
-            IReadOnlyList<string> specFiles,
-            string projectPath,
-            CancellationToken ct = default)
-        {
-            return Task.FromResult(new SpecStats(
-                Total: 0,
-                Regular: 0,
-                Focused: 0,
-                Skipped: 0,
-                Pending: 0,
-                HasFocusMode: false,
-                FileCount: specFiles.Count));
-        }
-    }
+    private class MockFileSystem : TestMocks.NullFileSystem { }
+    private class TrackingFileSystem : TestMocks.TrackingFileSystem { }
+    private class MockStatsCollector : TestMocks.NullStatsCollector { }
+    private class MockPartitioner : TestMocks.NullPartitioner { }
+    private class MockEnvironment : TestMocks.NullEnvironment { }
 
     #endregion
 }

--- a/tests/DraftSpec.Tests/Cli/SpecPartitionerTests.cs
+++ b/tests/DraftSpec.Tests/Cli/SpecPartitionerTests.cs
@@ -1,0 +1,216 @@
+using DraftSpec.Cli.Services;
+
+namespace DraftSpec.Tests.Cli;
+
+/// <summary>
+/// Tests for SpecPartitioner class.
+/// </summary>
+public class SpecPartitionerTests
+{
+    #region Partition By File (Round-Robin)
+
+    [Test]
+    public async Task PartitionByFile_EvenDistribution_AssignsCorrectly()
+    {
+        var partitioner = new SpecPartitioner();
+        var files = new List<string> { "a.spec.csx", "b.spec.csx", "c.spec.csx", "d.spec.csx" };
+
+        var result0 = await partitioner.PartitionAsync(files, 4, 0, "file", "/project");
+        var result1 = await partitioner.PartitionAsync(files, 4, 1, "file", "/project");
+        var result2 = await partitioner.PartitionAsync(files, 4, 2, "file", "/project");
+        var result3 = await partitioner.PartitionAsync(files, 4, 3, "file", "/project");
+
+        // Round-robin assignment after sorting: a.spec.csx(0), b.spec.csx(1), c.spec.csx(2), d.spec.csx(3)
+        await Assert.That(result0.Files).HasSingleItem().And.Contains("a.spec.csx");
+        await Assert.That(result1.Files).HasSingleItem().And.Contains("b.spec.csx");
+        await Assert.That(result2.Files).HasSingleItem().And.Contains("c.spec.csx");
+        await Assert.That(result3.Files).HasSingleItem().And.Contains("d.spec.csx");
+    }
+
+    [Test]
+    public async Task PartitionByFile_UnevenDistribution_HandlesRemainder()
+    {
+        var partitioner = new SpecPartitioner();
+        var files = new List<string> { "a.spec.csx", "b.spec.csx", "c.spec.csx", "d.spec.csx", "e.spec.csx" };
+
+        var result0 = await partitioner.PartitionAsync(files, 2, 0, "file", "/project");
+        var result1 = await partitioner.PartitionAsync(files, 2, 1, "file", "/project");
+
+        // Round-robin: 0->a, 1->b, 0->c, 1->d, 0->e
+        await Assert.That(result0.Files.Count).IsEqualTo(3);
+        await Assert.That(result1.Files.Count).IsEqualTo(2);
+        await Assert.That(result0.Files).Contains("a.spec.csx");
+        await Assert.That(result0.Files).Contains("c.spec.csx");
+        await Assert.That(result0.Files).Contains("e.spec.csx");
+        await Assert.That(result1.Files).Contains("b.spec.csx");
+        await Assert.That(result1.Files).Contains("d.spec.csx");
+    }
+
+    [Test]
+    public async Task PartitionByFile_MorePartitionsThanFiles_SomeEmpty()
+    {
+        var partitioner = new SpecPartitioner();
+        var files = new List<string> { "a.spec.csx", "b.spec.csx" };
+
+        var result0 = await partitioner.PartitionAsync(files, 4, 0, "file", "/project");
+        var result1 = await partitioner.PartitionAsync(files, 4, 1, "file", "/project");
+        var result2 = await partitioner.PartitionAsync(files, 4, 2, "file", "/project");
+        var result3 = await partitioner.PartitionAsync(files, 4, 3, "file", "/project");
+
+        await Assert.That(result0.Files.Count).IsEqualTo(1);
+        await Assert.That(result1.Files.Count).IsEqualTo(1);
+        await Assert.That(result2.Files.Count).IsEqualTo(0);
+        await Assert.That(result3.Files.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task PartitionByFile_IsDeterministic()
+    {
+        var partitioner = new SpecPartitioner();
+        var files = new List<string> { "c.spec.csx", "a.spec.csx", "b.spec.csx" };
+
+        var result1 = await partitioner.PartitionAsync(files, 3, 0, "file", "/project");
+        var result2 = await partitioner.PartitionAsync(files, 3, 0, "file", "/project");
+
+        await Assert.That(result1.Files.SequenceEqual(result2.Files)).IsTrue();
+    }
+
+    [Test]
+    public async Task PartitionByFile_SortsFilesFirst()
+    {
+        var partitioner = new SpecPartitioner();
+        // Files in non-alphabetical order
+        var files = new List<string> { "c.spec.csx", "a.spec.csx", "b.spec.csx" };
+
+        var result0 = await partitioner.PartitionAsync(files, 3, 0, "file", "/project");
+
+        // After sorting: a, b, c - so partition 0 gets "a.spec.csx"
+        await Assert.That(result0.Files).HasSingleItem().And.Contains("a.spec.csx");
+    }
+
+    [Test]
+    public async Task PartitionByFile_AllPartitionsCoverAllFiles()
+    {
+        var partitioner = new SpecPartitioner();
+        var files = new List<string> { "a.spec.csx", "b.spec.csx", "c.spec.csx", "d.spec.csx", "e.spec.csx" };
+
+        var allPartitionedFiles = new List<string>();
+        for (int i = 0; i < 3; i++)
+        {
+            var result = await partitioner.PartitionAsync(files, 3, i, "file", "/project");
+            allPartitionedFiles.AddRange(result.Files);
+        }
+
+        // All files should be covered exactly once
+        await Assert.That(allPartitionedFiles.OrderBy(f => f)).IsEquivalentTo(files.OrderBy(f => f));
+    }
+
+    [Test]
+    public async Task PartitionByFile_NoOverlap()
+    {
+        var partitioner = new SpecPartitioner();
+        var files = new List<string> { "a.spec.csx", "b.spec.csx", "c.spec.csx", "d.spec.csx" };
+
+        var result0 = await partitioner.PartitionAsync(files, 2, 0, "file", "/project");
+        var result1 = await partitioner.PartitionAsync(files, 2, 1, "file", "/project");
+
+        // No overlap between partitions
+        await Assert.That(result0.Files.Intersect(result1.Files)).IsEmpty();
+    }
+
+    #endregion
+
+    #region Empty Files
+
+    [Test]
+    public async Task Partition_EmptyFiles_ReturnsEmpty()
+    {
+        var partitioner = new SpecPartitioner();
+        var files = new List<string>();
+
+        var result = await partitioner.PartitionAsync(files, 4, 0, "file", "/project");
+
+        await Assert.That(result.Files).IsEmpty();
+        await Assert.That(result.TotalFiles).IsEqualTo(0);
+    }
+
+    #endregion
+
+    #region TotalFiles Tracking
+
+    [Test]
+    public async Task Partition_SetsTotalFiles()
+    {
+        var partitioner = new SpecPartitioner();
+        var files = new List<string> { "a.spec.csx", "b.spec.csx", "c.spec.csx" };
+
+        var result = await partitioner.PartitionAsync(files, 2, 0, "file", "/project");
+
+        await Assert.That(result.TotalFiles).IsEqualTo(3);
+    }
+
+    #endregion
+
+    #region Single File
+
+    [Test]
+    public async Task PartitionByFile_SingleFile_GoesToFirstPartition()
+    {
+        var partitioner = new SpecPartitioner();
+        var files = new List<string> { "only.spec.csx" };
+
+        var result0 = await partitioner.PartitionAsync(files, 4, 0, "file", "/project");
+        var result1 = await partitioner.PartitionAsync(files, 4, 1, "file", "/project");
+
+        await Assert.That(result0.Files).HasSingleItem();
+        await Assert.That(result1.Files).IsEmpty();
+    }
+
+    #endregion
+
+    #region Single Partition
+
+    [Test]
+    public async Task PartitionByFile_SinglePartition_ReturnsAllFiles()
+    {
+        var partitioner = new SpecPartitioner();
+        var files = new List<string> { "a.spec.csx", "b.spec.csx", "c.spec.csx" };
+
+        var result = await partitioner.PartitionAsync(files, 1, 0, "file", "/project");
+
+        await Assert.That(result.Files.Count).IsEqualTo(3);
+        await Assert.That(result.TotalFiles).IsEqualTo(3);
+    }
+
+    #endregion
+
+    #region Strategy Selection
+
+    [Test]
+    public async Task Partition_DefaultStrategyIsFile()
+    {
+        var partitioner = new SpecPartitioner();
+        var files = new List<string> { "a.spec.csx", "b.spec.csx" };
+
+        // Passing "file" explicitly should work the same as default
+        var result = await partitioner.PartitionAsync(files, 2, 0, "file", "/project");
+
+        await Assert.That(result.Files).HasSingleItem();
+    }
+
+    [Test]
+    public async Task Partition_SpecCountStrategy_Works()
+    {
+        var partitioner = new SpecPartitioner();
+        var files = new List<string> { "a.spec.csx", "b.spec.csx" };
+
+        // With non-existent files (0 specs each), greedy assigns all to partition 0
+        // since all partitions have equal totals, first partition (0) is always chosen
+        var result = await partitioner.PartitionAsync(files, 2, 0, "spec-count", "/project");
+
+        // Both files go to partition 0 (greedy with equal weights)
+        await Assert.That(result.Files.Count).IsEqualTo(2);
+    }
+
+    #endregion
+}

--- a/tests/DraftSpec.Tests/Cli/TestMocks.cs
+++ b/tests/DraftSpec.Tests/Cli/TestMocks.cs
@@ -1,0 +1,240 @@
+using DraftSpec.Cli;
+using DraftSpec.Cli.Configuration;
+using DraftSpec.Cli.DependencyInjection;
+using DraftSpec.Cli.Services;
+using DraftSpec.Formatters;
+
+namespace DraftSpec.Tests.Cli;
+
+/// <summary>
+/// Shared mock implementations for CLI tests.
+/// </summary>
+public static class TestMocks
+{
+    /// <summary>
+    /// A console mock that captures output for assertions.
+    /// </summary>
+    public class MockConsole : IConsole
+    {
+        private readonly List<string> _output = [];
+
+        public string Output => string.Join("", _output);
+
+        public void Write(string text) => _output.Add(text);
+        public void WriteLine(string text) => _output.Add(text + "\n");
+        public void WriteLine() => _output.Add("\n");
+        public ConsoleColor ForegroundColor { get; set; }
+        public void ResetColor() { }
+        public void Clear() { }
+        public void WriteWarning(string text) => WriteLine(text);
+        public void WriteSuccess(string text) => WriteLine(text);
+        public void WriteError(string text) => WriteLine(text);
+    }
+
+    /// <summary>
+    /// A no-op console that discards all output.
+    /// </summary>
+    public class NullConsole : IConsole
+    {
+        public void Write(string text) { }
+        public void WriteLine(string text) { }
+        public void WriteLine() { }
+        public ConsoleColor ForegroundColor { get; set; }
+        public void ResetColor() { }
+        public void Clear() { }
+        public void WriteWarning(string text) { }
+        public void WriteSuccess(string text) { }
+        public void WriteError(string text) { }
+    }
+
+    /// <summary>
+    /// A no-op file system mock.
+    /// </summary>
+    public class NullFileSystem : IFileSystem
+    {
+        public bool FileExists(string path) => false;
+        public void WriteAllText(string path, string content) { }
+        public Task WriteAllTextAsync(string path, string content, CancellationToken ct = default) => Task.CompletedTask;
+        public string ReadAllText(string path) => "";
+        public bool DirectoryExists(string path) => true;
+        public void CreateDirectory(string path) { }
+        public string[] GetFiles(string path, string searchPattern) => [];
+        public string[] GetFiles(string path, string searchPattern, SearchOption searchOption) => [];
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption) => [];
+        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern) => [];
+        public DateTime GetLastWriteTimeUtc(string path) => DateTime.MinValue;
+    }
+
+    /// <summary>
+    /// A file system that tracks writes for assertions.
+    /// </summary>
+    public class TrackingFileSystem : IFileSystem
+    {
+        public List<(string Path, string Content)> WrittenFiles { get; } = [];
+
+        public bool FileExists(string path) => false;
+        public void WriteAllText(string path, string content) => WrittenFiles.Add((path, content));
+        public Task WriteAllTextAsync(string path, string content, CancellationToken ct = default)
+        {
+            WrittenFiles.Add((path, content));
+            return Task.CompletedTask;
+        }
+        public string ReadAllText(string path) => "";
+        public bool DirectoryExists(string path) => true;
+        public void CreateDirectory(string path) { }
+        public string[] GetFiles(string path, string searchPattern) => [];
+        public string[] GetFiles(string path, string searchPattern, SearchOption searchOption) => [];
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption) => [];
+        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern) => [];
+        public DateTime GetLastWriteTimeUtc(string path) => DateTime.MinValue;
+    }
+
+    /// <summary>
+    /// A no-op spec finder.
+    /// </summary>
+    public class NullSpecFinder : ISpecFinder
+    {
+        public IReadOnlyList<string> FindSpecs(string path, string? baseDirectory = null) => [];
+    }
+
+    /// <summary>
+    /// A no-op runner factory.
+    /// </summary>
+    public class NullRunnerFactory : IInProcessSpecRunnerFactory
+    {
+        public IInProcessSpecRunner Create(
+            string? filterTags = null,
+            string? excludeTags = null,
+            string? filterName = null,
+            string? excludeName = null,
+            IReadOnlyList<string>? filterContext = null,
+            IReadOnlyList<string>? excludeContext = null) => new NullRunner();
+    }
+
+    /// <summary>
+    /// A no-op spec runner.
+    /// </summary>
+    public class NullRunner : IInProcessSpecRunner
+    {
+#pragma warning disable CS0067
+        public event Action<string>? OnBuildStarted;
+        public event Action<BuildResult>? OnBuildCompleted;
+        public event Action<string>? OnBuildSkipped;
+#pragma warning restore CS0067
+
+        public Task<InProcessRunResult> RunFileAsync(string specFile, CancellationToken ct = default)
+            => Task.FromResult(new InProcessRunResult(
+                specFile,
+                new SpecReport(),
+                TimeSpan.Zero,
+                null));
+
+        public Task<InProcessRunSummary> RunAllAsync(
+            IReadOnlyList<string> specFiles,
+            bool parallel = false,
+            CancellationToken ct = default)
+            => Task.FromResult(new InProcessRunSummary([], TimeSpan.Zero));
+
+        public void ClearBuildCache() { }
+    }
+
+    /// <summary>
+    /// A no-op formatter registry.
+    /// </summary>
+    public class NullFormatterRegistry : ICliFormatterRegistry
+    {
+        public IFormatter? GetFormatter(string name, CliOptions? options = null) => null;
+        public void Register(string name, Func<CliOptions?, IFormatter> factory) { }
+        public IEnumerable<string> Names => [];
+    }
+
+    /// <summary>
+    /// A config loader that returns empty config.
+    /// </summary>
+    public class NullConfigLoader : IConfigLoader
+    {
+        private readonly string? _error;
+
+        public NullConfigLoader(string? error = null) => _error = error;
+
+        public ConfigLoadResult Load(string? path = null)
+        {
+            if (_error != null)
+                return new ConfigLoadResult(null, _error, null);
+
+            return new ConfigLoadResult(null, null, null);
+        }
+    }
+
+    /// <summary>
+    /// A no-op environment.
+    /// </summary>
+    public class NullEnvironment : IEnvironment
+    {
+        public string CurrentDirectory => Directory.GetCurrentDirectory();
+        public string NewLine => Environment.NewLine;
+    }
+
+    /// <summary>
+    /// A no-op stats collector.
+    /// </summary>
+    public class NullStatsCollector : ISpecStatsCollector
+    {
+        public Task<SpecStats> CollectAsync(
+            IReadOnlyList<string> specFiles,
+            string projectPath,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult(new SpecStats(
+                Total: 0,
+                Regular: 0,
+                Focused: 0,
+                Skipped: 0,
+                Pending: 0,
+                HasFocusMode: false,
+                FileCount: specFiles.Count));
+        }
+    }
+
+    /// <summary>
+    /// A no-op partitioner that returns all files unmodified.
+    /// </summary>
+    public class NullPartitioner : ISpecPartitioner
+    {
+        public Task<PartitionResult> PartitionAsync(
+            IReadOnlyList<string> specFiles,
+            int totalPartitions,
+            int partitionIndex,
+            string strategy,
+            string projectPath,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult(new PartitionResult(specFiles, specFiles.Count));
+        }
+    }
+
+    /// <summary>
+    /// A no-op file watcher factory.
+    /// </summary>
+    public class NullFileWatcherFactory : IFileWatcherFactory
+    {
+        public IFileWatcher Create(string path, Action<FileChangeInfo> onChange, int debounceMs = 200) => new NullFileWatcher();
+    }
+
+    /// <summary>
+    /// A no-op file watcher.
+    /// </summary>
+    public class NullFileWatcher : IFileWatcher
+    {
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// A no-op project resolver.
+    /// </summary>
+    public class NullProjectResolver : IProjectResolver
+    {
+        public string? FindProject(string directory) => null;
+        public ProjectInfo? GetProjectInfo(string csprojPath) => null;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `--partition N` and `--partition-index I` flags to divide specs across parallel CI runners
- Support two partitioning strategies: `file` (round-robin, default) and `spec-count` (balanced by spec count)
- Enable faster test execution in distributed CI environments like GitHub Actions matrix builds
- Consolidate duplicate test mocks into shared `TestMocks.cs` for better maintainability

## Usage
```bash
# Run partition 0 of 4 (round-robin by file)
draftspec run . --partition 4 --partition-index 0

# Run partition 1 of 4 (balanced by spec count)
draftspec run . --partition 4 --partition-index 1 --partition-strategy spec-count

# GitHub Actions matrix example
jobs:
  test:
    strategy:
      matrix:
        partition: [0, 1, 2, 3]
    steps:
      - run: draftspec run . --partition 4 --partition-index ${{ matrix.partition }}
```

## Test plan
- [x] Parser tests for all partition options and error cases
- [x] Partitioner unit tests for both strategies
- [x] Cross-validation ensures `--partition` and `--partition-index` are used together
- [x] All 2100 tests pass

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)