### PR TITLE
fix(ci): Configure release drafter for prerelease versions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,10 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 
+# Include prerelease tags when resolving version
+prerelease: true
+prerelease-identifier: alpha
+
 categories:
   - title: '🚀 Features'
     labels:


### PR DESCRIPTION
## Summary

The release drafter was ignoring prerelease tags (v0.6.x-alpha.x) and calculating v0.1.0 as the first version. This adds `prerelease: true` and `prerelease-identifier: alpha` configuration to ensure it uses the correct previous tag when drafting releases.

Also deleted the erroneous v0.1.0 draft release that was created due to this misconfiguration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)