### PR TITLE
feat(cli): Add runtime estimation based on historical data

### DIFF
--- a/src/DraftSpec.Cli/CliOptions.cs
+++ b/src/DraftSpec.Cli/CliOptions.cs
@@ -257,6 +257,20 @@ public class CliOptions
     /// </summary>
     public string? Clear { get; set; }
 
+    // Estimate command options
+
+    /// <summary>
+    /// Percentile to use for runtime estimation (1-99).
+    /// Default: 50 (median)
+    /// </summary>
+    public int Percentile { get; set; } = 50;
+
+    /// <summary>
+    /// Output the estimate in seconds (machine-readable format).
+    /// Used with estimate command.
+    /// </summary>
+    public bool OutputSeconds { get; set; }
+
     /// <summary>
     /// Apply default values from a project configuration file.
     /// Only applies values that weren't explicitly set via CLI.
@@ -422,6 +436,16 @@ public class CliOptions
         MinStatusChanges = MinStatusChanges,
         WindowSize = WindowSize,
         Clear = Clear
+    };
+
+    /// <summary>
+    /// Converts to EstimateOptions for the estimate command.
+    /// </summary>
+    public EstimateOptions ToEstimateOptions() => new()
+    {
+        Path = Path,
+        Percentile = Percentile,
+        OutputSeconds = OutputSeconds
     };
 
     #endregion

--- a/src/DraftSpec.Cli/CliOptionsParser.cs
+++ b/src/DraftSpec.Cli/CliOptionsParser.cs
@@ -408,6 +408,29 @@ public static class CliOptionsParser
                 options.Clear = args[++i];
                 options.ExplicitlySet.Add(nameof(CliOptions.Clear));
             }
+            // Estimate command options
+            else if (arg == "--percentile")
+            {
+                if (i + 1 >= args.Length)
+                {
+                    options.Error = "--percentile requires a value (1-99)";
+                    return options;
+                }
+
+                if (!int.TryParse(args[++i], out var percentile) || percentile < 1 || percentile > 99)
+                {
+                    options.Error = "--percentile must be between 1 and 99";
+                    return options;
+                }
+
+                options.Percentile = percentile;
+                options.ExplicitlySet.Add(nameof(CliOptions.Percentile));
+            }
+            else if (arg == "--output-seconds")
+            {
+                options.OutputSeconds = true;
+                options.ExplicitlySet.Add(nameof(CliOptions.OutputSeconds));
+            }
             else if (!arg.StartsWith('-'))
             {
                 positional.Add(arg);

--- a/src/DraftSpec.Cli/CommandFactory.cs
+++ b/src/DraftSpec.Cli/CommandFactory.cs
@@ -19,6 +19,7 @@ public class CommandFactory : ICommandFactory
     private readonly Func<NewCommand> _newFactory;
     private readonly Func<SchemaCommand> _schemaFactory;
     private readonly Func<FlakyCommand> _flakyFactory;
+    private readonly Func<EstimateCommand> _estimateFactory;
 
     public CommandFactory(
         IConfigApplier configApplier,
@@ -29,7 +30,8 @@ public class CommandFactory : ICommandFactory
         Func<InitCommand> initFactory,
         Func<NewCommand> newFactory,
         Func<SchemaCommand> schemaFactory,
-        Func<FlakyCommand> flakyFactory)
+        Func<FlakyCommand> flakyFactory,
+        Func<EstimateCommand> estimateFactory)
     {
         _configApplier = configApplier;
         _runFactory = runFactory;
@@ -40,6 +42,7 @@ public class CommandFactory : ICommandFactory
         _newFactory = newFactory;
         _schemaFactory = schemaFactory;
         _flakyFactory = flakyFactory;
+        _estimateFactory = estimateFactory;
     }
 
     public Func<CliOptions, CancellationToken, Task<int>>? Create(string commandName)
@@ -67,6 +70,8 @@ public class CommandFactory : ICommandFactory
                 _schemaFactory(), o => o.ToSchemaOptions(), _configApplier),
             "flaky" => new CommandExecutor<FlakyCommand, FlakyOptions>(
                 _flakyFactory(), o => o.ToFlakyOptions(), _configApplier),
+            "estimate" => new CommandExecutor<EstimateCommand, EstimateOptions>(
+                _estimateFactory(), o => o.ToEstimateOptions(), _configApplier),
             _ => null
         };
 }

--- a/src/DraftSpec.Cli/Commands/EstimateCommand.cs
+++ b/src/DraftSpec.Cli/Commands/EstimateCommand.cs
@@ -1,0 +1,122 @@
+using DraftSpec.Cli.History;
+using DraftSpec.Cli.Options;
+
+namespace DraftSpec.Cli.Commands;
+
+/// <summary>
+/// Estimates runtime based on historical execution data.
+/// </summary>
+public class EstimateCommand : ICommand<EstimateOptions>
+{
+    private readonly IRuntimeEstimator _estimator;
+    private readonly ISpecHistoryService _historyService;
+    private readonly IConsole _console;
+    private readonly IFileSystem _fileSystem;
+
+    public EstimateCommand(
+        IRuntimeEstimator estimator,
+        ISpecHistoryService historyService,
+        IConsole console,
+        IFileSystem fileSystem)
+    {
+        _estimator = estimator;
+        _historyService = historyService;
+        _console = console;
+        _fileSystem = fileSystem;
+    }
+
+    public async Task<int> ExecuteAsync(EstimateOptions options, CancellationToken ct = default)
+    {
+        var projectPath = Path.GetFullPath(options.Path);
+
+        if (!_fileSystem.DirectoryExists(projectPath))
+            throw new ArgumentException($"Directory not found: {projectPath}");
+
+        // Load history
+        var history = await _historyService.LoadAsync(projectPath, ct);
+
+        if (history.Specs.Count == 0)
+        {
+            _console.WriteLine("No test history found. Run specs first to collect data.");
+            _console.WriteLine();
+            _console.ForegroundColor = ConsoleColor.DarkGray;
+            _console.WriteLine("  draftspec run");
+            _console.ResetColor();
+            return 0;
+        }
+
+        // Calculate estimates
+        var estimate = _estimator.Calculate(history, options.Percentile);
+
+        if (estimate.SpecCount == 0)
+        {
+            _console.WriteLine("No timing data available. Run specs to collect duration data.");
+            return 0;
+        }
+
+        // Output in machine-readable format if requested
+        if (options.OutputSeconds)
+        {
+            _console.WriteLine($"{estimate.TotalEstimateMs / 1000:F1}");
+            return 0;
+        }
+
+        // Human-readable output
+        ShowEstimate(estimate, options);
+
+        return 0;
+    }
+
+    private void ShowEstimate(RuntimeEstimate estimate, EstimateOptions options)
+    {
+        _console.WriteLine($"Runtime Estimate (based on {estimate.SampleSize} historical runs):");
+        _console.WriteLine();
+
+        // Show P50, P95, and Max
+        _console.ForegroundColor = ConsoleColor.White;
+        _console.WriteLine($"  P50 (median):      {FormatDuration(estimate.P50Ms)}");
+        _console.WriteLine($"  P95:               {FormatDuration(estimate.P95Ms)}");
+        _console.ForegroundColor = ConsoleColor.DarkGray;
+        _console.WriteLine($"  Max observed:      {FormatDuration(estimate.MaxMs)}");
+        _console.ResetColor();
+        _console.WriteLine();
+
+        // Show slowest specs
+        if (estimate.SlowestSpecs.Count > 0)
+        {
+            _console.WriteLine($"Slowest specs (P{options.Percentile}):");
+            var index = 1;
+            foreach (var spec in estimate.SlowestSpecs)
+            {
+                _console.ForegroundColor = ConsoleColor.Yellow;
+                _console.Write($"  {index}. ");
+                _console.ResetColor();
+                _console.WriteLine($"{spec.DisplayName} ({FormatDuration(spec.EstimateMs)})");
+                index++;
+            }
+            _console.WriteLine();
+        }
+
+        // Recommended CI timeout
+        var recommendedTimeout = estimate.P95Ms * 2;
+        _console.ForegroundColor = ConsoleColor.Green;
+        _console.WriteLine($"Recommended CI timeout: {FormatDuration(recommendedTimeout)} (2x P95)");
+        _console.ResetColor();
+    }
+
+    private static string FormatDuration(double ms)
+    {
+        var span = TimeSpan.FromMilliseconds(ms);
+
+        if (span.TotalHours >= 1)
+            return $"{(int)span.TotalHours}h {span.Minutes:D2}m {span.Seconds:D2}s";
+
+        if (span.TotalMinutes >= 1)
+            return $"{(int)span.TotalMinutes}m {span.Seconds:D2}s";
+
+        if (span.TotalSeconds >= 1)
+            return $"{span.TotalSeconds:F1}s";
+
+        return $"{ms:F0}ms";
+    }
+}

--- a/src/DraftSpec.Cli/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/DraftSpec.Cli/DependencyInjection/ServiceCollectionExtensions.cs
@@ -46,6 +46,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISpecChangeTracker, SpecChangeTracker>();
         services.AddSingleton<IGitService, GitService>();
         services.AddSingleton<ISpecHistoryService, SpecHistoryService>();
+        services.AddSingleton<IRuntimeEstimator, RuntimeEstimator>();
 
         // Commands
         services.AddTransient<RunCommand>();
@@ -56,6 +57,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<NewCommand>();
         services.AddTransient<SchemaCommand>();
         services.AddTransient<FlakyCommand>();
+        services.AddTransient<EstimateCommand>();
 
         // Pipeline
         services.AddSingleton<IConfigApplier, ConfigApplier>();
@@ -70,7 +72,8 @@ public static class ServiceCollectionExtensions
             () => sp.GetRequiredService<InitCommand>(),
             () => sp.GetRequiredService<NewCommand>(),
             () => sp.GetRequiredService<SchemaCommand>(),
-            () => sp.GetRequiredService<FlakyCommand>()));
+            () => sp.GetRequiredService<FlakyCommand>(),
+            () => sp.GetRequiredService<EstimateCommand>()));
 
         return services;
     }

--- a/src/DraftSpec.Cli/History/IRuntimeEstimator.cs
+++ b/src/DraftSpec.Cli/History/IRuntimeEstimator.cs
@@ -1,0 +1,17 @@
+namespace DraftSpec.Cli.History;
+
+/// <summary>
+/// Calculates runtime estimates based on historical execution data.
+/// </summary>
+public interface IRuntimeEstimator
+{
+    /// <summary>
+    /// Calculate runtime estimates from spec history.
+    /// </summary>
+    RuntimeEstimate Calculate(SpecHistory history, int percentile = 50);
+
+    /// <summary>
+    /// Calculate a percentile value from a list of durations.
+    /// </summary>
+    double CalculatePercentile(IReadOnlyList<double> values, int percentile);
+}

--- a/src/DraftSpec.Cli/History/RuntimeEstimate.cs
+++ b/src/DraftSpec.Cli/History/RuntimeEstimate.cs
@@ -1,0 +1,47 @@
+namespace DraftSpec.Cli.History;
+
+/// <summary>
+/// Aggregated runtime estimate for a spec suite.
+/// </summary>
+public class RuntimeEstimate
+{
+    /// <summary>
+    /// Median (P50) total runtime in milliseconds.
+    /// </summary>
+    public double P50Ms { get; init; }
+
+    /// <summary>
+    /// 95th percentile total runtime in milliseconds.
+    /// </summary>
+    public double P95Ms { get; init; }
+
+    /// <summary>
+    /// Maximum observed total runtime in milliseconds.
+    /// </summary>
+    public double MaxMs { get; init; }
+
+    /// <summary>
+    /// Total estimated runtime at the requested percentile in milliseconds.
+    /// </summary>
+    public double TotalEstimateMs { get; init; }
+
+    /// <summary>
+    /// The percentile used for TotalEstimateMs.
+    /// </summary>
+    public int Percentile { get; init; }
+
+    /// <summary>
+    /// Number of historical runs analyzed.
+    /// </summary>
+    public int SampleSize { get; init; }
+
+    /// <summary>
+    /// Number of unique specs with history.
+    /// </summary>
+    public int SpecCount { get; init; }
+
+    /// <summary>
+    /// Top slowest specs ordered by estimated duration.
+    /// </summary>
+    public IReadOnlyList<SpecEstimate> SlowestSpecs { get; init; } = [];
+}

--- a/src/DraftSpec.Cli/History/RuntimeEstimator.cs
+++ b/src/DraftSpec.Cli/History/RuntimeEstimator.cs
@@ -1,0 +1,121 @@
+namespace DraftSpec.Cli.History;
+
+/// <summary>
+/// Default implementation of runtime estimation using percentile calculations.
+/// </summary>
+public class RuntimeEstimator : IRuntimeEstimator
+{
+    private const int TopSlowestCount = 5;
+
+    public RuntimeEstimate Calculate(SpecHistory history, int percentile = 50)
+    {
+        if (history.Specs.Count == 0)
+        {
+            return new RuntimeEstimate
+            {
+                P50Ms = 0,
+                P95Ms = 0,
+                MaxMs = 0,
+                TotalEstimateMs = 0,
+                Percentile = percentile,
+                SampleSize = 0,
+                SpecCount = 0,
+                SlowestSpecs = []
+            };
+        }
+
+        var specEstimates = new List<SpecEstimate>();
+        var allRunCounts = new List<int>();
+
+        foreach (var (specId, entry) in history.Specs)
+        {
+            if (entry.Runs.Count == 0) continue;
+
+            var durations = entry.Runs
+                .Where(r => r.DurationMs > 0)
+                .Select(r => r.DurationMs)
+                .ToList();
+
+            if (durations.Count == 0) continue;
+
+            var estimate = CalculatePercentile(durations, percentile);
+            allRunCounts.Add(durations.Count);
+
+            specEstimates.Add(new SpecEstimate
+            {
+                SpecId = specId,
+                DisplayName = entry.DisplayName,
+                EstimateMs = estimate,
+                RunCount = durations.Count
+            });
+        }
+
+        if (specEstimates.Count == 0)
+        {
+            return new RuntimeEstimate
+            {
+                P50Ms = 0,
+                P95Ms = 0,
+                MaxMs = 0,
+                TotalEstimateMs = 0,
+                Percentile = percentile,
+                SampleSize = 0,
+                SpecCount = 0,
+                SlowestSpecs = []
+            };
+        }
+
+        // Calculate totals by summing individual spec estimates
+        var allEstimates = specEstimates.Select(s => s.EstimateMs).ToList();
+        var totalAtPercentile = allEstimates.Sum();
+
+        // For P50 and P95, recalculate each spec's contribution
+        var p50Total = specEstimates.Sum(s =>
+        {
+            var entry = history.Specs[s.SpecId];
+            var durations = entry.Runs.Where(r => r.DurationMs > 0).Select(r => r.DurationMs).ToList();
+            return durations.Count > 0 ? CalculatePercentile(durations, 50) : 0;
+        });
+
+        var p95Total = specEstimates.Sum(s =>
+        {
+            var entry = history.Specs[s.SpecId];
+            var durations = entry.Runs.Where(r => r.DurationMs > 0).Select(r => r.DurationMs).ToList();
+            return durations.Count > 0 ? CalculatePercentile(durations, 95) : 0;
+        });
+
+        var maxTotal = specEstimates.Sum(s =>
+        {
+            var entry = history.Specs[s.SpecId];
+            var durations = entry.Runs.Where(r => r.DurationMs > 0).Select(r => r.DurationMs).ToList();
+            return durations.Count > 0 ? durations.Max() : 0;
+        });
+
+        var slowestSpecs = specEstimates
+            .OrderByDescending(s => s.EstimateMs)
+            .Take(TopSlowestCount)
+            .ToList();
+
+        return new RuntimeEstimate
+        {
+            P50Ms = p50Total,
+            P95Ms = p95Total,
+            MaxMs = maxTotal,
+            TotalEstimateMs = totalAtPercentile,
+            Percentile = percentile,
+            SampleSize = allRunCounts.Count > 0 ? (int)allRunCounts.Average() : 0,
+            SpecCount = specEstimates.Count,
+            SlowestSpecs = slowestSpecs
+        };
+    }
+
+    public double CalculatePercentile(IReadOnlyList<double> values, int percentile)
+    {
+        if (values.Count == 0) return 0;
+        if (values.Count == 1) return values[0];
+
+        var sorted = values.OrderBy(v => v).ToList();
+        var index = (int)Math.Ceiling(percentile / 100.0 * sorted.Count) - 1;
+        return sorted[Math.Clamp(index, 0, sorted.Count - 1)];
+    }
+}

--- a/src/DraftSpec.Cli/History/SpecEstimate.cs
+++ b/src/DraftSpec.Cli/History/SpecEstimate.cs
@@ -1,0 +1,27 @@
+namespace DraftSpec.Cli.History;
+
+/// <summary>
+/// Runtime estimate for an individual spec.
+/// </summary>
+public class SpecEstimate
+{
+    /// <summary>
+    /// Unique identifier for the spec.
+    /// </summary>
+    public required string SpecId { get; init; }
+
+    /// <summary>
+    /// Human-readable display name.
+    /// </summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Estimated runtime at the requested percentile in milliseconds.
+    /// </summary>
+    public double EstimateMs { get; init; }
+
+    /// <summary>
+    /// Number of historical runs for this spec.
+    /// </summary>
+    public int RunCount { get; init; }
+}

--- a/src/DraftSpec.Cli/Options/EstimateOptions.cs
+++ b/src/DraftSpec.Cli/Options/EstimateOptions.cs
@@ -1,0 +1,22 @@
+namespace DraftSpec.Cli.Options;
+
+/// <summary>
+/// Command-specific options for the 'estimate' command.
+/// </summary>
+public class EstimateOptions
+{
+    /// <summary>
+    /// Path to the project root directory.
+    /// </summary>
+    public string Path { get; set; } = ".";
+
+    /// <summary>
+    /// Percentile to use for estimation (1-99). Default is 50 (median).
+    /// </summary>
+    public int Percentile { get; set; } = 50;
+
+    /// <summary>
+    /// Output the estimate in seconds (machine-readable) instead of formatted time.
+    /// </summary>
+    public bool OutputSeconds { get; set; }
+}

--- a/src/DraftSpec.Cli/UsageWriter.cs
+++ b/src/DraftSpec.Cli/UsageWriter.cs
@@ -30,6 +30,7 @@ public class UsageWriter : IUsageWriter
         _console.WriteLine("  draftspec watch <path> [options] Watch for changes and re-run");
         _console.WriteLine("  draftspec list <path> [options]  List specs without running them");
         _console.WriteLine("  draftspec flaky [path] [options] Show flaky test detection report");
+        _console.WriteLine("  draftspec estimate [path]        Estimate runtime based on history");
         _console.WriteLine("  draftspec init [path]            Initialize spec infrastructure");
         _console.WriteLine("  draftspec new <name> [path]      Create a new spec file");
         _console.WriteLine();
@@ -67,6 +68,10 @@ public class UsageWriter : IUsageWriter
         _console.WriteLine("  --window-size <n>       Number of recent runs to analyze (default: 10)");
         _console.WriteLine("  --clear <spec-id>       Clear a specific spec from history");
         _console.WriteLine();
+        _console.WriteLine("Estimate Command Options:");
+        _console.WriteLine("  --percentile <n>        Percentile for estimation (1-99, default: 50)");
+        _console.WriteLine("  --output-seconds        Output estimate in seconds (for scripting)");
+        _console.WriteLine();
         _console.WriteLine("Path can be:");
         _console.WriteLine("  - A directory (runs all *.spec.csx files recursively)");
         _console.WriteLine("  - A single .spec.csx file");
@@ -84,6 +89,8 @@ public class UsageWriter : IUsageWriter
         _console.WriteLine("  draftspec list . --focused-only");
         _console.WriteLine("  draftspec flaky                     # Show flaky test report");
         _console.WriteLine("  draftspec run . --quarantine        # Skip known flaky tests");
+        _console.WriteLine("  draftspec estimate                  # Show runtime estimate");
+        _console.WriteLine("  draftspec estimate --percentile 95  # P95 estimate for CI timeout");
 
         return errorMessage != null ? 1 : 0;
     }

--- a/tests/DraftSpec.Tests/Cli/CliOptionsConversionTests.cs
+++ b/tests/DraftSpec.Tests/Cli/CliOptionsConversionTests.cs
@@ -424,4 +424,38 @@ public class CliOptionsConversionTests
     }
 
     #endregion
+
+    #region ToEstimateOptions Tests
+
+    [Test]
+    public async Task ToEstimateOptions_MapsAllProperties()
+    {
+        var cliOptions = new CliOptions
+        {
+            Path = "/project/path",
+            Percentile = 95,
+            OutputSeconds = true
+        };
+
+        var estimateOptions = cliOptions.ToEstimateOptions();
+
+        await Assert.That(estimateOptions.Path).IsEqualTo("/project/path");
+        await Assert.That(estimateOptions.Percentile).IsEqualTo(95);
+        await Assert.That(estimateOptions.OutputSeconds).IsTrue();
+    }
+
+    [Test]
+    public async Task ToEstimateOptions_DefaultValues_CreatesValidOptions()
+    {
+        var cliOptions = new CliOptions();
+
+        var estimateOptions = cliOptions.ToEstimateOptions();
+
+        await Assert.That(estimateOptions).IsNotNull();
+        await Assert.That(estimateOptions.Path).IsEqualTo(".");
+        await Assert.That(estimateOptions.Percentile).IsEqualTo(50);
+        await Assert.That(estimateOptions.OutputSeconds).IsFalse();
+    }
+
+    #endregion
 }

--- a/tests/DraftSpec.Tests/Cli/CliOptionsParserTests.cs
+++ b/tests/DraftSpec.Tests/Cli/CliOptionsParserTests.cs
@@ -1376,4 +1376,120 @@ public class CliOptionsParserTests
     }
 
     #endregion
+
+    #region Estimate Command Options
+
+    [Test]
+    public async Task Parse_EstimateCommand_SetsCommand()
+    {
+        var options = CliOptionsParser.Parse(["estimate", "."]);
+
+        await Assert.That(options.Command).IsEqualTo("estimate");
+        await Assert.That(options.Path).IsEqualTo(".");
+    }
+
+    [Test]
+    public async Task Parse_EstimateCommandWithoutPath_UsesDefaultPath()
+    {
+        var options = CliOptionsParser.Parse(["estimate"]);
+
+        await Assert.That(options.Command).IsEqualTo("estimate");
+        await Assert.That(options.Path).IsEqualTo(".");
+    }
+
+    [Test]
+    public async Task Parse_PercentileOption_SetsPercentile()
+    {
+        var options = CliOptionsParser.Parse(["estimate", ".", "--percentile", "95"]);
+
+        await Assert.That(options.Percentile).IsEqualTo(95);
+        await Assert.That(options.ExplicitlySet).Contains(nameof(CliOptions.Percentile));
+    }
+
+    [Test]
+    public async Task Parse_PercentileWithoutValue_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["estimate", ".", "--percentile"]);
+
+        await Assert.That(options.Error).IsNotNull();
+        await Assert.That(options.Error).Contains("--percentile requires a value");
+    }
+
+    [Test]
+    public async Task Parse_PercentileInvalidValue_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["estimate", ".", "--percentile", "abc"]);
+
+        await Assert.That(options.Error).IsNotNull();
+        await Assert.That(options.Error).Contains("--percentile must be between 1 and 99");
+    }
+
+    [Test]
+    public async Task Parse_PercentileZero_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["estimate", ".", "--percentile", "0"]);
+
+        await Assert.That(options.Error).IsNotNull();
+        await Assert.That(options.Error).Contains("--percentile must be between 1 and 99");
+    }
+
+    [Test]
+    public async Task Parse_PercentileHundred_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["estimate", ".", "--percentile", "100"]);
+
+        await Assert.That(options.Error).IsNotNull();
+        await Assert.That(options.Error).Contains("--percentile must be between 1 and 99");
+    }
+
+    [Test]
+    public async Task Parse_PercentileNegative_SetsError()
+    {
+        var options = CliOptionsParser.Parse(["estimate", ".", "--percentile", "-5"]);
+
+        await Assert.That(options.Error).IsNotNull();
+        await Assert.That(options.Error).Contains("--percentile must be between 1 and 99");
+    }
+
+    [Test]
+    public async Task Parse_PercentileDefaultIs50()
+    {
+        var options = CliOptionsParser.Parse(["estimate", "."]);
+
+        await Assert.That(options.Percentile).IsEqualTo(50);
+    }
+
+    [Test]
+    public async Task Parse_OutputSecondsFlag_SetsOutputSeconds()
+    {
+        var options = CliOptionsParser.Parse(["estimate", ".", "--output-seconds"]);
+
+        await Assert.That(options.OutputSeconds).IsTrue();
+        await Assert.That(options.ExplicitlySet).Contains(nameof(CliOptions.OutputSeconds));
+    }
+
+    [Test]
+    public async Task Parse_OutputSecondsDefaultIsFalse()
+    {
+        var options = CliOptionsParser.Parse(["estimate", "."]);
+
+        await Assert.That(options.OutputSeconds).IsFalse();
+    }
+
+    [Test]
+    public async Task Parse_EstimateWithAllOptions_SetsAll()
+    {
+        var options = CliOptionsParser.Parse([
+            "estimate", "./specs",
+            "--percentile", "95",
+            "--output-seconds"
+        ]);
+
+        await Assert.That(options.Command).IsEqualTo("estimate");
+        await Assert.That(options.Path).IsEqualTo("./specs");
+        await Assert.That(options.Percentile).IsEqualTo(95);
+        await Assert.That(options.OutputSeconds).IsTrue();
+    }
+
+    #endregion
 }

--- a/tests/DraftSpec.Tests/Cli/CommandFactoryTests.cs
+++ b/tests/DraftSpec.Tests/Cli/CommandFactoryTests.cs
@@ -84,6 +84,26 @@ public class CommandFactoryTests
     }
 
     [Test]
+    public async Task Create_Flaky_ReturnsExecutor()
+    {
+        var factory = CreateFactory();
+
+        var executor = factory.Create("flaky");
+
+        await Assert.That(executor).IsNotNull();
+    }
+
+    [Test]
+    public async Task Create_Estimate_ReturnsExecutor()
+    {
+        var factory = CreateFactory();
+
+        var executor = factory.Create("estimate");
+
+        await Assert.That(executor).IsNotNull();
+    }
+
+    [Test]
     public async Task Create_Unknown_ReturnsNull()
     {
         var factory = CreateFactory();
@@ -227,7 +247,8 @@ public class CommandFactoryTests
             CreateInitCommand,
             CreateNewCommand,
             CreateSchemaCommand,
-            CreateFlakyCommand);
+            CreateFlakyCommand,
+            CreateEstimateCommand);
     }
 
     private static RunCommand CreateRunCommand() => new(
@@ -271,6 +292,12 @@ public class CommandFactoryTests
         NullObjects.FileSystem);
 
     private static FlakyCommand CreateFlakyCommand() => new(
+        NullObjects.HistoryService,
+        NullObjects.Console,
+        NullObjects.FileSystem);
+
+    private static EstimateCommand CreateEstimateCommand() => new(
+        NullObjects.RuntimeEstimator,
         NullObjects.HistoryService,
         NullObjects.Console,
         NullObjects.FileSystem);

--- a/tests/DraftSpec.Tests/Cli/Commands/EstimateCommandTests.cs
+++ b/tests/DraftSpec.Tests/Cli/Commands/EstimateCommandTests.cs
@@ -1,0 +1,543 @@
+using DraftSpec.Cli.Commands;
+using DraftSpec.Cli.History;
+using DraftSpec.Cli.Options;
+using DraftSpec.Tests.Infrastructure.Mocks;
+
+namespace DraftSpec.Tests.Cli.Commands;
+
+/// <summary>
+/// Tests for EstimateCommand which shows runtime estimates based on historical data.
+/// </summary>
+public class EstimateCommandTests
+{
+    private string _tempDir = null!;
+    private MockConsole _console = null!;
+    private MockFileSystem _fileSystem = null!;
+
+    [Before(Test)]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"draftspec_estimate_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _console = new MockConsole();
+        _fileSystem = new MockFileSystem().AddDirectory(_tempDir);
+    }
+
+    [After(Test)]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    #region Directory Validation Tests
+
+    [Test]
+    public async Task ExecuteAsync_DirectoryNotFound_ThrowsArgumentException()
+    {
+        var estimator = new MockRuntimeEstimator();
+        var historyService = new MockSpecHistoryService();
+        var command = CreateCommand(estimator, historyService);
+
+        var options = new EstimateOptions { Path = "/nonexistent/path" };
+
+        await Assert.ThrowsAsync<ArgumentException>(async () => await command.ExecuteAsync(options));
+    }
+
+    #endregion
+
+    #region Empty History Tests
+
+    [Test]
+    public async Task ExecuteAsync_NoHistory_ShowsRunSpecsFirstMessage()
+    {
+        var estimator = new MockRuntimeEstimator();
+        var historyService = new MockSpecHistoryService()
+            .WithHistory(SpecHistory.Empty);
+        var command = CreateCommand(estimator, historyService);
+
+        var options = new EstimateOptions { Path = _tempDir };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(0);
+        await Assert.That(_console.Output).Contains("No test history found");
+        await Assert.That(_console.Output).Contains("Run specs first to collect data");
+        await Assert.That(_console.Output).Contains("draftspec run");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_NoTimingData_ShowsNoTimingDataMessage()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry { DisplayName = "spec1", Runs = [] }
+            }
+        };
+        var estimate = new RuntimeEstimate
+        {
+            P50Ms = 0,
+            P95Ms = 0,
+            MaxMs = 0,
+            TotalEstimateMs = 0,
+            Percentile = 50,
+            SampleSize = 0,
+            SpecCount = 0,
+            SlowestSpecs = []
+        };
+        var estimator = new MockRuntimeEstimator().WithEstimate(estimate);
+        var historyService = new MockSpecHistoryService().WithHistory(history);
+        var command = CreateCommand(estimator, historyService);
+
+        var options = new EstimateOptions { Path = _tempDir };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(0);
+        await Assert.That(_console.Output).Contains("No timing data available");
+    }
+
+    #endregion
+
+    #region Estimate Output Tests
+
+    [Test]
+    public async Task ExecuteAsync_WithEstimate_ShowsRuntimeEstimate()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 1000 }]
+                }
+            }
+        };
+        var estimate = new RuntimeEstimate
+        {
+            P50Ms = 135000,  // 2m 15s
+            P95Ms = 272000,  // 4m 32s
+            MaxMs = 361000,  // 6m 01s
+            TotalEstimateMs = 135000,
+            Percentile = 50,
+            SampleSize = 47,
+            SpecCount = 10,
+            SlowestSpecs = []
+        };
+        var estimator = new MockRuntimeEstimator().WithEstimate(estimate);
+        var historyService = new MockSpecHistoryService().WithHistory(history);
+        var command = CreateCommand(estimator, historyService);
+
+        var options = new EstimateOptions { Path = _tempDir };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(0);
+        await Assert.That(_console.Output).Contains("Runtime Estimate (based on 47 historical runs)");
+        await Assert.That(_console.Output).Contains("P50 (median):");
+        await Assert.That(_console.Output).Contains("2m 15s");
+        await Assert.That(_console.Output).Contains("P95:");
+        await Assert.That(_console.Output).Contains("4m 32s");
+        await Assert.That(_console.Output).Contains("Max observed:");
+        await Assert.That(_console.Output).Contains("6m 01s");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_WithSlowestSpecs_ShowsSlowestSpecs()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 1000 }]
+                }
+            }
+        };
+        var estimate = new RuntimeEstimate
+        {
+            P50Ms = 10000,
+            P95Ms = 20000,
+            MaxMs = 30000,
+            TotalEstimateMs = 10000,
+            Percentile = 50,
+            SampleSize = 10,
+            SpecCount = 3,
+            SlowestSpecs =
+            [
+                new SpecEstimate
+                {
+                    SpecId = "test:slow",
+                    DisplayName = "Integration > Database > handles concurrent writes",
+                    EstimateMs = 45000,
+                    RunCount = 5
+                },
+                new SpecEstimate
+                {
+                    SpecId = "test:medium",
+                    DisplayName = "EmailService > SendAsync > retries on failure",
+                    EstimateMs = 23000,
+                    RunCount = 5
+                }
+            ]
+        };
+        var estimator = new MockRuntimeEstimator().WithEstimate(estimate);
+        var historyService = new MockSpecHistoryService().WithHistory(history);
+        var command = CreateCommand(estimator, historyService);
+
+        var options = new EstimateOptions { Path = _tempDir, Percentile = 50 };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(0);
+        await Assert.That(_console.Output).Contains("Slowest specs (P50):");
+        await Assert.That(_console.Output).Contains("1.");
+        await Assert.That(_console.Output).Contains("Integration > Database > handles concurrent writes");
+        await Assert.That(_console.Output).Contains("45.0s");
+        await Assert.That(_console.Output).Contains("2.");
+        await Assert.That(_console.Output).Contains("EmailService > SendAsync > retries on failure");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ShowsRecommendedCiTimeout()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 1000 }]
+                }
+            }
+        };
+        var estimate = new RuntimeEstimate
+        {
+            P50Ms = 10000,
+            P95Ms = 120000, // 2 minutes
+            MaxMs = 180000,
+            TotalEstimateMs = 10000,
+            Percentile = 50,
+            SampleSize = 10,
+            SpecCount = 5,
+            SlowestSpecs = []
+        };
+        var estimator = new MockRuntimeEstimator().WithEstimate(estimate);
+        var historyService = new MockSpecHistoryService().WithHistory(history);
+        var command = CreateCommand(estimator, historyService);
+
+        var options = new EstimateOptions { Path = _tempDir };
+
+        await command.ExecuteAsync(options);
+
+        // 2x P95 = 4 minutes
+        await Assert.That(_console.Output).Contains("Recommended CI timeout:");
+        await Assert.That(_console.Output).Contains("4m 00s");
+        await Assert.That(_console.Output).Contains("(2x P95)");
+    }
+
+    #endregion
+
+    #region OutputSeconds Mode Tests
+
+    [Test]
+    public async Task ExecuteAsync_OutputSeconds_ReturnsSecondsOnly()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 1000 }]
+                }
+            }
+        };
+        var estimate = new RuntimeEstimate
+        {
+            P50Ms = 135500, // 135.5 seconds
+            P95Ms = 200000,
+            MaxMs = 300000,
+            TotalEstimateMs = 135500,
+            Percentile = 50,
+            SampleSize = 10,
+            SpecCount = 5,
+            SlowestSpecs = []
+        };
+        var estimator = new MockRuntimeEstimator().WithEstimate(estimate);
+        var historyService = new MockSpecHistoryService().WithHistory(history);
+        var command = CreateCommand(estimator, historyService);
+
+        var options = new EstimateOptions { Path = _tempDir, OutputSeconds = true };
+
+        var result = await command.ExecuteAsync(options);
+
+        await Assert.That(result).IsEqualTo(0);
+        // Should only output the seconds value
+        await Assert.That(_console.Output.Trim()).IsEqualTo("135.5");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_OutputSeconds_DoesNotShowHumanReadableOutput()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 1000 }]
+                }
+            }
+        };
+        var estimate = new RuntimeEstimate
+        {
+            P50Ms = 60000,
+            P95Ms = 120000,
+            MaxMs = 180000,
+            TotalEstimateMs = 60000,
+            Percentile = 50,
+            SampleSize = 10,
+            SpecCount = 5,
+            SlowestSpecs = []
+        };
+        var estimator = new MockRuntimeEstimator().WithEstimate(estimate);
+        var historyService = new MockSpecHistoryService().WithHistory(history);
+        var command = CreateCommand(estimator, historyService);
+
+        var options = new EstimateOptions { Path = _tempDir, OutputSeconds = true };
+
+        await command.ExecuteAsync(options);
+
+        await Assert.That(_console.Output).DoesNotContain("Runtime Estimate");
+        await Assert.That(_console.Output).DoesNotContain("P50");
+        await Assert.That(_console.Output).DoesNotContain("P95");
+        await Assert.That(_console.Output).DoesNotContain("Recommended");
+    }
+
+    #endregion
+
+    #region Percentile Option Tests
+
+    [Test]
+    public async Task ExecuteAsync_UsesCustomPercentile()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 1000 }]
+                }
+            }
+        };
+        var estimate = new RuntimeEstimate
+        {
+            P50Ms = 60000,
+            P95Ms = 120000,
+            MaxMs = 180000,
+            TotalEstimateMs = 120000,
+            Percentile = 95,
+            SampleSize = 10,
+            SpecCount = 5,
+            SlowestSpecs =
+            [
+                new SpecEstimate
+                {
+                    SpecId = "test:slow",
+                    DisplayName = "slow spec",
+                    EstimateMs = 10000,
+                    RunCount = 5
+                }
+            ]
+        };
+        var estimator = new MockRuntimeEstimator().WithEstimate(estimate);
+        var historyService = new MockSpecHistoryService().WithHistory(history);
+        var command = CreateCommand(estimator, historyService);
+
+        var options = new EstimateOptions { Path = _tempDir, Percentile = 95 };
+
+        await command.ExecuteAsync(options);
+
+        // Verify the estimator was called with the right percentile
+        await Assert.That(estimator.LastPercentile).IsEqualTo(95);
+        await Assert.That(_console.Output).Contains("Slowest specs (P95):");
+    }
+
+    #endregion
+
+    #region Duration Formatting Tests
+
+    [Test]
+    public async Task ExecuteAsync_FormatsDurationInMilliseconds()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 100 }]
+                }
+            }
+        };
+        var estimate = new RuntimeEstimate
+        {
+            P50Ms = 500,
+            P95Ms = 800,
+            MaxMs = 950,
+            TotalEstimateMs = 500,
+            Percentile = 50,
+            SampleSize = 5,
+            SpecCount = 1,
+            SlowestSpecs = []
+        };
+        var estimator = new MockRuntimeEstimator().WithEstimate(estimate);
+        var historyService = new MockSpecHistoryService().WithHistory(history);
+        var command = CreateCommand(estimator, historyService);
+
+        var options = new EstimateOptions { Path = _tempDir };
+
+        await command.ExecuteAsync(options);
+
+        await Assert.That(_console.Output).Contains("500ms");
+        await Assert.That(_console.Output).Contains("800ms");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_FormatsDurationInSeconds()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 1000 }]
+                }
+            }
+        };
+        var estimate = new RuntimeEstimate
+        {
+            P50Ms = 5500,  // 5.5 seconds
+            P95Ms = 10000,
+            MaxMs = 15000,
+            TotalEstimateMs = 5500,
+            Percentile = 50,
+            SampleSize = 5,
+            SpecCount = 1,
+            SlowestSpecs = []
+        };
+        var estimator = new MockRuntimeEstimator().WithEstimate(estimate);
+        var historyService = new MockSpecHistoryService().WithHistory(history);
+        var command = CreateCommand(estimator, historyService);
+
+        var options = new EstimateOptions { Path = _tempDir };
+
+        await command.ExecuteAsync(options);
+
+        await Assert.That(_console.Output).Contains("5.5s");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_FormatsDurationInMinutes()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 1000 }]
+                }
+            }
+        };
+        var estimate = new RuntimeEstimate
+        {
+            P50Ms = 135000, // 2m 15s
+            P95Ms = 300000,
+            MaxMs = 450000,
+            TotalEstimateMs = 135000,
+            Percentile = 50,
+            SampleSize = 5,
+            SpecCount = 1,
+            SlowestSpecs = []
+        };
+        var estimator = new MockRuntimeEstimator().WithEstimate(estimate);
+        var historyService = new MockSpecHistoryService().WithHistory(history);
+        var command = CreateCommand(estimator, historyService);
+
+        var options = new EstimateOptions { Path = _tempDir };
+
+        await command.ExecuteAsync(options);
+
+        await Assert.That(_console.Output).Contains("2m 15s");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_FormatsDurationInHours()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 1000 }]
+                }
+            }
+        };
+        var estimate = new RuntimeEstimate
+        {
+            P50Ms = 3723000, // 1h 02m 03s
+            P95Ms = 7200000,
+            MaxMs = 10800000,
+            TotalEstimateMs = 3723000,
+            Percentile = 50,
+            SampleSize = 5,
+            SpecCount = 1,
+            SlowestSpecs = []
+        };
+        var estimator = new MockRuntimeEstimator().WithEstimate(estimate);
+        var historyService = new MockSpecHistoryService().WithHistory(history);
+        var command = CreateCommand(estimator, historyService);
+
+        var options = new EstimateOptions { Path = _tempDir };
+
+        await command.ExecuteAsync(options);
+
+        await Assert.That(_console.Output).Contains("1h 02m 03s");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private EstimateCommand CreateCommand(MockRuntimeEstimator? estimator = null, MockSpecHistoryService? historyService = null)
+    {
+        return new EstimateCommand(
+            estimator ?? new MockRuntimeEstimator(),
+            historyService ?? new MockSpecHistoryService(),
+            _console,
+            _fileSystem);
+    }
+
+    #endregion
+}

--- a/tests/DraftSpec.Tests/Cli/History/RuntimeEstimatorTests.cs
+++ b/tests/DraftSpec.Tests/Cli/History/RuntimeEstimatorTests.cs
@@ -1,0 +1,505 @@
+using DraftSpec.Cli.History;
+
+namespace DraftSpec.Tests.Cli.History;
+
+/// <summary>
+/// Tests for RuntimeEstimator which calculates runtime estimates from historical data.
+/// </summary>
+public class RuntimeEstimatorTests
+{
+    private RuntimeEstimator _estimator = null!;
+
+    [Before(Test)]
+    public void SetUp()
+    {
+        _estimator = new RuntimeEstimator();
+    }
+
+    #region CalculatePercentile Tests
+
+    [Test]
+    public async Task CalculatePercentile_EmptyList_ReturnsZero()
+    {
+        var result = _estimator.CalculatePercentile([], 50);
+
+        await Assert.That(result).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CalculatePercentile_SingleValue_ReturnsValue()
+    {
+        var result = _estimator.CalculatePercentile([100.0], 50);
+
+        await Assert.That(result).IsEqualTo(100.0);
+    }
+
+    [Test]
+    public async Task CalculatePercentile_P50_ReturnsMedian()
+    {
+        // 10, 20, 30, 40, 50 - median is 30
+        var values = new List<double> { 10, 20, 30, 40, 50 };
+
+        var result = _estimator.CalculatePercentile(values, 50);
+
+        await Assert.That(result).IsEqualTo(30);
+    }
+
+    [Test]
+    public async Task CalculatePercentile_P95_ReturnsHighValue()
+    {
+        // 10 values: 10, 20, 30, 40, 50, 60, 70, 80, 90, 100
+        // P95 should be 100 (95% of 10 = 9.5, ceiling = 10, index 9)
+        var values = new List<double> { 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 };
+
+        var result = _estimator.CalculatePercentile(values, 95);
+
+        await Assert.That(result).IsEqualTo(100);
+    }
+
+    [Test]
+    public async Task CalculatePercentile_P99_ReturnsMaxForSmallList()
+    {
+        var values = new List<double> { 10, 20, 30, 40, 50 };
+
+        var result = _estimator.CalculatePercentile(values, 99);
+
+        await Assert.That(result).IsEqualTo(50);
+    }
+
+    [Test]
+    public async Task CalculatePercentile_P1_ReturnsMinValue()
+    {
+        var values = new List<double> { 10, 20, 30, 40, 50 };
+
+        var result = _estimator.CalculatePercentile(values, 1);
+
+        await Assert.That(result).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task CalculatePercentile_UnsortedInput_SortsAndCalculates()
+    {
+        // Input is unsorted
+        var values = new List<double> { 50, 10, 40, 20, 30 };
+
+        var result = _estimator.CalculatePercentile(values, 50);
+
+        await Assert.That(result).IsEqualTo(30);
+    }
+
+    #endregion
+
+    #region Calculate - Empty History Tests
+
+    [Test]
+    public async Task Calculate_EmptyHistory_ReturnsZeroEstimate()
+    {
+        var history = SpecHistory.Empty;
+
+        var result = _estimator.Calculate(history);
+
+        await Assert.That(result.P50Ms).IsEqualTo(0);
+        await Assert.That(result.P95Ms).IsEqualTo(0);
+        await Assert.That(result.MaxMs).IsEqualTo(0);
+        await Assert.That(result.TotalEstimateMs).IsEqualTo(0);
+        await Assert.That(result.SampleSize).IsEqualTo(0);
+        await Assert.That(result.SpecCount).IsEqualTo(0);
+        await Assert.That(result.SlowestSpecs).IsEmpty();
+    }
+
+    [Test]
+    public async Task Calculate_HistoryWithNoRuns_ReturnsZeroEstimate()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = []
+                }
+            }
+        };
+
+        var result = _estimator.Calculate(history);
+
+        await Assert.That(result.SpecCount).IsEqualTo(0);
+        await Assert.That(result.TotalEstimateMs).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Calculate_HistoryWithZeroDurations_ReturnsZeroEstimate()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [
+                        new SpecRun { Status = "passed", DurationMs = 0 },
+                        new SpecRun { Status = "passed", DurationMs = 0 }
+                    ]
+                }
+            }
+        };
+
+        var result = _estimator.Calculate(history);
+
+        await Assert.That(result.SpecCount).IsEqualTo(0);
+        await Assert.That(result.TotalEstimateMs).IsEqualTo(0);
+    }
+
+    #endregion
+
+    #region Calculate - Single Spec Tests
+
+    [Test]
+    public async Task Calculate_SingleSpecSingleRun_ReturnsRunDuration()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 100 }]
+                }
+            }
+        };
+
+        var result = _estimator.Calculate(history);
+
+        await Assert.That(result.SpecCount).IsEqualTo(1);
+        await Assert.That(result.TotalEstimateMs).IsEqualTo(100);
+        await Assert.That(result.P50Ms).IsEqualTo(100);
+        await Assert.That(result.P95Ms).IsEqualTo(100);
+        await Assert.That(result.MaxMs).IsEqualTo(100);
+        await Assert.That(result.SampleSize).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Calculate_SingleSpecMultipleRuns_ReturnsPercentileEstimate()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [
+                        new SpecRun { Status = "passed", DurationMs = 100 },
+                        new SpecRun { Status = "passed", DurationMs = 200 },
+                        new SpecRun { Status = "passed", DurationMs = 300 },
+                        new SpecRun { Status = "passed", DurationMs = 400 },
+                        new SpecRun { Status = "passed", DurationMs = 500 }
+                    ]
+                }
+            }
+        };
+
+        var result = _estimator.Calculate(history, percentile: 50);
+
+        await Assert.That(result.SpecCount).IsEqualTo(1);
+        await Assert.That(result.TotalEstimateMs).IsEqualTo(300); // P50 = median
+        await Assert.That(result.P50Ms).IsEqualTo(300);
+        await Assert.That(result.MaxMs).IsEqualTo(500);
+        await Assert.That(result.SampleSize).IsEqualTo(5);
+    }
+
+    #endregion
+
+    #region Calculate - Multiple Specs Tests
+
+    [Test]
+    public async Task Calculate_MultipleSpecs_SumsEstimates()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 100 }]
+                },
+                ["test:spec2"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec2",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 200 }]
+                },
+                ["test:spec3"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec3",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 300 }]
+                }
+            }
+        };
+
+        var result = _estimator.Calculate(history);
+
+        await Assert.That(result.SpecCount).IsEqualTo(3);
+        await Assert.That(result.TotalEstimateMs).IsEqualTo(600); // 100 + 200 + 300
+        await Assert.That(result.P50Ms).IsEqualTo(600);
+        await Assert.That(result.MaxMs).IsEqualTo(600);
+    }
+
+    [Test]
+    public async Task Calculate_MultipleSpecsWithVaryingRuns_CalculatesPerSpecThenSums()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:fast"] = new SpecHistoryEntry
+                {
+                    DisplayName = "fast spec",
+                    Runs = [
+                        new SpecRun { Status = "passed", DurationMs = 10 },
+                        new SpecRun { Status = "passed", DurationMs = 20 },
+                        new SpecRun { Status = "passed", DurationMs = 30 }
+                    ]
+                },
+                ["test:slow"] = new SpecHistoryEntry
+                {
+                    DisplayName = "slow spec",
+                    Runs = [
+                        new SpecRun { Status = "passed", DurationMs = 1000 },
+                        new SpecRun { Status = "passed", DurationMs = 2000 },
+                        new SpecRun { Status = "passed", DurationMs = 3000 }
+                    ]
+                }
+            }
+        };
+
+        var result = _estimator.Calculate(history, percentile: 50);
+
+        // fast spec P50 = 20ms, slow spec P50 = 2000ms
+        await Assert.That(result.SpecCount).IsEqualTo(2);
+        await Assert.That(result.TotalEstimateMs).IsEqualTo(2020); // 20 + 2000
+    }
+
+    #endregion
+
+    #region Calculate - Slowest Specs Tests
+
+    [Test]
+    public async Task Calculate_ReturnsSlowestSpecsInOrder()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:fast"] = new SpecHistoryEntry
+                {
+                    DisplayName = "fast spec",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 10 }]
+                },
+                ["test:medium"] = new SpecHistoryEntry
+                {
+                    DisplayName = "medium spec",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 100 }]
+                },
+                ["test:slow"] = new SpecHistoryEntry
+                {
+                    DisplayName = "slow spec",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 1000 }]
+                }
+            }
+        };
+
+        var result = _estimator.Calculate(history);
+
+        await Assert.That(result.SlowestSpecs.Count).IsEqualTo(3);
+        await Assert.That(result.SlowestSpecs[0].DisplayName).IsEqualTo("slow spec");
+        await Assert.That(result.SlowestSpecs[0].EstimateMs).IsEqualTo(1000);
+        await Assert.That(result.SlowestSpecs[1].DisplayName).IsEqualTo("medium spec");
+        await Assert.That(result.SlowestSpecs[2].DisplayName).IsEqualTo("fast spec");
+    }
+
+    [Test]
+    public async Task Calculate_LimitsToTopFiveSlowestSpecs()
+    {
+        var specs = new Dictionary<string, SpecHistoryEntry>();
+        for (int i = 1; i <= 10; i++)
+        {
+            specs[$"test:spec{i}"] = new SpecHistoryEntry
+            {
+                DisplayName = $"spec{i}",
+                Runs = [new SpecRun { Status = "passed", DurationMs = i * 100 }]
+            };
+        }
+
+        var history = new SpecHistory { Specs = specs };
+
+        var result = _estimator.Calculate(history);
+
+        await Assert.That(result.SlowestSpecs.Count).IsEqualTo(5);
+        await Assert.That(result.SlowestSpecs[0].EstimateMs).IsEqualTo(1000); // spec10
+        await Assert.That(result.SlowestSpecs[4].EstimateMs).IsEqualTo(600);  // spec6
+    }
+
+    [Test]
+    public async Task Calculate_SlowestSpecsIncludeSpecIdAndRunCount()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test.spec.csx:Context/spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "Context > spec1",
+                    Runs = [
+                        new SpecRun { Status = "passed", DurationMs = 100 },
+                        new SpecRun { Status = "passed", DurationMs = 200 },
+                        new SpecRun { Status = "passed", DurationMs = 300 }
+                    ]
+                }
+            }
+        };
+
+        var result = _estimator.Calculate(history);
+
+        await Assert.That(result.SlowestSpecs[0].SpecId).IsEqualTo("test.spec.csx:Context/spec1");
+        await Assert.That(result.SlowestSpecs[0].DisplayName).IsEqualTo("Context > spec1");
+        await Assert.That(result.SlowestSpecs[0].RunCount).IsEqualTo(3);
+    }
+
+    #endregion
+
+    #region Calculate - Percentile Parameter Tests
+
+    [Test]
+    public async Task Calculate_CustomPercentile_UsesForTotalEstimate()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [
+                        new SpecRun { Status = "passed", DurationMs = 100 },
+                        new SpecRun { Status = "passed", DurationMs = 200 },
+                        new SpecRun { Status = "passed", DurationMs = 300 },
+                        new SpecRun { Status = "passed", DurationMs = 400 },
+                        new SpecRun { Status = "passed", DurationMs = 500 }
+                    ]
+                }
+            }
+        };
+
+        var resultP50 = _estimator.Calculate(history, percentile: 50);
+        var resultP95 = _estimator.Calculate(history, percentile: 95);
+
+        await Assert.That(resultP50.TotalEstimateMs).IsEqualTo(300);
+        await Assert.That(resultP50.Percentile).IsEqualTo(50);
+        await Assert.That(resultP95.TotalEstimateMs).IsEqualTo(500);
+        await Assert.That(resultP95.Percentile).IsEqualTo(95);
+    }
+
+    [Test]
+    public async Task Calculate_AlwaysReturnsP50AndP95Regardless()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [
+                        new SpecRun { Status = "passed", DurationMs = 100 },
+                        new SpecRun { Status = "passed", DurationMs = 200 },
+                        new SpecRun { Status = "passed", DurationMs = 300 },
+                        new SpecRun { Status = "passed", DurationMs = 400 },
+                        new SpecRun { Status = "passed", DurationMs = 500 }
+                    ]
+                }
+            }
+        };
+
+        // Request P75 but still get P50 and P95
+        var result = _estimator.Calculate(history, percentile: 75);
+
+        await Assert.That(result.P50Ms).IsEqualTo(300);
+        await Assert.That(result.P95Ms).IsEqualTo(500);
+        await Assert.That(result.TotalEstimateMs).IsEqualTo(400); // P75
+        await Assert.That(result.Percentile).IsEqualTo(75);
+    }
+
+    #endregion
+
+    #region Calculate - Mixed Data Tests
+
+    [Test]
+    public async Task Calculate_MixedValidAndZeroDurations_IgnoresZeros()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [
+                        new SpecRun { Status = "passed", DurationMs = 0 },  // ignored
+                        new SpecRun { Status = "passed", DurationMs = 100 },
+                        new SpecRun { Status = "passed", DurationMs = 0 },  // ignored
+                        new SpecRun { Status = "passed", DurationMs = 200 }
+                    ]
+                }
+            }
+        };
+
+        var result = _estimator.Calculate(history, percentile: 50);
+
+        // Only considers 100 and 200
+        await Assert.That(result.SampleSize).IsEqualTo(2);
+        await Assert.That(result.TotalEstimateMs).IsEqualTo(100); // P50 of [100, 200] = 100
+    }
+
+    [Test]
+    public async Task Calculate_MultipleSpecsWithMixedData_HandlesCorrectly()
+    {
+        var history = new SpecHistory
+        {
+            Specs = new Dictionary<string, SpecHistoryEntry>
+            {
+                ["test:spec1"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec1",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 100 }]
+                },
+                ["test:spec2"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec2",
+                    Runs = [] // no runs
+                },
+                ["test:spec3"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec3",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 0 }] // zero duration
+                },
+                ["test:spec4"] = new SpecHistoryEntry
+                {
+                    DisplayName = "spec4",
+                    Runs = [new SpecRun { Status = "passed", DurationMs = 200 }]
+                }
+            }
+        };
+
+        var result = _estimator.Calculate(history);
+
+        // Only spec1 and spec4 have valid data
+        await Assert.That(result.SpecCount).IsEqualTo(2);
+        await Assert.That(result.TotalEstimateMs).IsEqualTo(300); // 100 + 200
+    }
+
+    #endregion
+}

--- a/tests/DraftSpec.Tests/Cli/UsageWriterTests.cs
+++ b/tests/DraftSpec.Tests/Cli/UsageWriterTests.cs
@@ -184,4 +184,60 @@ public class UsageWriterTests
     }
 
     #endregion
+
+    #region Flaky Command Documentation
+
+    [Test]
+    public async Task Show_NoError_DisplaysFlakyCommand()
+    {
+        _writer.Show();
+
+        await Assert.That(_console.Output).Contains("draftspec flaky");
+        await Assert.That(_console.Output).Contains("flaky test detection");
+    }
+
+    [Test]
+    public async Task Show_NoError_DisplaysFlakyOptions()
+    {
+        _writer.Show();
+
+        await Assert.That(_console.Output).Contains("Flaky Command Options:");
+        await Assert.That(_console.Output).Contains("--min-changes");
+        await Assert.That(_console.Output).Contains("--window-size");
+        await Assert.That(_console.Output).Contains("--clear");
+    }
+
+    #endregion
+
+    #region Estimate Command Documentation
+
+    [Test]
+    public async Task Show_NoError_DisplaysEstimateCommand()
+    {
+        _writer.Show();
+
+        await Assert.That(_console.Output).Contains("draftspec estimate");
+        await Assert.That(_console.Output).Contains("Estimate runtime based on history");
+    }
+
+    [Test]
+    public async Task Show_NoError_DisplaysEstimateOptions()
+    {
+        _writer.Show();
+
+        await Assert.That(_console.Output).Contains("Estimate Command Options:");
+        await Assert.That(_console.Output).Contains("--percentile");
+        await Assert.That(_console.Output).Contains("--output-seconds");
+    }
+
+    [Test]
+    public async Task Show_NoError_DisplaysEstimateExamples()
+    {
+        _writer.Show();
+
+        await Assert.That(_console.Output).Contains("draftspec estimate");
+        await Assert.That(_console.Output).Contains("--percentile 95");
+    }
+
+    #endregion
 }

--- a/tests/DraftSpec.Tests/Infrastructure/Mocks/MockRuntimeEstimator.cs
+++ b/tests/DraftSpec.Tests/Infrastructure/Mocks/MockRuntimeEstimator.cs
@@ -1,0 +1,79 @@
+using DraftSpec.Cli.History;
+
+namespace DraftSpec.Tests.Infrastructure.Mocks;
+
+/// <summary>
+/// Mock implementation of IRuntimeEstimator for testing.
+/// </summary>
+public class MockRuntimeEstimator : IRuntimeEstimator
+{
+    private RuntimeEstimate _estimate = new()
+    {
+        P50Ms = 0,
+        P95Ms = 0,
+        MaxMs = 0,
+        TotalEstimateMs = 0,
+        Percentile = 50,
+        SampleSize = 0,
+        SpecCount = 0,
+        SlowestSpecs = []
+    };
+
+    private readonly Dictionary<int, double> _percentileResults = new();
+
+    /// <summary>
+    /// Gets how many times Calculate was called.
+    /// </summary>
+    public int CalculateCalls { get; private set; }
+
+    /// <summary>
+    /// Gets the last history passed to Calculate.
+    /// </summary>
+    public SpecHistory? LastHistory { get; private set; }
+
+    /// <summary>
+    /// Gets the last percentile passed to Calculate.
+    /// </summary>
+    public int LastPercentile { get; private set; }
+
+    /// <summary>
+    /// Configure the estimate to return.
+    /// </summary>
+    public MockRuntimeEstimator WithEstimate(RuntimeEstimate estimate)
+    {
+        _estimate = estimate;
+        return this;
+    }
+
+    /// <summary>
+    /// Configure a percentile calculation result.
+    /// </summary>
+    public MockRuntimeEstimator WithPercentileResult(int percentile, double result)
+    {
+        _percentileResults[percentile] = result;
+        return this;
+    }
+
+    public RuntimeEstimate Calculate(SpecHistory history, int percentile = 50)
+    {
+        CalculateCalls++;
+        LastHistory = history;
+        LastPercentile = percentile;
+        return _estimate;
+    }
+
+    public double CalculatePercentile(IReadOnlyList<double> values, int percentile)
+    {
+        if (_percentileResults.TryGetValue(percentile, out var result))
+        {
+            return result;
+        }
+
+        // Default: return simple calculation
+        if (values.Count == 0) return 0;
+        if (values.Count == 1) return values[0];
+        var sorted = values.OrderBy(v => v).ToList();
+        var index = (int)Math.Ceiling(percentile / 100.0 * sorted.Count) - 1;
+        return sorted[Math.Clamp(index, 0, sorted.Count - 1)];
+    }
+}

--- a/tests/DraftSpec.Tests/Infrastructure/NullObjects.cs
+++ b/tests/DraftSpec.Tests/Infrastructure/NullObjects.cs
@@ -99,6 +99,11 @@ public static class NullObjects
     /// </summary>
     public static ISpecHistoryService HistoryService { get; } = new NullHistoryService();
 
+    /// <summary>
+    /// A no-op runtime estimator.
+    /// </summary>
+    public static IRuntimeEstimator RuntimeEstimator { get; } = new NullRuntimeEstimator();
+
     #region Null Object Implementations
 
     private class NullConsole : IConsole
@@ -291,6 +296,25 @@ public static class NullObjects
 
         public Task<bool> ClearSpecAsync(string projectPath, string specId, CancellationToken ct = default)
             => Task.FromResult(false);
+    }
+
+    private class NullRuntimeEstimator : IRuntimeEstimator
+    {
+        public RuntimeEstimate Calculate(SpecHistory history, int percentile = 50)
+            => new()
+            {
+                P50Ms = 0,
+                P95Ms = 0,
+                MaxMs = 0,
+                TotalEstimateMs = 0,
+                Percentile = percentile,
+                SampleSize = 0,
+                SpecCount = 0,
+                SlowestSpecs = []
+            };
+
+        public double CalculatePercentile(IReadOnlyList<double> values, int percentile)
+            => 0;
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Add `draftspec estimate` command that analyzes historical execution data to provide runtime estimates for spec suites.

### Features
- **P50/P95 percentiles**: Median and 95th percentile runtime estimates
- **Maximum observed**: Shows worst-case historical runtime
- **Slowest specs**: Top 5 slowest specs by estimated duration
- **CI timeout recommendation**: 2x P95 for safe CI configuration
- **Machine-readable output**: `--output-seconds` for scripting

### Usage
```bash
draftspec estimate                    # Show P50 estimate
draftspec estimate --percentile 95    # Show P95 estimate  
draftspec estimate --output-seconds   # Output seconds for CI scripts
```

### Example Output
```
Runtime Estimate (based on 47 historical runs):
  P50 (median):      2m 15s
  P95:               4m 32s
  Max observed:      6m 01s

Slowest specs (P50):
  1. Integration > Database > handles concurrent writes (45.0s)
  2. EmailService > SendAsync > retries on failure (23.0s)
  3. OrderService > ProcessAsync > handles timeout (18.0s)

Recommended CI timeout: 9m 04s (2x P95)
```

## Implementation

| Component | Description |
|-----------|-------------|
| `EstimateOptions` | Command options (path, percentile, output-seconds) |
| `IRuntimeEstimator` | Interface for estimation service |
| `RuntimeEstimator` | Percentile calculation implementation |
| `EstimateCommand` | Command following existing patterns |

## Test Plan

- [x] RuntimeEstimatorTests (21 tests) - percentile calculations, empty/mixed data
- [x] EstimateCommandTests (13 tests) - command execution, formatting, output modes
- [x] CliOptionsParserTests (12 tests) - option parsing, validation
- [x] CliOptionsConversionTests (2 tests) - ToEstimateOptions conversion
- [x] CommandFactoryTests (2 tests) - factory creates executor
- [x] UsageWriterTests (5 tests) - help text display

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)