### PR TITLE
feat: Add let/get lazy fixture pattern for memoized test data

### DIFF
--- a/src/DraftSpec/Dsl.Let.cs
+++ b/src/DraftSpec/Dsl.Let.cs
@@ -1,0 +1,74 @@
+namespace DraftSpec;
+
+public static partial class Dsl
+{
+    /// <summary>
+    /// Register a lazy fixture that is memoized per spec.
+    /// The factory is invoked on first access via get&lt;T&gt;() and cached.
+    /// </summary>
+    /// <typeparam name="T">The type of the fixture</typeparam>
+    /// <param name="name">Unique name for this fixture within the context</param>
+    /// <param name="factory">Factory function that creates the value</param>
+    /// <example>
+    /// <code>
+    /// describe("UserService", () => {
+    ///     let("db", () => new InMemoryDatabase());
+    ///     let("service", () => new UserService(get&lt;IDatabase&gt;("db")));
+    ///
+    ///     it("creates users", () => {
+    ///         var service = get&lt;UserService&gt;("service");
+    ///         expect(service).toNotBeNull();
+    ///     });
+    /// });
+    /// </code>
+    /// </example>
+    public static void let<T>(string name, Func<T> factory)
+    {
+        CurrentContext?.AddLetDefinition(name, () => factory()!);
+    }
+
+    /// <summary>
+    /// Get the value of a lazy fixture by name.
+    /// Creates the value on first access and caches it for the spec duration.
+    /// </summary>
+    /// <typeparam name="T">The expected type of the fixture</typeparam>
+    /// <param name="name">Name of the fixture registered with let()</param>
+    /// <returns>The fixture value</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when called outside spec execution or when no definition exists
+    /// </exception>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the value cannot be cast to the requested type
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// it("uses fixtures", () => {
+    ///     var db = get&lt;IDatabase&gt;("db");
+    ///     var service = get&lt;UserService&gt;("service");
+    ///     // Both values are memoized - calling again returns same instance
+    /// });
+    /// </code>
+    /// </example>
+    public static T get<T>(string name)
+    {
+        var scope = LetScope.Current
+            ?? throw new InvalidOperationException(
+                "get<T>() can only be called during spec execution. " +
+                "Ensure you are calling it from within an it() block.");
+
+        // Check if already memoized
+        if (scope.Values.TryGetValue(name, out var cached))
+            return (T)cached;
+
+        // Find the factory in this context or ancestors
+        var factory = scope.Context.GetLetFactory(name)
+            ?? throw new InvalidOperationException(
+                $"No let definition found for '{name}'. " +
+                $"Ensure let(\"{name}\", ...) is called in this context or a parent.");
+
+        // Create and memoize the value
+        var value = factory();
+        scope.Values[name] = value;
+        return (T)value;
+    }
+}

--- a/src/DraftSpec/LetScope.cs
+++ b/src/DraftSpec/LetScope.cs
@@ -1,0 +1,47 @@
+namespace DraftSpec;
+
+/// <summary>
+/// Holds the execution context for let/get fixtures during spec execution.
+/// Uses AsyncLocal for thread-safe access during parallel spec execution.
+/// </summary>
+/// <remarks>
+/// LetScope is created fresh for each spec execution and holds:
+/// - Reference to the SpecContext (for finding let definitions)
+/// - Memoized values (cached results of factory invocations)
+///
+/// Values are lazily created on first access via get&lt;T&gt;() and
+/// cached for the duration of the spec. Each spec gets a fresh LetScope.
+/// </remarks>
+public class LetScope
+{
+    private static readonly AsyncLocal<LetScope?> CurrentLocal = new();
+
+    /// <summary>
+    /// Current let scope for the executing spec.
+    /// Null when not inside a spec body.
+    /// </summary>
+    public static LetScope? Current
+    {
+        get => CurrentLocal.Value;
+        internal set => CurrentLocal.Value = value;
+    }
+
+    /// <summary>
+    /// The context containing let definitions for this scope.
+    /// </summary>
+    public SpecContext Context { get; }
+
+    /// <summary>
+    /// Memoized values created during this spec execution.
+    /// </summary>
+    internal Dictionary<string, object> Values { get; } = new();
+
+    /// <summary>
+    /// Creates a new let scope for the given context.
+    /// </summary>
+    /// <param name="context">The spec context containing let definitions</param>
+    public LetScope(SpecContext context)
+    {
+        Context = context;
+    }
+}

--- a/src/DraftSpec/SpecContext.cs
+++ b/src/DraftSpec/SpecContext.cs
@@ -37,6 +37,7 @@ public class SpecContext
     // Internal mutable lists
     private readonly List<SpecContext> _children = [];
     private readonly List<SpecDefinition> _specs = [];
+    private Dictionary<string, Func<object>>? _letDefinitions;
 
     // Cached counts computed during tree construction
     private int _totalSpecCount;
@@ -259,5 +260,33 @@ public class SpecContext
             current = current.Parent;
         }
         return false;
+    }
+
+    /// <summary>
+    /// Adds a let definition to this context.
+    /// </summary>
+    /// <param name="name">The name of the fixture</param>
+    /// <param name="factory">Factory function that creates the value</param>
+    internal void AddLetDefinition(string name, Func<object> factory)
+    {
+        _letDefinitions ??= new Dictionary<string, Func<object>>();
+        _letDefinitions[name] = factory;
+    }
+
+    /// <summary>
+    /// Gets the factory for a let definition, searching this context and ancestors.
+    /// </summary>
+    /// <param name="name">The name of the fixture</param>
+    /// <returns>The factory function, or null if not found</returns>
+    internal Func<object>? GetLetFactory(string name)
+    {
+        var current = this;
+        while (current != null)
+        {
+            if (current._letDefinitions?.TryGetValue(name, out var factory) == true)
+                return factory;
+            current = current.Parent;
+        }
+        return null;
     }
 }

--- a/src/DraftSpec/SpecRunner.cs
+++ b/src/DraftSpec/SpecRunner.cs
@@ -433,6 +433,9 @@ public class SpecRunner : ISpecRunner
             ctx.ContextPath,
             ctx.Spec.Description);
 
+        // Set let scope for let/get fixtures
+        LetScope.Current = new LetScope(ctx.Context);
+
         try
         {
             await ctx.Spec.Body!.Invoke();
@@ -447,6 +450,7 @@ public class SpecRunner : ISpecRunner
         }
         finally
         {
+            LetScope.Current = null;
             SnapshotContext.Current = null;
         }
 

--- a/tests/DraftSpec.Tests/Dsl/LetTests.cs
+++ b/tests/DraftSpec.Tests/Dsl/LetTests.cs
@@ -1,0 +1,402 @@
+using static DraftSpec.Dsl;
+
+namespace DraftSpec.Tests.Dsl;
+
+/// <summary>
+/// Tests for let/get lazy fixture pattern.
+/// </summary>
+public class LetTests
+{
+    #region Basic Functionality
+
+    [Test]
+    public async Task let_RegistersFactory_GetReturnsValue()
+    {
+        var runner = new SpecRunner();
+        object? capturedValue = null;
+
+        describe("test", () =>
+        {
+            let("fixture", () => new TestFixture { Value = 42 });
+
+            it("gets the value", () =>
+            {
+                capturedValue = get<TestFixture>("fixture");
+            });
+        });
+
+        var results = await runner.RunAsync(RootContext!);
+
+        await Assert.That(results[0].Status).IsEqualTo(SpecStatus.Passed);
+        await Assert.That(capturedValue).IsNotNull();
+        await Assert.That(((TestFixture)capturedValue!).Value).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task get_MemoizesValueWithinSpec()
+    {
+        var runner = new SpecRunner();
+        var factoryCallCount = 0;
+        TestFixture? first = null;
+        TestFixture? second = null;
+
+        describe("test", () =>
+        {
+            let("fixture", () =>
+            {
+                factoryCallCount++;
+                return new TestFixture { Value = factoryCallCount };
+            });
+
+            it("calls factory once", () =>
+            {
+                first = get<TestFixture>("fixture");
+                second = get<TestFixture>("fixture");
+            });
+        });
+
+        await runner.RunAsync(RootContext!);
+
+        await Assert.That(factoryCallCount).IsEqualTo(1);
+        await Assert.That(first).IsSameReferenceAs(second);
+    }
+
+    [Test]
+    public async Task get_ResetsBetweenSpecs()
+    {
+        var runner = new SpecRunner();
+        var factoryCallCount = 0;
+        var spec1Value = 0;
+        var spec2Value = 0;
+
+        describe("test", () =>
+        {
+            let("counter", () =>
+            {
+                factoryCallCount++;
+                return factoryCallCount;
+            });
+
+            it("first spec", () =>
+            {
+                spec1Value = get<int>("counter");
+            });
+
+            it("second spec", () =>
+            {
+                spec2Value = get<int>("counter");
+            });
+        });
+
+        await runner.RunAsync(RootContext!);
+
+        // Factory called twice - once per spec
+        await Assert.That(factoryCallCount).IsEqualTo(2);
+        await Assert.That(spec1Value).IsEqualTo(1);
+        await Assert.That(spec2Value).IsEqualTo(2);
+    }
+
+    #endregion
+
+    #region Context Inheritance
+
+    [Test]
+    public async Task let_NestedContextShadowsParent()
+    {
+        var runner = new SpecRunner();
+        var parentValue = 0;
+        var childValue = 0;
+
+        describe("parent", () =>
+        {
+            let("value", () => 100);
+
+            it("uses parent let", () =>
+            {
+                parentValue = get<int>("value");
+            });
+
+            describe("child", () =>
+            {
+                let("value", () => 200); // Shadow parent
+
+                it("uses child let", () =>
+                {
+                    childValue = get<int>("value");
+                });
+            });
+        });
+
+        await runner.RunAsync(RootContext!);
+
+        await Assert.That(parentValue).IsEqualTo(100);
+        await Assert.That(childValue).IsEqualTo(200);
+    }
+
+    [Test]
+    public async Task get_AccessesParentLetFromNestedContext()
+    {
+        var runner = new SpecRunner();
+        var capturedValue = 0;
+
+        describe("parent", () =>
+        {
+            let("parentFixture", () => 42);
+
+            describe("child", () =>
+            {
+                it("accesses parent let", () =>
+                {
+                    capturedValue = get<int>("parentFixture");
+                });
+            });
+        });
+
+        await runner.RunAsync(RootContext!);
+
+        await Assert.That(capturedValue).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task let_CanReferenceOtherLets()
+    {
+        var runner = new SpecRunner();
+        var capturedValue = "";
+
+        describe("test", () =>
+        {
+            let("first", () => "Hello");
+            let("second", () => get<string>("first") + " World");
+
+            it("composes lets", () =>
+            {
+                capturedValue = get<string>("second");
+            });
+        });
+
+        await runner.RunAsync(RootContext!);
+
+        await Assert.That(capturedValue).IsEqualTo("Hello World");
+    }
+
+    #endregion
+
+    #region Error Handling
+
+    [Test]
+    public async Task get_OutsideExecution_ThrowsInvalidOperation()
+    {
+        // Ensure we're not in a spec execution
+        LetScope.Current = null;
+
+        var action = () => get<string>("anything");
+
+        await Assert.That(action).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task get_UndefinedName_ThrowsInvalidOperation()
+    {
+        var runner = new SpecRunner();
+        Exception? capturedException = null;
+
+        describe("test", () =>
+        {
+            it("tries undefined let", () =>
+            {
+                try
+                {
+                    get<string>("undefined");
+                }
+                catch (Exception ex)
+                {
+                    capturedException = ex;
+                    throw;
+                }
+            });
+        });
+
+        var results = await runner.RunAsync(RootContext!);
+
+        await Assert.That(results[0].Status).IsEqualTo(SpecStatus.Failed);
+        await Assert.That(capturedException).IsTypeOf<InvalidOperationException>();
+        await Assert.That(capturedException!.Message).Contains("undefined");
+    }
+
+    [Test]
+    public async Task get_TypeMismatch_ThrowsInvalidCast()
+    {
+        var runner = new SpecRunner();
+        Exception? capturedException = null;
+
+        describe("test", () =>
+        {
+            let("number", () => 42);
+
+            it("casts to wrong type", () =>
+            {
+                try
+                {
+                    get<string>("number"); // int -> string should fail
+                }
+                catch (Exception ex)
+                {
+                    capturedException = ex;
+                    throw;
+                }
+            });
+        });
+
+        var results = await runner.RunAsync(RootContext!);
+
+        await Assert.That(results[0].Status).IsEqualTo(SpecStatus.Failed);
+        await Assert.That(capturedException).IsTypeOf<InvalidCastException>();
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Test]
+    public async Task let_WithNullValue_WorksCorrectly()
+    {
+        var runner = new SpecRunner();
+        var factoryCallCount = 0;
+        object? capturedValue = "not null";
+
+        describe("test", () =>
+        {
+            let<string?>("nullable", () =>
+            {
+                factoryCallCount++;
+                return null;
+            });
+
+            it("gets null value", () =>
+            {
+                capturedValue = get<string?>("nullable");
+                // Call again to verify memoization
+                _ = get<string?>("nullable");
+            });
+        });
+
+        await runner.RunAsync(RootContext!);
+
+        await Assert.That(capturedValue).IsNull();
+        // Factory should still only be called once
+        await Assert.That(factoryCallCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task let_OverwritesInSameContext()
+    {
+        var runner = new SpecRunner();
+        var capturedValue = 0;
+
+        describe("test", () =>
+        {
+            let("value", () => 100);
+            let("value", () => 200); // Overwrite
+
+            it("uses latest definition", () =>
+            {
+                capturedValue = get<int>("value");
+            });
+        });
+
+        await runner.RunAsync(RootContext!);
+
+        await Assert.That(capturedValue).IsEqualTo(200);
+    }
+
+    [Test]
+    public async Task let_WorksWithAsyncFactoryBody()
+    {
+        var runner = new SpecRunner();
+        var capturedValue = 0;
+
+        describe("test", () =>
+        {
+            // Factory can call async methods internally
+            let("asyncValue", () =>
+            {
+                // Simulate async work
+                return Task.Run(() => 42).Result;
+            });
+
+            it("gets async value", () =>
+            {
+                capturedValue = get<int>("asyncValue");
+            });
+        });
+
+        await runner.RunAsync(RootContext!);
+
+        await Assert.That(capturedValue).IsEqualTo(42);
+    }
+
+    #endregion
+
+    #region Parallel Execution
+
+    [Test]
+    public async Task let_IsolatedBetweenParallelSpecs()
+    {
+        var runner = new SpecRunner([], null, maxDegreeOfParallelism: 4);
+        var values = new System.Collections.Concurrent.ConcurrentBag<int>();
+        var factoryCallCount = 0;
+
+        describe("parallel", () =>
+        {
+            let("counter", () =>
+            {
+                return Interlocked.Increment(ref factoryCallCount);
+            });
+
+            for (var i = 0; i < 10; i++)
+            {
+                it($"spec {i}", () =>
+                {
+                    values.Add(get<int>("counter"));
+                    // Call again to verify memoization within spec
+                    var second = get<int>("counter");
+                    // Should be same value
+                    expect(second).toBe(get<int>("counter"));
+                });
+            }
+        });
+
+        var results = await runner.RunAsync(RootContext!);
+
+        // All specs should pass
+        var passedCount = results.Count(r => r.Status == SpecStatus.Passed);
+        await Assert.That(passedCount).IsEqualTo(10);
+
+        // Factory called 10 times (once per spec)
+        await Assert.That(factoryCallCount).IsEqualTo(10);
+
+        // All values should be unique (1-10)
+        await Assert.That(values.Distinct().Count()).IsEqualTo(10);
+    }
+
+    #endregion
+
+    #region Test Setup/Teardown
+
+    [Before(Test)]
+    public void ResetDsl()
+    {
+        Reset();
+    }
+
+    #endregion
+
+    #region Helper Classes
+
+    private class TestFixture
+    {
+        public int Value { get; init; }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Implement RSpec-style `let()` for lazy-evaluated, memoized fixtures. This addresses a key ergonomic issue where specs required verbose `var x = null!;` patterns.

### Features
- **`let("name", () => value)`** - Register a lazy fixture in current context
- **`get<T>("name")`** - Get memoized value, creating on first access
- **Per-spec memoization** - Values reset between specs, cached within each spec
- **Context inheritance** - Nested contexts can shadow parent definitions
- **Thread-safe** - Parallel execution via `AsyncLocal<LetScope>`

### Example Usage
```csharp
describe("UserService", () => {
    let("db", () => new InMemoryDatabase());
    let("service", () => new UserService(get<IDatabase>("db")));
    
    it("creates users", () => {
        var service = get<UserService>("service");
        expect(service).toNotBeNull();
    });
    
    describe("with admin", () => {
        let("service", () => new AdminUserService(get<IDatabase>("db"))); // shadows parent
        
        it("has admin features", () => {
            expect(get<UserService>("service")).toBeInstanceOf<AdminUserService>();
        });
    });
});
```

### Implementation
- `LetScope.cs` - Execution context with `AsyncLocal` for thread safety
- `Dsl.Let.cs` - DSL methods following partial class pattern
- `SpecContext.cs` - Let definition storage with parent chain traversal
- `SpecRunner.cs` - Lifecycle integration (setup/teardown per spec)

### Tests
13 comprehensive tests covering:
- Basic functionality (register, get, memoization)
- Context inheritance and shadowing
- Error handling (undefined names, type mismatches, outside execution)
- Edge cases (null values, overwrites, async factory bodies)
- Parallel execution isolation

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)