### PR TITLE
feat: Add GitHub Discussion templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,45 @@
+title: "[Idea] "
+labels: ["enhancement", "idea"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing your idea! We love hearing from the community about how to improve DraftSpec.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this idea solve?
+      placeholder: |
+        Currently, when I try to...
+        It's difficult to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like this to work?
+      placeholder: |
+        I'd like to be able to...
+        The ideal behavior would be...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any workarounds or alternative approaches?
+      placeholder: |
+        I've thought about...
+        Another option might be...
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, examples, or screenshots?
+      placeholder: Add any other context about the idea here...

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,44 @@
+title: "[Q&A] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your question! Please fill out the sections below to help us understand your issue.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+      placeholder: Describe your question clearly...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What are you trying to accomplish?
+      placeholder: |
+        I'm trying to...
+        My use case is...
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Share any approaches you've already attempted
+      placeholder: |
+        I've tried...
+        I looked at...
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment (optional)
+      description: If relevant, share your environment details
+      placeholder: |
+        - DraftSpec version:
+        - .NET version:
+        - OS:


### PR DESCRIPTION
## Summary

Add structured templates for GitHub Discussions:

### Q&A Template (`.github/DISCUSSION_TEMPLATE/q-a.yml`)
- Question field (required)
- Context - what you're trying to accomplish
- What have you tried?
- Environment info (optional)

### Ideas Template (`.github/DISCUSSION_TEMPLATE/ideas.yml`)
- Problem statement (required)
- Proposed solution (required)
- Alternatives considered
- Additional context

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)