### PR TITLE
feat: Add GitHub automation (stale bot, release drafter, all-contributors)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,14 @@
+{
+  "projectName": "draftspec",
+  "projectOwner": "juvistr",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": ["README.md"],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "angular",
+  "contributors": [],
+  "contributorsPerLine": 7,
+  "skipCi": true,
+  "contributorsSortAlphabetically": true
+}

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,51 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: '🚀 Features'
+    labels:
+      - enhancement
+      - feature
+  - title: '🐛 Bug Fixes'
+    labels:
+      - bug
+      - fix
+  - title: '📚 Documentation'
+    labels:
+      - documentation
+  - title: '🔧 Maintenance'
+    labels:
+      - refactor
+      - chore
+      - dependencies
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - major
+      - breaking
+  minor:
+    labels:
+      - minor
+      - enhancement
+      - feature
+  patch:
+    labels:
+      - patch
+      - bug
+      - fix
+      - documentation
+      - chore
+      - dependencies
+      - refactor
+  default: patch
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,28 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,45 @@
+name: Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Daily at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issue settings
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 14 days if no further activity occurs.
+            Thank you for your contributions!
+          close-issue-message: |
+            This issue has been automatically closed due to inactivity.
+            Feel free to reopen if this is still relevant.
+
+          # PR settings
+          stale-pr-label: stale
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 14 days if no further activity occurs.
+            Please update the PR or leave a comment if this is still being worked on.
+          close-pr-message: |
+            This pull request has been automatically closed due to inactivity.
+            Feel free to reopen when ready to continue.
+
+          # Exempt labels - issues/PRs with these labels won't be marked stale
+          exempt-issue-labels: pinned,security,help wanted
+          exempt-pr-labels: pinned,security,help wanted
+
+          # Don't close issues/PRs with these labels
+          exempt-all-assignees: true

--- a/README.md
+++ b/README.md
@@ -304,6 +304,15 @@ git checkout -b feat/your-feature
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.
 
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary

Add three GitHub automation tools to reduce manual effort:

### 1. Stale Issue/PR Workflow (`.github/workflows/stale.yml`)
- Runs daily at midnight UTC
- Marks issues/PRs as stale after 60 days of inactivity
- Closes after 14 more days if no activity
- Exempt labels: `pinned`, `security`, `help wanted`
- Exempt assigned issues/PRs

### 2. Release Drafter (`.github/release-drafter.yml`)
- Auto-generates draft release notes from merged PRs
- Categories: Features, Bug Fixes, Documentation, Maintenance
- Version resolution based on labels (major/minor/patch)

### 3. All Contributors (`.all-contributorsrc`)
- Recognizes contributors in README
- Supports: code, docs, bug reports, ideas, testing
- Contributors section placeholder added to README

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)