### PR TITLE
fix: Add inner exception constructor to AssertionException

### DIFF
--- a/src/DraftSpec/AssertionException.cs
+++ b/src/DraftSpec/AssertionException.cs
@@ -23,4 +23,13 @@ public class AssertionException : Exception
     public AssertionException(string message) : base(message)
     {
     }
+
+    /// <summary>
+    /// Creates a new assertion exception with the specified message and inner exception.
+    /// </summary>
+    /// <param name="message">A message describing what was expected vs what was found.</param>
+    /// <param name="innerException">The exception that caused this assertion failure.</param>
+    public AssertionException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
 }

--- a/tests/DraftSpec.Tests/Core/CoreEdgeCaseTests.cs
+++ b/tests/DraftSpec.Tests/Core/CoreEdgeCaseTests.cs
@@ -44,6 +44,43 @@ public class CoreEdgeCaseTests
         await Assert.That(caught!.Message).IsEqualTo("test message");
     }
 
+    [Test]
+    public async Task AssertionException_WithInnerException_SetsBoth()
+    {
+        var inner = new InvalidOperationException("Something went wrong");
+        var exception = new AssertionException("Assertion failed during operation", inner);
+
+        await Assert.That(exception.Message).IsEqualTo("Assertion failed during operation");
+        await Assert.That(exception.InnerException).IsSameReferenceAs(inner);
+    }
+
+    [Test]
+    public async Task AssertionException_InnerException_PreservesStackTrace()
+    {
+        Exception? caught = null;
+
+        try
+        {
+            try
+            {
+                throw new InvalidOperationException("Original error");
+            }
+            catch (Exception ex)
+            {
+                throw new AssertionException("Wrapped assertion failure", ex);
+            }
+        }
+        catch (Exception ex)
+        {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!.InnerException).IsNotNull();
+        await Assert.That(caught.InnerException!.Message).IsEqualTo("Original error");
+        await Assert.That(caught.InnerException.StackTrace).IsNotNull();
+    }
+
     #endregion
 
     #region SpecReportBuilder Tests


### PR DESCRIPTION
## Summary

Add constructor overload to `AssertionException` that accepts an inner exception, enabling proper exception chaining when wrapping exceptions.

```csharp
public AssertionException(string message, Exception innerException) 
    : base(message, innerException)
```

## Changes

- Added new constructor in `src/DraftSpec/AssertionException.cs`
- Added 2 tests in `CoreEdgeCaseTests.cs`:
  - `AssertionException_WithInnerException_SetsBoth`
  - `AssertionException_InnerException_PreservesStackTrace`

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)