### PR TITLE
refactor(cli): Add ApplyIfNotSet helper to reduce repetition

### DIFF
--- a/src/DraftSpec.Cli/CliOptions.cs
+++ b/src/DraftSpec.Cli/CliOptions.cs
@@ -216,47 +216,24 @@ public class CliOptions
     /// <param name="config">The project configuration to apply.</param>
     public void ApplyDefaults(DraftSpecProjectConfig config)
     {
-        if (!ExplicitlySet.Contains(nameof(Parallel)) && config.Parallel.HasValue)
-            Parallel = config.Parallel.Value;
+        ExplicitlySet.ApplyIfNotSet(nameof(Parallel), v => Parallel = v, config.Parallel);
+        ExplicitlySet.ApplyIfNotSet(nameof(Bail), v => Bail = v, config.Bail);
+        ExplicitlySet.ApplyIfNotSet(nameof(NoCache), v => NoCache = v, config.NoCache);
 
-        if (!ExplicitlySet.Contains(nameof(Bail)) && config.Bail.HasValue)
-            Bail = config.Bail.Value;
+        ExplicitlySet.ApplyIfValid<OutputFormat>(nameof(Format), v => Format = v, config.Format,
+            (string s, out OutputFormat r) => s.TryParseOutputFormat(out r));
 
-        if (!ExplicitlySet.Contains(nameof(NoCache)) && config.NoCache.HasValue)
-            NoCache = config.NoCache.Value;
-
-        if (!ExplicitlySet.Contains(nameof(Format)) && !string.IsNullOrEmpty(config.Format))
-        {
-            if (config.Format.TryParseOutputFormat(out var format))
-                Format = format;
-        }
-
-        if (!ExplicitlySet.Contains(nameof(OutputFile)) && !string.IsNullOrEmpty(config.OutputDirectory))
-            OutputFile = config.OutputDirectory;
-
-        if (!ExplicitlySet.Contains(nameof(FilterTags)) && config.Tags?.Include is { Count: > 0 })
-            FilterTags = string.Join(",", config.Tags.Include);
-
-        if (!ExplicitlySet.Contains(nameof(ExcludeTags)) && config.Tags?.Exclude is { Count: > 0 })
-            ExcludeTags = string.Join(",", config.Tags.Exclude);
-
-        if (!ExplicitlySet.Contains(nameof(Reporters)) && config.Reporters is { Count: > 0 })
-            Reporters = string.Join(",", config.Reporters);
+        ExplicitlySet.ApplyIfNotEmpty(nameof(OutputFile), v => OutputFile = v, config.OutputDirectory);
+        ExplicitlySet.ApplyIfNotEmpty(nameof(FilterTags), v => FilterTags = v, config.Tags?.Include);
+        ExplicitlySet.ApplyIfNotEmpty(nameof(ExcludeTags), v => ExcludeTags = v, config.Tags?.Exclude);
+        ExplicitlySet.ApplyIfNotEmpty(nameof(Reporters), v => Reporters = v, config.Reporters);
 
         // Coverage configuration
-        if (!ExplicitlySet.Contains(nameof(Coverage)) && config.Coverage?.Enabled == true)
-            Coverage = true;
-
-        if (!ExplicitlySet.Contains(nameof(CoverageOutput)) && !string.IsNullOrEmpty(config.Coverage?.Output))
-            CoverageOutput = config.Coverage.Output;
-
-        if (!ExplicitlySet.Contains(nameof(CoverageFormat)) && !string.IsNullOrEmpty(config.Coverage?.Format))
-        {
-            if (config.Coverage.Format.TryParseCoverageFormat(out var coverageFormat))
-                CoverageFormat = coverageFormat;
-        }
-
-        if (!ExplicitlySet.Contains(nameof(CoverageReportFormats)) && config.Coverage?.ReportFormats is { Count: > 0 })
-            CoverageReportFormats = string.Join(",", config.Coverage.ReportFormats);
+        ExplicitlySet.ApplyIfTrue(nameof(Coverage), v => Coverage = v, config.Coverage?.Enabled);
+        ExplicitlySet.ApplyIfNotEmpty(nameof(CoverageOutput), v => CoverageOutput = v, config.Coverage?.Output);
+        ExplicitlySet.ApplyIfValid<CoverageFormat>(nameof(CoverageFormat), v => CoverageFormat = v,
+            config.Coverage?.Format, (string s, out CoverageFormat r) => s.TryParseCoverageFormat(out r));
+        ExplicitlySet.ApplyIfNotEmpty(nameof(CoverageReportFormats), v => CoverageReportFormats = v,
+            config.Coverage?.ReportFormats);
     }
 }

--- a/src/DraftSpec.Cli/Configuration/ExplicitlySetExtensions.cs
+++ b/src/DraftSpec.Cli/Configuration/ExplicitlySetExtensions.cs
@@ -1,0 +1,80 @@
+namespace DraftSpec.Cli.Configuration;
+
+/// <summary>
+/// Extension methods for applying configuration values only when not explicitly set via CLI.
+/// Reduces repetitive patterns in CliOptions.ApplyDefaults.
+/// </summary>
+public static class ExplicitlySetExtensions
+{
+    /// <summary>
+    /// Applies a nullable value type if the property was not explicitly set.
+    /// </summary>
+    public static void ApplyIfNotSet<T>(
+        this HashSet<string> explicitlySet,
+        string propertyName,
+        Action<T> setter,
+        T? value) where T : struct
+    {
+        if (!explicitlySet.Contains(propertyName) && value.HasValue)
+            setter(value.Value);
+    }
+
+    /// <summary>
+    /// Applies a string value if the property was not explicitly set and the value is not null/empty.
+    /// </summary>
+    public static void ApplyIfNotEmpty(
+        this HashSet<string> explicitlySet,
+        string propertyName,
+        Action<string> setter,
+        string? value)
+    {
+        if (!explicitlySet.Contains(propertyName) && !string.IsNullOrEmpty(value))
+            setter(value);
+    }
+
+    /// <summary>
+    /// Applies a joined list of values if the property was not explicitly set and the list is not empty.
+    /// </summary>
+    public static void ApplyIfNotEmpty(
+        this HashSet<string> explicitlySet,
+        string propertyName,
+        Action<string> setter,
+        IReadOnlyList<string>? values,
+        string separator = ",")
+    {
+        if (!explicitlySet.Contains(propertyName) && values is { Count: > 0 })
+            setter(string.Join(separator, values));
+    }
+
+    /// <summary>
+    /// Delegate for TryParse-style methods.
+    /// </summary>
+    public delegate bool TryParseFunc<T>(string value, out T result);
+
+    /// <summary>
+    /// Applies a parsed value if the property was not explicitly set and parsing succeeds.
+    /// </summary>
+    public static void ApplyIfValid<T>(
+        this HashSet<string> explicitlySet,
+        string propertyName,
+        Action<T> setter,
+        string? value,
+        TryParseFunc<T> tryParse)
+    {
+        if (!explicitlySet.Contains(propertyName) && !string.IsNullOrEmpty(value) && tryParse(value, out var parsed))
+            setter(parsed);
+    }
+
+    /// <summary>
+    /// Applies true if the property was not explicitly set and the condition is true.
+    /// </summary>
+    public static void ApplyIfTrue(
+        this HashSet<string> explicitlySet,
+        string propertyName,
+        Action<bool> setter,
+        bool? condition)
+    {
+        if (!explicitlySet.Contains(propertyName) && condition == true)
+            setter(true);
+    }
+}


### PR DESCRIPTION
## Summary
Add extension methods for `HashSet<string>` to simplify the `ApplyDefaults` method:
- `ApplyIfNotSet<T>`: for nullable value types (bool?, int?)
- `ApplyIfNotEmpty`: for strings and lists
- `ApplyIfValid<T>`: for values requiring TryParse conversion
- `ApplyIfTrue`: for boolean conditions

## Before (40+ lines)
```csharp
if (!ExplicitlySet.Contains(nameof(Parallel)) && config.Parallel.HasValue)
    Parallel = config.Parallel.Value;

if (!ExplicitlySet.Contains(nameof(Bail)) && config.Bail.HasValue)
    Bail = config.Bail.Value;
// ... repeated 12+ times
```

## After (12 concise calls)
```csharp
ExplicitlySet.ApplyIfNotSet(nameof(Parallel), v => Parallel = v, config.Parallel);
ExplicitlySet.ApplyIfNotSet(nameof(Bail), v => Bail = v, config.Bail);
```

## Test plan
- [x] All 2416 tests pass
- [x] Existing ConfigLoaderTests verify ApplyDefaults behavior

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)