### PR TITLE
refactor(cli): Extract composable option groups

### DIFF
--- a/src/DraftSpec.Cli/Options/CoverageOptions.cs
+++ b/src/DraftSpec.Cli/Options/CoverageOptions.cs
@@ -1,0 +1,39 @@
+using DraftSpec.Cli.Options.Enums;
+
+namespace DraftSpec.Cli.Options;
+
+/// <summary>
+/// Composable options for code coverage collection.
+/// Used by run command.
+/// </summary>
+public class CoverageOptions
+{
+    /// <summary>
+    /// Enable code coverage collection via dotnet-coverage.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Output directory for coverage reports.
+    /// Default: ./coverage
+    /// </summary>
+    public string? Output { get; set; }
+
+    /// <summary>
+    /// Coverage output format: cobertura, xml, or coverage.
+    /// Default: cobertura
+    /// </summary>
+    public CoverageFormat Format { get; set; } = CoverageFormat.Cobertura;
+
+    /// <summary>
+    /// Additional coverage report formats to generate (comma-separated).
+    /// Options: html, json
+    /// Example: "html,json" generates both HTML and JSON reports.
+    /// </summary>
+    public string? ReportFormats { get; set; }
+
+    /// <summary>
+    /// Returns the output directory, defaulting to "./coverage" if not set.
+    /// </summary>
+    public string OutputDirectory => Output ?? "./coverage";
+}

--- a/src/DraftSpec.Cli/Options/FilterOptions.cs
+++ b/src/DraftSpec.Cli/Options/FilterOptions.cs
@@ -1,0 +1,72 @@
+namespace DraftSpec.Cli.Options;
+
+/// <summary>
+/// Composable options for filtering which specs to run.
+/// Used by run, list, and watch commands.
+/// </summary>
+public class FilterOptions
+{
+    /// <summary>
+    /// Specific spec name to run.
+    /// </summary>
+    public string? SpecName { get; set; }
+
+    /// <summary>
+    /// Comma-separated list of tags to include.
+    /// Only specs with any of these tags will run.
+    /// </summary>
+    public string? FilterTags { get; set; }
+
+    /// <summary>
+    /// Comma-separated list of tags to exclude.
+    /// Specs with any of these tags will be skipped.
+    /// </summary>
+    public string? ExcludeTags { get; set; }
+
+    /// <summary>
+    /// Regex pattern to match spec names (context path + description).
+    /// Only specs matching this pattern will run.
+    /// </summary>
+    public string? FilterName { get; set; }
+
+    /// <summary>
+    /// Regex pattern to exclude spec names (context path + description).
+    /// Specs matching this pattern will be skipped.
+    /// </summary>
+    public string? ExcludeName { get; set; }
+
+    /// <summary>
+    /// Context patterns to include (glob-style with / separator).
+    /// Only specs within matching contexts will run.
+    /// Supports * (single segment) and ** (multiple segments).
+    /// Example: "UserService/CreateAsync", "*/CreateAsync", "Integration/**"
+    /// </summary>
+    public List<string>? FilterContext { get; set; }
+
+    /// <summary>
+    /// Context patterns to exclude (glob-style with / separator).
+    /// Specs within matching contexts will be skipped.
+    /// Supports * (single segment) and ** (multiple segments).
+    /// Example: "Legacy/*", "**/Slow"
+    /// </summary>
+    public List<string>? ExcludeContext { get; set; }
+
+    /// <summary>
+    /// Line number filters parsed from file:line syntax.
+    /// Used to run specific specs by line number (e.g., "file.spec.csx:15,23").
+    /// </summary>
+    public List<LineFilter>? LineFilters { get; set; }
+
+    /// <summary>
+    /// Returns true if any filter is active.
+    /// </summary>
+    public bool HasActiveFilters =>
+        !string.IsNullOrEmpty(SpecName) ||
+        !string.IsNullOrEmpty(FilterTags) ||
+        !string.IsNullOrEmpty(ExcludeTags) ||
+        !string.IsNullOrEmpty(FilterName) ||
+        !string.IsNullOrEmpty(ExcludeName) ||
+        FilterContext is { Count: > 0 } ||
+        ExcludeContext is { Count: > 0 } ||
+        LineFilters is { Count: > 0 };
+}

--- a/src/DraftSpec.Cli/Options/PartitionOptions.cs
+++ b/src/DraftSpec.Cli/Options/PartitionOptions.cs
@@ -1,0 +1,57 @@
+using DraftSpec.Cli.Options.Enums;
+
+namespace DraftSpec.Cli.Options;
+
+/// <summary>
+/// Composable options for CI parallelism via spec partitioning.
+/// Used by run command.
+/// </summary>
+public class PartitionOptions
+{
+    /// <summary>
+    /// Total number of partitions to divide specs into.
+    /// Used with Index for CI parallel execution.
+    /// </summary>
+    public int? Total { get; set; }
+
+    /// <summary>
+    /// Zero-based index of this partition (0 to Total-1).
+    /// </summary>
+    public int? Index { get; set; }
+
+    /// <summary>
+    /// Strategy for partitioning: "file" (default) or "spec-count".
+    /// - file: Round-robin by sorted file path (fast, deterministic)
+    /// - spec-count: Balance by spec count per file (requires parsing)
+    /// </summary>
+    public PartitionStrategy Strategy { get; set; } = PartitionStrategy.File;
+
+    /// <summary>
+    /// Returns true if partitioning is enabled (both Total and Index are set).
+    /// </summary>
+    public bool IsEnabled => Total.HasValue && Index.HasValue;
+
+    /// <summary>
+    /// Validates the partition options.
+    /// </summary>
+    /// <returns>Error message if invalid, null if valid.</returns>
+    public string? Validate()
+    {
+        if (Total.HasValue && !Index.HasValue)
+            return "--partition requires --partition-index";
+
+        if (!Total.HasValue && Index.HasValue)
+            return "--partition-index requires --partition";
+
+        if (Total.HasValue && Total.Value < 1)
+            return "--partition must be at least 1";
+
+        if (Index.HasValue && Index.Value < 0)
+            return "--partition-index must be at least 0";
+
+        if (Total.HasValue && Index.HasValue && Index.Value >= Total.Value)
+            return $"--partition-index must be less than --partition ({Total.Value})";
+
+        return null;
+    }
+}

--- a/tests/DraftSpec.Tests/Cli/Options/ComposableOptionsTests.cs
+++ b/tests/DraftSpec.Tests/Cli/Options/ComposableOptionsTests.cs
@@ -1,0 +1,229 @@
+using DraftSpec.Cli.Options;
+using DraftSpec.Cli.Options.Enums;
+
+namespace DraftSpec.Tests.Cli.Options;
+
+/// <summary>
+/// Tests for composable option classes.
+/// </summary>
+public class ComposableOptionsTests
+{
+    #region FilterOptions
+
+    [Test]
+    public async Task FilterOptions_DefaultValues_NoActiveFilters()
+    {
+        var options = new FilterOptions();
+
+        await Assert.That(options.HasActiveFilters).IsFalse();
+        await Assert.That(options.SpecName).IsNull();
+        await Assert.That(options.FilterTags).IsNull();
+        await Assert.That(options.ExcludeTags).IsNull();
+        await Assert.That(options.FilterName).IsNull();
+        await Assert.That(options.ExcludeName).IsNull();
+        await Assert.That(options.FilterContext).IsNull();
+        await Assert.That(options.ExcludeContext).IsNull();
+        await Assert.That(options.LineFilters).IsNull();
+    }
+
+    [Test]
+    public async Task FilterOptions_SpecName_HasActiveFilters()
+    {
+        var options = new FilterOptions { SpecName = "my-spec" };
+        await Assert.That(options.HasActiveFilters).IsTrue();
+    }
+
+    [Test]
+    public async Task FilterOptions_FilterTags_HasActiveFilters()
+    {
+        var options = new FilterOptions { FilterTags = "unit,fast" };
+        await Assert.That(options.HasActiveFilters).IsTrue();
+    }
+
+    [Test]
+    public async Task FilterOptions_ExcludeTags_HasActiveFilters()
+    {
+        var options = new FilterOptions { ExcludeTags = "slow" };
+        await Assert.That(options.HasActiveFilters).IsTrue();
+    }
+
+    [Test]
+    public async Task FilterOptions_FilterName_HasActiveFilters()
+    {
+        var options = new FilterOptions { FilterName = ".*Create.*" };
+        await Assert.That(options.HasActiveFilters).IsTrue();
+    }
+
+    [Test]
+    public async Task FilterOptions_ExcludeName_HasActiveFilters()
+    {
+        var options = new FilterOptions { ExcludeName = ".*Legacy.*" };
+        await Assert.That(options.HasActiveFilters).IsTrue();
+    }
+
+    [Test]
+    public async Task FilterOptions_FilterContext_HasActiveFilters()
+    {
+        var options = new FilterOptions { FilterContext = ["UserService/*"] };
+        await Assert.That(options.HasActiveFilters).IsTrue();
+    }
+
+    [Test]
+    public async Task FilterOptions_ExcludeContext_HasActiveFilters()
+    {
+        var options = new FilterOptions { ExcludeContext = ["Legacy/**"] };
+        await Assert.That(options.HasActiveFilters).IsTrue();
+    }
+
+    [Test]
+    public async Task FilterOptions_LineFilters_HasActiveFilters()
+    {
+        var options = new FilterOptions { LineFilters = [new LineFilter("test.spec.csx", [10, 20])] };
+        await Assert.That(options.HasActiveFilters).IsTrue();
+    }
+
+    [Test]
+    public async Task FilterOptions_EmptyCollections_NoActiveFilters()
+    {
+        var options = new FilterOptions
+        {
+            FilterContext = [],
+            ExcludeContext = [],
+            LineFilters = []
+        };
+        await Assert.That(options.HasActiveFilters).IsFalse();
+    }
+
+    #endregion
+
+    #region CoverageOptions
+
+    [Test]
+    public async Task CoverageOptions_DefaultValues()
+    {
+        var options = new CoverageOptions();
+
+        await Assert.That(options.Enabled).IsFalse();
+        await Assert.That(options.Output).IsNull();
+        await Assert.That(options.Format).IsEqualTo(CoverageFormat.Cobertura);
+        await Assert.That(options.ReportFormats).IsNull();
+        await Assert.That(options.OutputDirectory).IsEqualTo("./coverage");
+    }
+
+    [Test]
+    public async Task CoverageOptions_CustomOutput_ReturnsCustomDirectory()
+    {
+        var options = new CoverageOptions { Output = "./my-coverage" };
+        await Assert.That(options.OutputDirectory).IsEqualTo("./my-coverage");
+    }
+
+    [Test]
+    public async Task CoverageOptions_AllPropertiesSet()
+    {
+        var options = new CoverageOptions
+        {
+            Enabled = true,
+            Output = "./reports",
+            Format = CoverageFormat.Xml,
+            ReportFormats = "html,json"
+        };
+
+        await Assert.That(options.Enabled).IsTrue();
+        await Assert.That(options.Output).IsEqualTo("./reports");
+        await Assert.That(options.Format).IsEqualTo(CoverageFormat.Xml);
+        await Assert.That(options.ReportFormats).IsEqualTo("html,json");
+        await Assert.That(options.OutputDirectory).IsEqualTo("./reports");
+    }
+
+    #endregion
+
+    #region PartitionOptions
+
+    [Test]
+    public async Task PartitionOptions_DefaultValues()
+    {
+        var options = new PartitionOptions();
+
+        await Assert.That(options.Total).IsNull();
+        await Assert.That(options.Index).IsNull();
+        await Assert.That(options.Strategy).IsEqualTo(PartitionStrategy.File);
+        await Assert.That(options.IsEnabled).IsFalse();
+        await Assert.That(options.Validate()).IsNull();
+    }
+
+    [Test]
+    public async Task PartitionOptions_BothSet_IsEnabled()
+    {
+        var options = new PartitionOptions { Total = 4, Index = 0 };
+
+        await Assert.That(options.IsEnabled).IsTrue();
+        await Assert.That(options.Validate()).IsNull();
+    }
+
+    [Test]
+    public async Task PartitionOptions_OnlyTotal_ValidationError()
+    {
+        var options = new PartitionOptions { Total = 4 };
+
+        await Assert.That(options.IsEnabled).IsFalse();
+        await Assert.That(options.Validate()).IsEqualTo("--partition requires --partition-index");
+    }
+
+    [Test]
+    public async Task PartitionOptions_OnlyIndex_ValidationError()
+    {
+        var options = new PartitionOptions { Index = 0 };
+
+        await Assert.That(options.IsEnabled).IsFalse();
+        await Assert.That(options.Validate()).IsEqualTo("--partition-index requires --partition");
+    }
+
+    [Test]
+    public async Task PartitionOptions_TotalLessThanOne_ValidationError()
+    {
+        var options = new PartitionOptions { Total = 0, Index = 0 };
+
+        await Assert.That(options.Validate()).IsEqualTo("--partition must be at least 1");
+    }
+
+    [Test]
+    public async Task PartitionOptions_IndexNegative_ValidationError()
+    {
+        var options = new PartitionOptions { Total = 4, Index = -1 };
+
+        await Assert.That(options.Validate()).IsEqualTo("--partition-index must be at least 0");
+    }
+
+    [Test]
+    public async Task PartitionOptions_IndexExceedsTotal_ValidationError()
+    {
+        var options = new PartitionOptions { Total = 4, Index = 4 };
+
+        await Assert.That(options.Validate()).IsEqualTo("--partition-index must be less than --partition (4)");
+    }
+
+    [Test]
+    public async Task PartitionOptions_ValidBoundaryIndex_NoError()
+    {
+        var options = new PartitionOptions { Total = 4, Index = 3 };
+
+        await Assert.That(options.IsEnabled).IsTrue();
+        await Assert.That(options.Validate()).IsNull();
+    }
+
+    [Test]
+    public async Task PartitionOptions_SpecCountStrategy()
+    {
+        var options = new PartitionOptions
+        {
+            Total = 2,
+            Index = 1,
+            Strategy = PartitionStrategy.SpecCount
+        };
+
+        await Assert.That(options.Strategy).IsEqualTo(PartitionStrategy.SpecCount);
+        await Assert.That(options.Validate()).IsNull();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Create reusable option classes for shared concerns that can be composed into command-specific options:

### FilterOptions (8 properties)
- `SpecName`, `FilterTags`, `ExcludeTags`
- `FilterName`, `ExcludeName`
- `FilterContext`, `ExcludeContext`
- `LineFilters`
- `HasActiveFilters` computed property

### CoverageOptions (4 properties)
- `Enabled`, `Output`, `Format`, `ReportFormats`
- `OutputDirectory` computed property with default

### PartitionOptions (3 properties + validation)
- `Total`, `Index`, `Strategy`
- `IsEnabled` computed property
- `Validate()` method for validation

## Test plan
- [x] All 2416 tests pass
- [x] New classes compile and are ready for composition in #261

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)