### PR TITLE
ci: Add Codecov test analytics integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,13 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          dotnet run --project tests/DraftSpec.Tests -c Release -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml
+          dotnet run --project tests/DraftSpec.Tests -c Release -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --report-trx --report-trx-filename test-results.trx
+
+      - name: Convert TRX to JUnit
+        if: ${{ !cancelled() }}
+        run: |
+          dotnet tool install -g trx2junit
+          trx2junit tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/test-results.trx --output tests/DraftSpec.Tests/bin/Release/net10.0/TestResults
 
       - name: Run CLI integration tests
         run: |
@@ -50,6 +56,13 @@ jobs:
           files: tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/coverage.cobertura.xml
           fail_ci_if_error: false
           verbose: true
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/test-results.xml
 
       - name: Upload coverage report artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Add JUnit XML test result reporting to Codecov for failed test visibility in PR comments.

**How it works:**
1. TUnit generates TRX output during test run (`--report-trx`)
2. `trx2junit` converts TRX to JUnit XML format
3. `codecov/test-results-action@v1` uploads results to Codecov

**Benefits:**
- Failed tests appear directly in PR comments
- Flaky test detection
- Test analytics dashboard in Codecov

## Test plan

- [ ] CI workflow runs successfully
- [ ] Codecov receives test results (check Codecov dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)