### PR TITLE
refactor: Extract ISpecFileProvider interface for testable file discovery

### DIFF
--- a/src/DraftSpec.Cli/Commands/ListCommand.cs
+++ b/src/DraftSpec.Cli/Commands/ListCommand.cs
@@ -104,16 +104,16 @@ public class ListCommand : ICommand<ListOptions>
         return 0;
     }
 
-    private static List<string> GetSpecFiles(string path)
+    private List<string> GetSpecFiles(string path)
     {
-        if (File.Exists(path) && path.EndsWith(".spec.csx", StringComparison.OrdinalIgnoreCase))
+        if (_fileSystem.FileExists(path) && path.EndsWith(".spec.csx", StringComparison.OrdinalIgnoreCase))
         {
             return [path];
         }
 
-        if (Directory.Exists(path))
+        if (_fileSystem.DirectoryExists(path))
         {
-            return Directory.EnumerateFiles(path, "*.spec.csx", SearchOption.AllDirectories).ToList();
+            return _fileSystem.EnumerateFiles(path, "*.spec.csx", SearchOption.AllDirectories).ToList();
         }
 
         return [];

--- a/src/DraftSpec.Cli/Commands/ValidateCommand.cs
+++ b/src/DraftSpec.Cli/Commands/ValidateCommand.cs
@@ -142,7 +142,7 @@ public class ValidateCommand : ICommand<ValidateOptions>
 
         if (_fileSystem.DirectoryExists(projectPath))
         {
-            return Directory.EnumerateFiles(projectPath, "*.spec.csx", SearchOption.AllDirectories).ToList();
+            return _fileSystem.EnumerateFiles(projectPath, "*.spec.csx", SearchOption.AllDirectories).ToList();
         }
 
         return [];

--- a/src/DraftSpec.TestingPlatform/FileSystemSpecFileProvider.cs
+++ b/src/DraftSpec.TestingPlatform/FileSystemSpecFileProvider.cs
@@ -1,0 +1,31 @@
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Default implementation of ISpecFileProvider that uses the file system.
+/// </summary>
+public class FileSystemSpecFileProvider : ISpecFileProvider
+{
+    /// <inheritdoc />
+    public IEnumerable<string> GetSpecFiles(string directory)
+    {
+        return Directory.EnumerateFiles(directory, "*.spec.csx", SearchOption.AllDirectories);
+    }
+
+    /// <inheritdoc />
+    public string GetRelativePath(string basePath, string absolutePath)
+    {
+        return Path.GetRelativePath(basePath, absolutePath);
+    }
+
+    /// <inheritdoc />
+    public string GetAbsolutePath(string basePath, string relativePath)
+    {
+        return Path.GetFullPath(relativePath, basePath);
+    }
+
+    /// <inheritdoc />
+    public bool FileExists(string path)
+    {
+        return File.Exists(path);
+    }
+}

--- a/src/DraftSpec.TestingPlatform/ISpecFileProvider.cs
+++ b/src/DraftSpec.TestingPlatform/ISpecFileProvider.cs
@@ -1,0 +1,38 @@
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Abstraction for spec file discovery operations.
+/// Enables unit testing of discovery logic without file system dependencies.
+/// </summary>
+public interface ISpecFileProvider
+{
+    /// <summary>
+    /// Finds all spec files (*.spec.csx) in the given directory and subdirectories.
+    /// </summary>
+    /// <param name="directory">The directory to search.</param>
+    /// <returns>Enumerable of absolute paths to spec files.</returns>
+    IEnumerable<string> GetSpecFiles(string directory);
+
+    /// <summary>
+    /// Gets the relative path from a base directory to an absolute path.
+    /// </summary>
+    /// <param name="basePath">The base directory path.</param>
+    /// <param name="absolutePath">The absolute path to make relative.</param>
+    /// <returns>The relative path.</returns>
+    string GetRelativePath(string basePath, string absolutePath);
+
+    /// <summary>
+    /// Gets the full absolute path from a base directory and relative path.
+    /// </summary>
+    /// <param name="basePath">The base directory path.</param>
+    /// <param name="relativePath">The relative path to resolve.</param>
+    /// <returns>The absolute path.</returns>
+    string GetAbsolutePath(string basePath, string relativePath);
+
+    /// <summary>
+    /// Checks if a file exists.
+    /// </summary>
+    /// <param name="path">The file path to check.</param>
+    /// <returns>True if the file exists, false otherwise.</returns>
+    bool FileExists(string path);
+}

--- a/tests/DraftSpec.Tests/Infrastructure/Mocks/MockSpecFileProvider.cs
+++ b/tests/DraftSpec.Tests/Infrastructure/Mocks/MockSpecFileProvider.cs
@@ -1,0 +1,86 @@
+using DraftSpec.TestingPlatform;
+
+namespace DraftSpec.Tests.Infrastructure.Mocks;
+
+/// <summary>
+/// Mock implementation of ISpecFileProvider for testing.
+/// </summary>
+public class MockSpecFileProvider : ISpecFileProvider
+{
+    private readonly Dictionary<string, List<string>> _specFiles = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _existingFiles = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Tracks calls to GetSpecFiles for verification.
+    /// </summary>
+    public List<string> GetSpecFilesCalls { get; } = [];
+
+    /// <summary>
+    /// Tracks calls to FileExists for verification.
+    /// </summary>
+    public List<string> FileExistsCalls { get; } = [];
+
+    /// <summary>
+    /// Configures the mock to return specific spec files for a directory.
+    /// </summary>
+    public MockSpecFileProvider WithSpecFiles(string directory, params string[] files)
+    {
+        _specFiles[directory] = new List<string>(files);
+        foreach (var file in files)
+        {
+            _existingFiles.Add(file);
+        }
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the mock to report that a file exists.
+    /// </summary>
+    public MockSpecFileProvider WithExistingFile(string path)
+    {
+        _existingFiles.Add(path);
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the mock to return no spec files for any directory.
+    /// </summary>
+    public MockSpecFileProvider WithNoSpecFiles()
+    {
+        _specFiles.Clear();
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> GetSpecFiles(string directory)
+    {
+        GetSpecFilesCalls.Add(directory);
+
+        if (_specFiles.TryGetValue(directory, out var files))
+        {
+            return files;
+        }
+
+        return [];
+    }
+
+    /// <inheritdoc />
+    public string GetRelativePath(string basePath, string absolutePath)
+    {
+        // Simple implementation: just use Path.GetRelativePath
+        return Path.GetRelativePath(basePath, absolutePath);
+    }
+
+    /// <inheritdoc />
+    public string GetAbsolutePath(string basePath, string relativePath)
+    {
+        return Path.GetFullPath(relativePath, basePath);
+    }
+
+    /// <inheritdoc />
+    public bool FileExists(string path)
+    {
+        FileExistsCalls.Add(path);
+        return _existingFiles.Contains(path);
+    }
+}


### PR DESCRIPTION
## Summary

Implements testability refactoring for file discovery operations, following the established pattern from #252 (IScriptHost extraction).

- **ISpecFileProvider interface**: Abstracts file discovery operations (GetSpecFiles, GetRelativePath, GetAbsolutePath, FileExists)
- **FileSystemSpecFileProvider**: Default implementation using real file system
- **SpecDiscoverer**: Updated to accept optional ISpecFileProvider for dependency injection
- **CLI commands**: Updated to use IFileSystem.EnumerateFiles consistently
- **MockSpecFileProvider**: Test double for unit testing without file system access
- **Unit tests**: 5 new tests demonstrating mock provider usage

This enables unit testing of spec discovery logic in isolation from the file system, improving test reliability and speed.

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)