### PR TITLE
feat(cli): Add pre-flight validation for CI pipelines

### DIFF
--- a/src/DraftSpec.Cli/CliOptions.cs
+++ b/src/DraftSpec.Cli/CliOptions.cs
@@ -141,6 +141,12 @@ public class CliOptions
     // Validate command options
 
     /// <summary>
+    /// Use static parsing only (no script execution).
+    /// This is the default for validate command; flag is for documentation.
+    /// </summary>
+    public bool Static { get; set; }
+
+    /// <summary>
     /// Treat warnings as errors (exit code 2 instead of 0).
     /// Used with validate command.
     /// </summary>

--- a/src/DraftSpec.Cli/CliOptionsParser.cs
+++ b/src/DraftSpec.Cli/CliOptionsParser.cs
@@ -214,6 +214,11 @@ public static class CliOptionsParser
                 options.ExplicitlySet.Add(nameof(CliOptions.SkippedOnly));
             }
             // Validate command options
+            else if (arg == "--static")
+            {
+                options.Static = true;
+                options.ExplicitlySet.Add(nameof(CliOptions.Static));
+            }
             else if (arg == "--strict")
             {
                 options.Strict = true;

--- a/tests/DraftSpec.Tests/Cli/CliOptionsParserTests.cs
+++ b/tests/DraftSpec.Tests/Cli/CliOptionsParserTests.cs
@@ -1048,4 +1048,74 @@ public class CliOptionsParserTests
     }
 
     #endregion
+
+    #region Validate Command Options
+
+    [Test]
+    public async Task Parse_StaticFlag_SetsStatic()
+    {
+        var options = CliOptionsParser.Parse(["validate", ".", "--static"]);
+
+        await Assert.That(options.Static).IsTrue();
+        await Assert.That(options.ExplicitlySet).Contains(nameof(CliOptions.Static));
+    }
+
+    [Test]
+    public async Task Parse_StrictFlag_SetsStrict()
+    {
+        var options = CliOptionsParser.Parse(["validate", ".", "--strict"]);
+
+        await Assert.That(options.Strict).IsTrue();
+        await Assert.That(options.ExplicitlySet).Contains(nameof(CliOptions.Strict));
+    }
+
+    [Test]
+    public async Task Parse_QuietFlag_SetsQuiet()
+    {
+        var options = CliOptionsParser.Parse(["validate", ".", "--quiet"]);
+
+        await Assert.That(options.Quiet).IsTrue();
+        await Assert.That(options.ExplicitlySet).Contains(nameof(CliOptions.Quiet));
+    }
+
+    [Test]
+    public async Task Parse_ShortQuietFlag_SetsQuiet()
+    {
+        var options = CliOptionsParser.Parse(["validate", ".", "-q"]);
+
+        await Assert.That(options.Quiet).IsTrue();
+    }
+
+    [Test]
+    public async Task Parse_FilesFlag_SetsFiles()
+    {
+        var options = CliOptionsParser.Parse(["validate", ".", "--files", "a.spec.csx,b.spec.csx"]);
+
+        await Assert.That(options.Files).IsNotNull();
+        await Assert.That(options.Files!.Count).IsEqualTo(2);
+        await Assert.That(options.Files).Contains("a.spec.csx");
+        await Assert.That(options.Files).Contains("b.spec.csx");
+    }
+
+    [Test]
+    public async Task Parse_FilesFlagWithoutValue_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["validate", ".", "--files"]);
+
+        await Assert.That(options.Error).IsNotNull();
+        await Assert.That(options.Error).Contains("--files requires a value");
+    }
+
+    [Test]
+    public async Task Parse_ValidateWithAllOptions_Works()
+    {
+        var options = CliOptionsParser.Parse(["validate", ".", "--static", "--strict", "--quiet"]);
+
+        await Assert.That(options.Command).IsEqualTo("validate");
+        await Assert.That(options.Static).IsTrue();
+        await Assert.That(options.Strict).IsTrue();
+        await Assert.That(options.Quiet).IsTrue();
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- Add `--static` flag to validate command for explicit documentation
- Add comprehensive validate command documentation to CLI docs
- Add CI/CD integration examples:
  - GitHub Actions pre-flight validation workflow
  - Pre-commit hook script
  - GitLab CI example
  - Partitioned execution example

Closes #194