### PR TITLE
refactor: Extract ISpecStateManager for testable state management

### DIFF
--- a/src/DraftSpec.TestingPlatform/DefaultSpecStateManager.cs
+++ b/src/DraftSpec.TestingPlatform/DefaultSpecStateManager.cs
@@ -1,0 +1,16 @@
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Default implementation of ISpecStateManager that delegates to static Dsl state.
+/// </summary>
+public class DefaultSpecStateManager : ISpecStateManager
+{
+    /// <inheritdoc />
+    public void ResetState() => Dsl.Reset();
+
+    /// <inheritdoc />
+    public SpecContext? GetRootContext() => Dsl.RootContext;
+
+    /// <inheritdoc />
+    public void SetRootContext(SpecContext? context) => Dsl.RootContext = context;
+}

--- a/src/DraftSpec.TestingPlatform/ISpecStateManager.cs
+++ b/src/DraftSpec.TestingPlatform/ISpecStateManager.cs
@@ -1,0 +1,33 @@
+namespace DraftSpec.TestingPlatform;
+
+/// <summary>
+/// Manages DSL state for spec discovery and execution.
+/// Enables testability by abstracting static Dsl state access.
+/// </summary>
+/// <remarks>
+/// This interface allows:
+/// - Unit testing without global state pollution
+/// - Verification that state is properly reset between executions
+/// - Future support for parallel test execution with isolated state
+/// </remarks>
+public interface ISpecStateManager
+{
+    /// <summary>
+    /// Resets all DSL state for a clean execution context.
+    /// Should be called before and after each spec file execution.
+    /// </summary>
+    void ResetState();
+
+    /// <summary>
+    /// Gets the current root context from DSL state.
+    /// </summary>
+    /// <returns>The root SpecContext, or null if no specs have been defined.</returns>
+    SpecContext? GetRootContext();
+
+    /// <summary>
+    /// Sets the root context in DSL state.
+    /// Used for testing or manual state manipulation.
+    /// </summary>
+    /// <param name="context">The context to set as root, or null to clear.</param>
+    void SetRootContext(SpecContext? context);
+}

--- a/src/DraftSpec.TestingPlatform/MtpSpecExecutor.cs
+++ b/src/DraftSpec.TestingPlatform/MtpSpecExecutor.cs
@@ -10,16 +10,22 @@ internal sealed class MtpSpecExecutor : IMtpSpecExecutor
 {
     private readonly string _projectDirectory;
     private readonly IScriptHost _scriptHost;
+    private readonly ISpecStateManager _stateManager;
 
     /// <summary>
     /// Creates a new MTP spec executor.
     /// </summary>
     /// <param name="projectDirectory">The project root directory.</param>
     /// <param name="scriptHost">Optional script host for testing. Defaults to CsxScriptHost.</param>
-    public MtpSpecExecutor(string projectDirectory, IScriptHost? scriptHost = null)
+    /// <param name="stateManager">Optional state manager for testing. Defaults to DefaultSpecStateManager.</param>
+    public MtpSpecExecutor(
+        string projectDirectory,
+        IScriptHost? scriptHost = null,
+        ISpecStateManager? stateManager = null)
     {
         _projectDirectory = Path.GetFullPath(projectDirectory);
         _scriptHost = scriptHost ?? new CsxScriptHost(_projectDirectory);
+        _stateManager = stateManager ?? new DefaultSpecStateManager();
     }
 
     /// <summary>
@@ -51,7 +57,7 @@ internal sealed class MtpSpecExecutor : IMtpSpecExecutor
         var relativePath = GetRelativePath(absolutePath);
 
         // Reset state before execution
-        _scriptHost.Reset();
+        _stateManager.ResetState();
 
         try
         {
@@ -111,7 +117,7 @@ internal sealed class MtpSpecExecutor : IMtpSpecExecutor
         }
         finally
         {
-            _scriptHost.Reset();
+            _stateManager.ResetState();
         }
     }
 

--- a/tests/DraftSpec.Tests/Infrastructure/Mocks/MockSpecStateManager.cs
+++ b/tests/DraftSpec.Tests/Infrastructure/Mocks/MockSpecStateManager.cs
@@ -1,0 +1,63 @@
+using DraftSpec.TestingPlatform;
+
+namespace DraftSpec.Tests.Infrastructure.Mocks;
+
+/// <summary>
+/// Mock implementation of ISpecStateManager for testing.
+/// Tracks all state operations for verification.
+/// </summary>
+public class MockSpecStateManager : ISpecStateManager
+{
+    private SpecContext? _rootContext;
+
+    /// <summary>
+    /// Number of times ResetState was called.
+    /// </summary>
+    public int ResetCallCount { get; private set; }
+
+    /// <summary>
+    /// Number of times GetRootContext was called.
+    /// </summary>
+    public int GetRootContextCallCount { get; private set; }
+
+    /// <summary>
+    /// Number of times SetRootContext was called.
+    /// </summary>
+    public int SetRootContextCallCount { get; private set; }
+
+    /// <summary>
+    /// History of contexts passed to SetRootContext.
+    /// </summary>
+    public List<SpecContext?> SetRootContextCalls { get; } = [];
+
+    /// <summary>
+    /// Configures the mock to return a specific root context.
+    /// </summary>
+    public MockSpecStateManager WithRootContext(SpecContext? context)
+    {
+        _rootContext = context;
+        return this;
+    }
+
+    /// <inheritdoc />
+    public void ResetState()
+    {
+        ResetCallCount++;
+        _rootContext = null;
+    }
+
+    /// <inheritdoc />
+    public SpecContext? GetRootContext()
+    {
+        GetRootContextCallCount++;
+        return _rootContext;
+    }
+
+    /// <inheritdoc />
+    public void SetRootContext(SpecContext? context)
+    {
+        SetRootContextCallCount++;
+        SetRootContextCalls.Add(context);
+        _rootContext = context;
+    }
+}


### PR DESCRIPTION
## Summary

Implements testability refactoring for DSL state management, following the established pattern from #252 (IScriptHost) and #253 (ISpecFileProvider).

- **ISpecStateManager interface**: Abstracts state operations (ResetState, GetRootContext, SetRootContext)
- **DefaultSpecStateManager**: Default implementation delegating to static Dsl
- **SpecDiscoverer & MtpSpecExecutor**: Updated to accept optional ISpecStateManager
- **MockSpecStateManager**: Test double for verifying state management behavior
- **Updated tests**: 3 existing tests updated + 2 new tests added

### Benefits
- Separates concerns between script execution (IScriptHost) and state management (ISpecStateManager)
- Enables unit testing of state reset behavior in isolation
- Prepares groundwork for future parallel test execution with isolated state

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)