### PR TITLE
fix(ci): Enforce coverage threshold and add enum tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,26 @@ jobs:
           dotnet tool install -g dotnet-reportgenerator-globaltool
           reportgenerator -reports:tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/coverage.cobertura.xml -targetdir:./coverage-report -reporttypes:Html
 
+      - name: Enforce coverage threshold
+        run: |
+          COVERAGE_FILE="tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/coverage.cobertura.xml"
+          THRESHOLD=85
+
+          # Extract line-rate from Cobertura XML (value between 0 and 1)
+          LINE_RATE=$(grep -oP 'line-rate="\K[0-9.]+' "$COVERAGE_FILE" | head -1)
+          COVERAGE=$(echo "$LINE_RATE * 100" | bc -l | xargs printf "%.2f")
+
+          echo "Current coverage: ${COVERAGE}%"
+          echo "Threshold: ${THRESHOLD}%"
+
+          # Compare using bc for floating point
+          if (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
+            echo "::error::Coverage ${COVERAGE}% is below threshold ${THRESHOLD}%"
+            exit 1
+          fi
+
+          echo "::notice::Coverage ${COVERAGE}% meets threshold ${THRESHOLD}%"
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,13 +7,17 @@ coverage:
       default:
         target: 85%
         threshold: 1%
-        # Fail PR if coverage drops below target
         if_ci_failed: error
+        # Post success if no base report exists (new repo/branch)
+        if_not_found: success
     patch:
       default:
-        # New code must be at least 85% covered
         target: 85%
         threshold: 0%
+        if_not_found: success
+
+# Explicitly enable GitHub Checks (default, but being explicit)
+github_checks: true
 
 comment:
   layout: "header, diff, flags, components, footer"

--- a/tests/DraftSpec.Tests/Cli/Options/EnumExtensionsTests.cs
+++ b/tests/DraftSpec.Tests/Cli/Options/EnumExtensionsTests.cs
@@ -1,0 +1,254 @@
+using DraftSpec.Cli.Options.Enums;
+
+namespace DraftSpec.Tests.Cli.Options;
+
+/// <summary>
+/// Tests for enum extension methods (Parse, TryParse, ToCliString).
+/// </summary>
+public class EnumExtensionsTests
+{
+    #region OutputFormat
+
+    [Test]
+    [Arguments("console", OutputFormat.Console)]
+    [Arguments("json", OutputFormat.Json)]
+    [Arguments("markdown", OutputFormat.Markdown)]
+    [Arguments("html", OutputFormat.Html)]
+    [Arguments("junit", OutputFormat.JUnit)]
+    [Arguments("CONSOLE", OutputFormat.Console)]
+    [Arguments("JSON", OutputFormat.Json)]
+    [Arguments("Html", OutputFormat.Html)]
+    public async Task ParseOutputFormat_ValidValues_ReturnsCorrectEnum(string input, OutputFormat expected)
+    {
+        var result = input.ParseOutputFormat();
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task ParseOutputFormat_InvalidValue_ThrowsArgumentException()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+        {
+            "invalid".ParseOutputFormat();
+            return Task.CompletedTask;
+        });
+    }
+
+    [Test]
+    [Arguments("console", true, OutputFormat.Console)]
+    [Arguments("json", true, OutputFormat.Json)]
+    [Arguments("invalid", false, OutputFormat.Console)]
+    [Arguments("", false, OutputFormat.Console)]
+    [Arguments(null, false, OutputFormat.Console)]
+    public async Task TryParseOutputFormat_ReturnsExpectedResult(string? input, bool expectedSuccess, OutputFormat expectedFormat)
+    {
+        var success = input.TryParseOutputFormat(out var format);
+        await Assert.That(success).IsEqualTo(expectedSuccess);
+        await Assert.That(format).IsEqualTo(expectedFormat);
+    }
+
+    [Test]
+    [Arguments(OutputFormat.Console, "console")]
+    [Arguments(OutputFormat.Json, "json")]
+    [Arguments(OutputFormat.Markdown, "markdown")]
+    [Arguments(OutputFormat.Html, "html")]
+    [Arguments(OutputFormat.JUnit, "junit")]
+    public async Task OutputFormat_ToCliString_ReturnsCorrectString(OutputFormat format, string expected)
+    {
+        var result = format.ToCliString();
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task OutputFormat_ToCliString_InvalidValue_ThrowsArgumentOutOfRangeException()
+    {
+        var invalidFormat = (OutputFormat)999;
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+        {
+            invalidFormat.ToCliString();
+            return Task.CompletedTask;
+        });
+    }
+
+    #endregion
+
+    #region ListFormat
+
+    [Test]
+    [Arguments("tree", ListFormat.Tree)]
+    [Arguments("flat", ListFormat.Flat)]
+    [Arguments("json", ListFormat.Json)]
+    [Arguments("TREE", ListFormat.Tree)]
+    [Arguments("Flat", ListFormat.Flat)]
+    public async Task ParseListFormat_ValidValues_ReturnsCorrectEnum(string input, ListFormat expected)
+    {
+        var result = input.ParseListFormat();
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task ParseListFormat_InvalidValue_ThrowsArgumentException()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+        {
+            "invalid".ParseListFormat();
+            return Task.CompletedTask;
+        });
+    }
+
+    [Test]
+    [Arguments("tree", true, ListFormat.Tree)]
+    [Arguments("flat", true, ListFormat.Flat)]
+    [Arguments("json", true, ListFormat.Json)]
+    [Arguments("invalid", false, ListFormat.Tree)]
+    [Arguments("", false, ListFormat.Tree)]
+    [Arguments(null, false, ListFormat.Tree)]
+    public async Task TryParseListFormat_ReturnsExpectedResult(string? input, bool expectedSuccess, ListFormat expectedFormat)
+    {
+        var success = input.TryParseListFormat(out var format);
+        await Assert.That(success).IsEqualTo(expectedSuccess);
+        await Assert.That(format).IsEqualTo(expectedFormat);
+    }
+
+    [Test]
+    [Arguments(ListFormat.Tree, "tree")]
+    [Arguments(ListFormat.Flat, "flat")]
+    [Arguments(ListFormat.Json, "json")]
+    public async Task ListFormat_ToCliString_ReturnsCorrectString(ListFormat format, string expected)
+    {
+        var result = format.ToCliString();
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task ListFormat_ToCliString_InvalidValue_ThrowsArgumentOutOfRangeException()
+    {
+        var invalidFormat = (ListFormat)999;
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+        {
+            invalidFormat.ToCliString();
+            return Task.CompletedTask;
+        });
+    }
+
+    #endregion
+
+    #region CoverageFormat
+
+    [Test]
+    [Arguments("cobertura", CoverageFormat.Cobertura)]
+    [Arguments("xml", CoverageFormat.Xml)]
+    [Arguments("coverage", CoverageFormat.Coverage)]
+    [Arguments("COBERTURA", CoverageFormat.Cobertura)]
+    [Arguments("XML", CoverageFormat.Xml)]
+    public async Task ParseCoverageFormat_ValidValues_ReturnsCorrectEnum(string input, CoverageFormat expected)
+    {
+        var result = input.ParseCoverageFormat();
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task ParseCoverageFormat_InvalidValue_ThrowsArgumentException()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+        {
+            "invalid".ParseCoverageFormat();
+            return Task.CompletedTask;
+        });
+    }
+
+    [Test]
+    [Arguments("cobertura", true, CoverageFormat.Cobertura)]
+    [Arguments("xml", true, CoverageFormat.Xml)]
+    [Arguments("coverage", true, CoverageFormat.Coverage)]
+    [Arguments("invalid", false, CoverageFormat.Cobertura)]
+    [Arguments("", false, CoverageFormat.Cobertura)]
+    [Arguments(null, false, CoverageFormat.Cobertura)]
+    public async Task TryParseCoverageFormat_ReturnsExpectedResult(string? input, bool expectedSuccess, CoverageFormat expectedFormat)
+    {
+        var success = input.TryParseCoverageFormat(out var format);
+        await Assert.That(success).IsEqualTo(expectedSuccess);
+        await Assert.That(format).IsEqualTo(expectedFormat);
+    }
+
+    [Test]
+    [Arguments(CoverageFormat.Cobertura, "cobertura")]
+    [Arguments(CoverageFormat.Xml, "xml")]
+    [Arguments(CoverageFormat.Coverage, "coverage")]
+    public async Task CoverageFormat_ToCliString_ReturnsCorrectString(CoverageFormat format, string expected)
+    {
+        var result = format.ToCliString();
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task CoverageFormat_ToCliString_InvalidValue_ThrowsArgumentOutOfRangeException()
+    {
+        var invalidFormat = (CoverageFormat)999;
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+        {
+            invalidFormat.ToCliString();
+            return Task.CompletedTask;
+        });
+    }
+
+    #endregion
+
+    #region PartitionStrategy
+
+    [Test]
+    [Arguments("file", PartitionStrategy.File)]
+    [Arguments("spec-count", PartitionStrategy.SpecCount)]
+    [Arguments("FILE", PartitionStrategy.File)]
+    [Arguments("SPEC-COUNT", PartitionStrategy.SpecCount)]
+    public async Task ParsePartitionStrategy_ValidValues_ReturnsCorrectEnum(string input, PartitionStrategy expected)
+    {
+        var result = input.ParsePartitionStrategy();
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task ParsePartitionStrategy_InvalidValue_ThrowsArgumentException()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+        {
+            "invalid".ParsePartitionStrategy();
+            return Task.CompletedTask;
+        });
+    }
+
+    [Test]
+    [Arguments("file", true, PartitionStrategy.File)]
+    [Arguments("spec-count", true, PartitionStrategy.SpecCount)]
+    [Arguments("invalid", false, PartitionStrategy.File)]
+    [Arguments("", false, PartitionStrategy.File)]
+    [Arguments(null, false, PartitionStrategy.File)]
+    public async Task TryParsePartitionStrategy_ReturnsExpectedResult(string? input, bool expectedSuccess, PartitionStrategy expectedFormat)
+    {
+        var success = input.TryParsePartitionStrategy(out var format);
+        await Assert.That(success).IsEqualTo(expectedSuccess);
+        await Assert.That(format).IsEqualTo(expectedFormat);
+    }
+
+    [Test]
+    [Arguments(PartitionStrategy.File, "file")]
+    [Arguments(PartitionStrategy.SpecCount, "spec-count")]
+    public async Task PartitionStrategy_ToCliString_ReturnsCorrectString(PartitionStrategy format, string expected)
+    {
+        var result = format.ToCliString();
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task PartitionStrategy_ToCliString_InvalidValue_ThrowsArgumentOutOfRangeException()
+    {
+        var invalidFormat = (PartitionStrategy)999;
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+        {
+            invalidFormat.ToCliString();
+            return Task.CompletedTask;
+        });
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Fixes coverage enforcement to prevent backslides like PR #264 (which merged with 49% patch coverage).

## Changes

### CI Pipeline
- Add coverage enforcement step that parses Cobertura XML and fails build if coverage < 85%
- This runs before Codecov upload, so it can't be bypassed

### Branch Protection
- Added `codecov/patch` and `codecov/project` as required status checks
- Installed Codecov GitHub App for reliable status check posting

### Tests
- Add 65 new tests for enum extension methods (`Parse`, `TryParse`, `ToCliString`)
- Covers `OutputFormat`, `ListFormat`, `CoverageFormat`, `PartitionStrategy`
- Tests valid values, invalid values, case insensitivity, and edge cases

## Test plan
- [x] All 2481 tests pass
- [x] Coverage enforcement step tested locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)