### PR TITLE
refactor(cli): Extract LineFilter to dedicated file

### DIFF
--- a/src/DraftSpec.Cli/CliOptions.cs
+++ b/src/DraftSpec.Cli/CliOptions.cs
@@ -1,14 +1,8 @@
 using DraftSpec.Cli.Configuration;
+using DraftSpec.Cli.Options;
 using DraftSpec.Cli.Options.Enums;
 
 namespace DraftSpec.Cli;
-
-/// <summary>
-/// Represents a line number filter for running specs at specific lines.
-/// </summary>
-/// <param name="File">The spec file path.</param>
-/// <param name="Lines">The line numbers to run.</param>
-public record LineFilter(string File, int[] Lines);
 
 public class CliOptions
 {

--- a/src/DraftSpec.Cli/CliOptionsParser.cs
+++ b/src/DraftSpec.Cli/CliOptionsParser.cs
@@ -1,3 +1,4 @@
+using DraftSpec.Cli.Options;
 using DraftSpec.Cli.Options.Enums;
 
 namespace DraftSpec.Cli;

--- a/src/DraftSpec.Cli/Commands/RunCommand.cs
+++ b/src/DraftSpec.Cli/Commands/RunCommand.cs
@@ -2,6 +2,7 @@ using System.Security;
 using System.Text.RegularExpressions;
 using DraftSpec.Cli.Configuration;
 using DraftSpec.Cli.DependencyInjection;
+using DraftSpec.Cli.Options;
 using DraftSpec.Cli.Options.Enums;
 using DraftSpec.Cli.Services;
 using DraftSpec.Formatters;

--- a/src/DraftSpec.Cli/Options/LineFilter.cs
+++ b/src/DraftSpec.Cli/Options/LineFilter.cs
@@ -1,0 +1,8 @@
+namespace DraftSpec.Cli.Options;
+
+/// <summary>
+/// Represents a line number filter for running specs at specific lines.
+/// </summary>
+/// <param name="File">The spec file path.</param>
+/// <param name="Lines">The line numbers to run.</param>
+public record LineFilter(string File, int[] Lines);

--- a/tests/DraftSpec.Tests/Cli/Commands/RunCommandTests.cs
+++ b/tests/DraftSpec.Tests/Cli/Commands/RunCommandTests.cs
@@ -2,6 +2,7 @@ using DraftSpec.Cli;
 using DraftSpec.Cli.Commands;
 using DraftSpec.Cli.Configuration;
 using DraftSpec.Cli.DependencyInjection;
+using DraftSpec.Cli.Options;
 using DraftSpec.Cli.Options.Enums;
 using DraftSpec.Cli.Services;
 using DraftSpec.Formatters;


### PR DESCRIPTION
## Summary
Move `LineFilter` record from `CliOptions.cs` to its own file at `Options/LineFilter.cs` for better organization.

## Changes
- Create `src/DraftSpec.Cli/Options/LineFilter.cs`
- Add `using DraftSpec.Cli.Options;` to files that reference LineFilter

## Test plan
- [x] All 2416 tests pass

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)