### PR TITLE
refactor(cli): Extract CommandRegistry to simplify CommandFactory

### DIFF
--- a/src/DraftSpec.Cli/CommandFactory.cs
+++ b/src/DraftSpec.Cli/CommandFactory.cs
@@ -1,77 +1,28 @@
-using DraftSpec.Cli.Commands;
-using DraftSpec.Cli.Options;
 using DraftSpec.Cli.Pipeline;
 
 namespace DraftSpec.Cli;
 
 /// <summary>
 /// Factory for creating command executors.
-/// Uses explicit factory functions for testability (no IServiceProvider coupling).
+/// Delegates to ICommandRegistry for command lookup.
 /// </summary>
 public class CommandFactory : ICommandFactory
 {
-    private readonly IConfigApplier _configApplier;
-    private readonly Func<RunCommand> _runFactory;
-    private readonly Func<WatchCommand> _watchFactory;
-    private readonly Func<ListCommand> _listFactory;
-    private readonly Func<ValidateCommand> _validateFactory;
-    private readonly Func<InitCommand> _initFactory;
-    private readonly Func<NewCommand> _newFactory;
-    private readonly Func<SchemaCommand> _schemaFactory;
-    private readonly Func<FlakyCommand> _flakyFactory;
-    private readonly Func<EstimateCommand> _estimateFactory;
+    private readonly ICommandRegistry _registry;
 
-    public CommandFactory(
-        IConfigApplier configApplier,
-        Func<RunCommand> runFactory,
-        Func<WatchCommand> watchFactory,
-        Func<ListCommand> listFactory,
-        Func<ValidateCommand> validateFactory,
-        Func<InitCommand> initFactory,
-        Func<NewCommand> newFactory,
-        Func<SchemaCommand> schemaFactory,
-        Func<FlakyCommand> flakyFactory,
-        Func<EstimateCommand> estimateFactory)
+    /// <summary>
+    /// Create a command factory.
+    /// </summary>
+    /// <param name="registry">The command registry to use for lookups.</param>
+    public CommandFactory(ICommandRegistry registry)
     {
-        _configApplier = configApplier;
-        _runFactory = runFactory;
-        _watchFactory = watchFactory;
-        _listFactory = listFactory;
-        _validateFactory = validateFactory;
-        _initFactory = initFactory;
-        _newFactory = newFactory;
-        _schemaFactory = schemaFactory;
-        _flakyFactory = flakyFactory;
-        _estimateFactory = estimateFactory;
+        _registry = registry ?? throw new ArgumentNullException(nameof(registry));
     }
 
+    /// <inheritdoc />
     public Func<CliOptions, CancellationToken, Task<int>>? Create(string commandName)
     {
-        var executor = CreateExecutor(commandName);
+        var executor = _registry.GetExecutor(commandName);
         return executor == null ? null : executor.ExecuteAsync;
     }
-
-    private ICommandExecutor? CreateExecutor(string commandName) =>
-        commandName.ToLowerInvariant() switch
-        {
-            "run" => new CommandExecutor<RunCommand, RunOptions>(
-                _runFactory(), o => o.ToRunOptions(), _configApplier),
-            "watch" => new CommandExecutor<WatchCommand, WatchOptions>(
-                _watchFactory(), o => o.ToWatchOptions(), _configApplier),
-            "list" => new CommandExecutor<ListCommand, ListOptions>(
-                _listFactory(), o => o.ToListOptions(), _configApplier),
-            "validate" => new CommandExecutor<ValidateCommand, ValidateOptions>(
-                _validateFactory(), o => o.ToValidateOptions(), _configApplier),
-            "init" => new CommandExecutor<InitCommand, InitOptions>(
-                _initFactory(), o => o.ToInitOptions(), _configApplier),
-            "new" => new CommandExecutor<NewCommand, NewOptions>(
-                _newFactory(), o => o.ToNewOptions(), _configApplier),
-            "schema" => new CommandExecutor<SchemaCommand, SchemaOptions>(
-                _schemaFactory(), o => o.ToSchemaOptions(), _configApplier),
-            "flaky" => new CommandExecutor<FlakyCommand, FlakyOptions>(
-                _flakyFactory(), o => o.ToFlakyOptions(), _configApplier),
-            "estimate" => new CommandExecutor<EstimateCommand, EstimateOptions>(
-                _estimateFactory(), o => o.ToEstimateOptions(), _configApplier),
-            _ => null
-        };
 }

--- a/src/DraftSpec.Cli/Pipeline/CommandRegistry.cs
+++ b/src/DraftSpec.Cli/Pipeline/CommandRegistry.cs
@@ -1,0 +1,57 @@
+namespace DraftSpec.Cli.Pipeline;
+
+/// <summary>
+/// Registry for command executors.
+/// Stores command registrations and creates executors on demand.
+/// </summary>
+public class CommandRegistry : ICommandRegistry
+{
+    private readonly IConfigApplier _configApplier;
+    private readonly Dictionary<string, Func<ICommandExecutor>> _executorFactories = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Create a command registry.
+    /// </summary>
+    /// <param name="configApplier">Config applier to inject into executors.</param>
+    public CommandRegistry(IConfigApplier configApplier)
+    {
+        _configApplier = configApplier ?? throw new ArgumentNullException(nameof(configApplier));
+    }
+
+    /// <inheritdoc />
+    public void Register<TCommand, TOptions>(
+        string name,
+        Func<TCommand> commandFactory,
+        Func<CliOptions, TOptions> optionsConverter)
+        where TCommand : ICommand<TOptions>
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(commandFactory);
+        ArgumentNullException.ThrowIfNull(optionsConverter);
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Command name cannot be empty.", nameof(name));
+        }
+
+        _executorFactories[name] = () =>
+        {
+            var command = commandFactory();
+            return new CommandExecutor<TCommand, TOptions>(command, optionsConverter, _configApplier);
+        };
+    }
+
+    /// <inheritdoc />
+    public ICommandExecutor? GetExecutor(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return null;
+        }
+
+        return _executorFactories.TryGetValue(name, out var factory) ? factory() : null;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<string> RegisteredCommands => _executorFactories.Keys;
+}

--- a/src/DraftSpec.Cli/Pipeline/ICommandRegistry.cs
+++ b/src/DraftSpec.Cli/Pipeline/ICommandRegistry.cs
@@ -1,0 +1,34 @@
+namespace DraftSpec.Cli.Pipeline;
+
+/// <summary>
+/// Registry for command executors.
+/// Allows commands to be registered by name and retrieved for execution.
+/// </summary>
+public interface ICommandRegistry
+{
+    /// <summary>
+    /// Register a command with the registry.
+    /// </summary>
+    /// <typeparam name="TCommand">The command type.</typeparam>
+    /// <typeparam name="TOptions">The command-specific options type.</typeparam>
+    /// <param name="name">The command name (e.g., "run", "watch").</param>
+    /// <param name="commandFactory">Factory function to create the command.</param>
+    /// <param name="optionsConverter">Function to convert CLI options to command options.</param>
+    void Register<TCommand, TOptions>(
+        string name,
+        Func<TCommand> commandFactory,
+        Func<CliOptions, TOptions> optionsConverter)
+        where TCommand : ICommand<TOptions>;
+
+    /// <summary>
+    /// Get an executor for the named command.
+    /// </summary>
+    /// <param name="name">The command name.</param>
+    /// <returns>The command executor, or null if not found.</returns>
+    ICommandExecutor? GetExecutor(string name);
+
+    /// <summary>
+    /// Get all registered command names.
+    /// </summary>
+    IEnumerable<string> RegisteredCommands { get; }
+}

--- a/tests/DraftSpec.Tests/Cli/CommandFactoryTests.cs
+++ b/tests/DraftSpec.Tests/Cli/CommandFactoryTests.cs
@@ -1,306 +1,87 @@
 using DraftSpec.Cli;
-using DraftSpec.Cli.Commands;
 using DraftSpec.Cli.Pipeline;
-using DraftSpec.Tests.Infrastructure;
+using DraftSpec.Tests.Infrastructure.Mocks;
 
 namespace DraftSpec.Tests.Cli;
 
 /// <summary>
 /// Tests for CommandFactory class.
-/// The factory returns executor functions that wrap command invocation.
+/// The factory is a thin wrapper that delegates to ICommandRegistry.
 /// </summary>
 public class CommandFactoryTests
 {
-    #region Create Command Tests
+    private MockCommandRegistry _registry = null!;
+    private CommandFactory _factory = null!;
 
-    [Test]
-    public async Task Create_Run_ReturnsExecutor()
+    [Before(Test)]
+    public void Setup()
     {
-        var factory = CreateFactory();
-
-        var executor = factory.Create("run");
-
-        await Assert.That(executor).IsNotNull();
+        _registry = new MockCommandRegistry();
+        _factory = new CommandFactory(_registry);
     }
 
-    [Test]
-    public async Task Create_Watch_ReturnsExecutor()
-    {
-        var factory = CreateFactory();
-
-        var executor = factory.Create("watch");
-
-        await Assert.That(executor).IsNotNull();
-    }
+    #region Constructor Tests
 
     [Test]
-    public async Task Create_List_ReturnsExecutor()
+    public void Constructor_NullRegistry_ThrowsArgumentNullException()
     {
-        var factory = CreateFactory();
-
-        var executor = factory.Create("list");
-
-        await Assert.That(executor).IsNotNull();
-    }
-
-    [Test]
-    public async Task Create_Validate_ReturnsExecutor()
-    {
-        var factory = CreateFactory();
-
-        var executor = factory.Create("validate");
-
-        await Assert.That(executor).IsNotNull();
-    }
-
-    [Test]
-    public async Task Create_Init_ReturnsExecutor()
-    {
-        var factory = CreateFactory();
-
-        var executor = factory.Create("init");
-
-        await Assert.That(executor).IsNotNull();
-    }
-
-    [Test]
-    public async Task Create_New_ReturnsExecutor()
-    {
-        var factory = CreateFactory();
-
-        var executor = factory.Create("new");
-
-        await Assert.That(executor).IsNotNull();
-    }
-
-    [Test]
-    public async Task Create_Schema_ReturnsExecutor()
-    {
-        var factory = CreateFactory();
-
-        var executor = factory.Create("schema");
-
-        await Assert.That(executor).IsNotNull();
-    }
-
-    [Test]
-    public async Task Create_Flaky_ReturnsExecutor()
-    {
-        var factory = CreateFactory();
-
-        var executor = factory.Create("flaky");
-
-        await Assert.That(executor).IsNotNull();
-    }
-
-    [Test]
-    public async Task Create_Estimate_ReturnsExecutor()
-    {
-        var factory = CreateFactory();
-
-        var executor = factory.Create("estimate");
-
-        await Assert.That(executor).IsNotNull();
-    }
-
-    [Test]
-    public async Task Create_Unknown_ReturnsNull()
-    {
-        var factory = CreateFactory();
-
-        var executor = factory.Create("unknown-command");
-
-        await Assert.That(executor).IsNull();
+        Assert.Throws<ArgumentNullException>(() => new CommandFactory(null!));
     }
 
     #endregion
 
-    #region Case Insensitivity Tests
+    #region Delegation Tests
 
     [Test]
-    [Arguments("RUN")]
-    [Arguments("Run")]
-    [Arguments("run")]
-    [Arguments("rUn")]
-    public async Task Create_Run_CaseInsensitive(string commandName)
+    public async Task Create_DelegatesToRegistry()
     {
-        var factory = CreateFactory();
+        _registry.WithCommand("run");
 
-        var executor = factory.Create(commandName);
+        _factory.Create("run");
 
-        await Assert.That(executor).IsNotNull();
+        await Assert.That(_registry.GetExecutorCalls).Contains("run");
     }
 
     [Test]
-    [Arguments("WATCH")]
-    [Arguments("Watch")]
-    [Arguments("wAtCh")]
-    public async Task Create_Watch_CaseInsensitive(string commandName)
+    public async Task Create_PassesCommandNameToRegistry()
     {
-        var factory = CreateFactory();
+        _registry.WithCommand("custom-command");
 
-        var executor = factory.Create(commandName);
+        _factory.Create("custom-command");
 
-        await Assert.That(executor).IsNotNull();
+        await Assert.That(_registry.GetExecutorCalls).Contains("custom-command");
     }
 
     [Test]
-    [Arguments("LIST")]
-    [Arguments("List")]
-    [Arguments("LiSt")]
-    public async Task Create_List_CaseInsensitive(string commandName)
+    public async Task Create_WhenRegistryReturnsExecutor_ReturnsFunction()
     {
-        var factory = CreateFactory();
+        _registry.WithCommand("run");
 
-        var executor = factory.Create(commandName);
+        var result = _factory.Create("run");
 
-        await Assert.That(executor).IsNotNull();
+        await Assert.That(result).IsNotNull();
     }
 
     [Test]
-    [Arguments("VALIDATE")]
-    [Arguments("Validate")]
-    [Arguments("vAlIdAtE")]
-    public async Task Create_Validate_CaseInsensitive(string commandName)
+    public async Task Create_WhenRegistryReturnsNull_ReturnsNull()
     {
-        var factory = CreateFactory();
+        // Registry has no commands configured
 
-        var executor = factory.Create(commandName);
+        var result = _factory.Create("unknown");
 
-        await Assert.That(executor).IsNotNull();
+        await Assert.That(result).IsNull();
     }
 
     [Test]
-    [Arguments("INIT")]
-    [Arguments("Init")]
-    [Arguments("iNiT")]
-    public async Task Create_Init_CaseInsensitive(string commandName)
+    public async Task Create_ReturnedFunction_ExecutesCommand()
     {
-        var factory = CreateFactory();
+        _registry.WithCommand("run", returnCode: 42);
 
-        var executor = factory.Create(commandName);
+        var executor = _factory.Create("run");
+        var result = await executor!(new CliOptions(), CancellationToken.None);
 
-        await Assert.That(executor).IsNotNull();
+        await Assert.That(result).IsEqualTo(42);
     }
-
-    [Test]
-    [Arguments("NEW")]
-    [Arguments("New")]
-    [Arguments("nEw")]
-    public async Task Create_New_CaseInsensitive(string commandName)
-    {
-        var factory = CreateFactory();
-
-        var executor = factory.Create(commandName);
-
-        await Assert.That(executor).IsNotNull();
-    }
-
-    #endregion
-
-    #region Edge Cases
-
-    [Test]
-    public async Task Create_EmptyString_ReturnsNull()
-    {
-        var factory = CreateFactory();
-
-        var executor = factory.Create("");
-
-        await Assert.That(executor).IsNull();
-    }
-
-    [Test]
-    public async Task Create_Whitespace_ReturnsNull()
-    {
-        var factory = CreateFactory();
-
-        var executor = factory.Create("   ");
-
-        await Assert.That(executor).IsNull();
-    }
-
-    [Test]
-    public async Task Create_WithExtraWhitespace_ReturnsNull()
-    {
-        // The factory uses ToLowerInvariant() which doesn't trim
-        // so "run " becomes "run " which doesn't match "run"
-        var factory = CreateFactory();
-
-        var executor = factory.Create("run ");
-
-        await Assert.That(executor).IsNull();
-    }
-
-    #endregion
-
-    #region Helpers
-
-    private static CommandFactory CreateFactory()
-    {
-        return new CommandFactory(
-            NullObjects.ConfigApplier,
-            CreateRunCommand,
-            CreateWatchCommand,
-            CreateListCommand,
-            CreateValidateCommand,
-            CreateInitCommand,
-            CreateNewCommand,
-            CreateSchemaCommand,
-            CreateFlakyCommand,
-            CreateEstimateCommand);
-    }
-
-    private static RunCommand CreateRunCommand() => new(
-        NullObjects.SpecFinder,
-        NullObjects.RunnerFactory,
-        NullObjects.Console,
-        NullObjects.FormatterRegistry,
-        NullObjects.FileSystem,
-        NullObjects.Environment,
-        NullObjects.StatsCollector,
-        NullObjects.Partitioner,
-        NullObjects.GitService,
-        NullObjects.HistoryService);
-
-    private static WatchCommand CreateWatchCommand() => new(
-        NullObjects.SpecFinder,
-        NullObjects.RunnerFactory,
-        NullObjects.FileWatcherFactory,
-        NullObjects.Console,
-        NullObjects.SpecChangeTracker);
-
-    private static ListCommand CreateListCommand() => new(
-        NullObjects.Console,
-        NullObjects.FileSystem);
-
-    private static ValidateCommand CreateValidateCommand() => new(
-        NullObjects.Console,
-        NullObjects.FileSystem);
-
-    private static InitCommand CreateInitCommand() => new(
-        NullObjects.Console,
-        NullObjects.FileSystem,
-        NullObjects.ProjectResolver);
-
-    private static NewCommand CreateNewCommand() => new(
-        NullObjects.Console,
-        NullObjects.FileSystem);
-
-    private static SchemaCommand CreateSchemaCommand() => new(
-        NullObjects.Console,
-        NullObjects.FileSystem);
-
-    private static FlakyCommand CreateFlakyCommand() => new(
-        NullObjects.HistoryService,
-        NullObjects.Console,
-        NullObjects.FileSystem);
-
-    private static EstimateCommand CreateEstimateCommand() => new(
-        NullObjects.RuntimeEstimator,
-        NullObjects.HistoryService,
-        NullObjects.Console,
-        NullObjects.FileSystem);
 
     #endregion
 }

--- a/tests/DraftSpec.Tests/Cli/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/tests/DraftSpec.Tests/Cli/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -28,7 +28,16 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Test]
-    public async Task AddDraftSpec_CommandFactory_CanCreateFlakyCommand()
+    [Arguments("run")]
+    [Arguments("watch")]
+    [Arguments("list")]
+    [Arguments("validate")]
+    [Arguments("init")]
+    [Arguments("new")]
+    [Arguments("schema")]
+    [Arguments("flaky")]
+    [Arguments("estimate")]
+    public async Task AddDraftSpec_CommandFactory_CanCreateCommand(string commandName)
     {
         var services = new ServiceCollection();
         services.AddDraftSpec();
@@ -36,9 +45,44 @@ public class ServiceCollectionExtensionsTests
 
         var factory = provider.GetRequiredService<ICommandFactory>();
 
-        // Exercise the lambda factory for FlakyCommand (lines 72-73 in ServiceCollectionExtensions)
-        var command = factory.Create("flaky");
+        // Exercise the lambda factory and options converter for each command
+        var executor = factory.Create(commandName);
 
-        await Assert.That(command).IsNotNull();
+        await Assert.That(executor).IsNotNull();
+    }
+
+    [Test]
+    [Arguments("run")]
+    [Arguments("watch")]
+    [Arguments("list")]
+    [Arguments("validate")]
+    [Arguments("init")]
+    [Arguments("new")]
+    [Arguments("schema")]
+    [Arguments("flaky")]
+    [Arguments("estimate")]
+    public async Task AddDraftSpec_CommandExecutor_InvokesOptionsConverter(string commandName)
+    {
+        var services = new ServiceCollection();
+        services.AddDraftSpec();
+        var provider = services.BuildServiceProvider();
+
+        var factory = provider.GetRequiredService<ICommandFactory>();
+        var executor = factory.Create(commandName);
+
+        // Execute to cover the options converter lambda (e.g., o => o.ToRunOptions())
+        // Commands may throw validation errors with default options - that's fine,
+        // we're just verifying the DI wiring invokes the options converter
+        try
+        {
+            await executor!(new CliOptions { Path = "." }, CancellationToken.None);
+        }
+        catch (ArgumentException)
+        {
+            // Expected for commands that require specific inputs (run, watch, new, etc.)
+        }
+
+        // If we get here without a DI resolution error, the wiring is correct
+        await Assert.That(true).IsTrue();
     }
 }

--- a/tests/DraftSpec.Tests/Cli/Pipeline/CommandRegistryTests.cs
+++ b/tests/DraftSpec.Tests/Cli/Pipeline/CommandRegistryTests.cs
@@ -1,0 +1,349 @@
+using DraftSpec.Cli;
+using DraftSpec.Cli.Pipeline;
+using DraftSpec.Tests.Infrastructure;
+using DraftSpec.Tests.Infrastructure.Mocks;
+
+namespace DraftSpec.Tests.Cli.Pipeline;
+
+/// <summary>
+/// Tests for CommandRegistry class.
+/// </summary>
+public class CommandRegistryTests
+{
+    private MockConfigApplier _configApplier = null!;
+    private CommandRegistry _registry = null!;
+
+    [Before(Test)]
+    public void Setup()
+    {
+        _configApplier = new MockConfigApplier();
+        _registry = new CommandRegistry(_configApplier);
+    }
+
+    #region Constructor Tests
+
+    [Test]
+    public void Constructor_NullConfigApplier_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CommandRegistry(null!));
+    }
+
+    #endregion
+
+    #region Register - Argument Validation
+
+    [Test]
+    public void Register_NullName_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _registry.Register<TestCommand, TestOptions>(
+                null!,
+                () => new TestCommand(),
+                _ => new TestOptions()));
+    }
+
+    [Test]
+    public void Register_EmptyName_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            _registry.Register<TestCommand, TestOptions>(
+                "",
+                () => new TestCommand(),
+                _ => new TestOptions()));
+    }
+
+    [Test]
+    public void Register_WhitespaceName_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            _registry.Register<TestCommand, TestOptions>(
+                "   ",
+                () => new TestCommand(),
+                _ => new TestOptions()));
+    }
+
+    [Test]
+    public void Register_NullCommandFactory_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _registry.Register<TestCommand, TestOptions>(
+                "test",
+                null!,
+                _ => new TestOptions()));
+    }
+
+    [Test]
+    public void Register_NullOptionsConverter_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _registry.Register<TestCommand, TestOptions>(
+                "test",
+                () => new TestCommand(),
+                null!));
+    }
+
+    #endregion
+
+    #region GetExecutor - Basic Behavior
+
+    [Test]
+    public async Task GetExecutor_RegisteredCommand_ReturnsExecutor()
+    {
+        _registry.Register<TestCommand, TestOptions>(
+            "test",
+            () => new TestCommand(),
+            _ => new TestOptions());
+
+        var executor = _registry.GetExecutor("test");
+
+        await Assert.That(executor).IsNotNull();
+    }
+
+    [Test]
+    public async Task GetExecutor_UnregisteredCommand_ReturnsNull()
+    {
+        var executor = _registry.GetExecutor("unknown");
+
+        await Assert.That(executor).IsNull();
+    }
+
+    [Test]
+    public async Task GetExecutor_EmptyString_ReturnsNull()
+    {
+        var executor = _registry.GetExecutor("");
+
+        await Assert.That(executor).IsNull();
+    }
+
+    [Test]
+    public async Task GetExecutor_Whitespace_ReturnsNull()
+    {
+        var executor = _registry.GetExecutor("   ");
+
+        await Assert.That(executor).IsNull();
+    }
+
+    #endregion
+
+    #region GetExecutor - Case Insensitivity
+
+    [Test]
+    [Arguments("TEST")]
+    [Arguments("Test")]
+    [Arguments("test")]
+    [Arguments("tEsT")]
+    public async Task GetExecutor_CaseInsensitive(string lookupName)
+    {
+        _registry.Register<TestCommand, TestOptions>(
+            "test",
+            () => new TestCommand(),
+            _ => new TestOptions());
+
+        var executor = _registry.GetExecutor(lookupName);
+
+        await Assert.That(executor).IsNotNull();
+    }
+
+    [Test]
+    public async Task GetExecutor_RegisteredWithMixedCase_FoundWithLowerCase()
+    {
+        _registry.Register<TestCommand, TestOptions>(
+            "MyCommand",
+            () => new TestCommand(),
+            _ => new TestOptions());
+
+        var executor = _registry.GetExecutor("mycommand");
+
+        await Assert.That(executor).IsNotNull();
+    }
+
+    #endregion
+
+    #region GetExecutor - Multiple Registrations
+
+    [Test]
+    public async Task GetExecutor_LastRegistrationWins()
+    {
+        var command1 = new TestCommand { ReturnCode = 1 };
+        var command2 = new TestCommand { ReturnCode = 2 };
+
+        _registry.Register<TestCommand, TestOptions>(
+            "test",
+            () => command1,
+            _ => new TestOptions());
+
+        _registry.Register<TestCommand, TestOptions>(
+            "test",
+            () => command2,
+            _ => new TestOptions());
+
+        var executor = _registry.GetExecutor("test");
+        var result = await executor!.ExecuteAsync(new CliOptions(), CancellationToken.None);
+
+        await Assert.That(result).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task GetExecutor_MultipleCommands_EachReturnsCorrectExecutor()
+    {
+        var commandA = new TestCommand { ReturnCode = 10 };
+        var commandB = new TestCommand { ReturnCode = 20 };
+
+        _registry.Register<TestCommand, TestOptions>(
+            "command-a",
+            () => commandA,
+            _ => new TestOptions());
+
+        _registry.Register<TestCommand, TestOptions>(
+            "command-b",
+            () => commandB,
+            _ => new TestOptions());
+
+        var executorA = _registry.GetExecutor("command-a");
+        var executorB = _registry.GetExecutor("command-b");
+
+        var resultA = await executorA!.ExecuteAsync(new CliOptions(), CancellationToken.None);
+        var resultB = await executorB!.ExecuteAsync(new CliOptions(), CancellationToken.None);
+
+        await Assert.That(resultA).IsEqualTo(10);
+        await Assert.That(resultB).IsEqualTo(20);
+    }
+
+    #endregion
+
+    #region GetExecutor - Executor Behavior
+
+    [Test]
+    public async Task GetExecutor_ExecutorAppliesConfig()
+    {
+        _registry.Register<TestCommand, TestOptions>(
+            "test",
+            () => new TestCommand(),
+            _ => new TestOptions());
+
+        var executor = _registry.GetExecutor("test");
+        await executor!.ExecuteAsync(new CliOptions(), CancellationToken.None);
+
+        await Assert.That(_configApplier.ApplyConfigCalls).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task GetExecutor_ExecutorConvertsOptions()
+    {
+        var convertedOptions = new TestOptions { Value = "converted" };
+        var command = new TestCommand();
+
+        _registry.Register<TestCommand, TestOptions>(
+            "test",
+            () => command,
+            _ => convertedOptions);
+
+        var executor = _registry.GetExecutor("test");
+        await executor!.ExecuteAsync(new CliOptions(), CancellationToken.None);
+
+        await Assert.That(command.ReceivedOptions?.Value).IsEqualTo("converted");
+    }
+
+    [Test]
+    public async Task GetExecutor_ExecutorPassesCliOptionsToConverter()
+    {
+        CliOptions? capturedOptions = null;
+
+        _registry.Register<TestCommand, TestOptions>(
+            "test",
+            () => new TestCommand(),
+            options =>
+            {
+                capturedOptions = options;
+                return new TestOptions();
+            });
+
+        var cliOptions = new CliOptions { Path = "/custom/path" };
+        var executor = _registry.GetExecutor("test");
+        await executor!.ExecuteAsync(cliOptions, CancellationToken.None);
+
+        await Assert.That(capturedOptions?.Path).IsEqualTo("/custom/path");
+    }
+
+    [Test]
+    public async Task GetExecutor_EachCallCreatesNewExecutor()
+    {
+        int factoryCalls = 0;
+
+        _registry.Register<TestCommand, TestOptions>(
+            "test",
+            () =>
+            {
+                factoryCalls++;
+                return new TestCommand();
+            },
+            _ => new TestOptions());
+
+        _registry.GetExecutor("test");
+        _registry.GetExecutor("test");
+        _registry.GetExecutor("test");
+
+        await Assert.That(factoryCalls).IsEqualTo(3);
+    }
+
+    #endregion
+
+    #region RegisteredCommands Property
+
+    [Test]
+    public async Task RegisteredCommands_Empty_ReturnsEmpty()
+    {
+        await Assert.That(_registry.RegisteredCommands).IsEmpty();
+    }
+
+    [Test]
+    public async Task RegisteredCommands_AfterRegistration_ContainsCommandName()
+    {
+        _registry.Register<TestCommand, TestOptions>(
+            "my-command",
+            () => new TestCommand(),
+            _ => new TestOptions());
+
+        await Assert.That(_registry.RegisteredCommands).Contains("my-command");
+    }
+
+    [Test]
+    public async Task RegisteredCommands_MultipleRegistrations_ContainsAll()
+    {
+        _registry.Register<TestCommand, TestOptions>(
+            "alpha",
+            () => new TestCommand(),
+            _ => new TestOptions());
+
+        _registry.Register<TestCommand, TestOptions>(
+            "beta",
+            () => new TestCommand(),
+            _ => new TestOptions());
+
+        await Assert.That(_registry.RegisteredCommands).Contains("alpha");
+        await Assert.That(_registry.RegisteredCommands).Contains("beta");
+    }
+
+    #endregion
+
+    #region Test Helpers
+
+    private class TestOptions
+    {
+        public string? Value { get; set; }
+    }
+
+    private class TestCommand : ICommand<TestOptions>
+    {
+        public int ReturnCode { get; set; }
+        public TestOptions? ReceivedOptions { get; private set; }
+
+        public Task<int> ExecuteAsync(TestOptions options, CancellationToken cancellationToken)
+        {
+            ReceivedOptions = options;
+            return Task.FromResult(ReturnCode);
+        }
+    }
+
+    #endregion
+}

--- a/tests/DraftSpec.Tests/Infrastructure/Mocks/MockCommandRegistry.cs
+++ b/tests/DraftSpec.Tests/Infrastructure/Mocks/MockCommandRegistry.cs
@@ -1,0 +1,63 @@
+using DraftSpec.Cli;
+using DraftSpec.Cli.Pipeline;
+
+namespace DraftSpec.Tests.Infrastructure.Mocks;
+
+/// <summary>
+/// Mock implementation of ICommandRegistry for testing.
+/// </summary>
+public class MockCommandRegistry : ICommandRegistry
+{
+    private readonly Dictionary<string, ICommandExecutor> _executors = new(StringComparer.OrdinalIgnoreCase);
+    private readonly List<string> _registeredCommands = [];
+
+    /// <summary>
+    /// Gets the command names that were looked up via GetExecutor.
+    /// </summary>
+    public List<string> GetExecutorCalls { get; } = [];
+
+    /// <summary>
+    /// Configure an executor to return for a command name.
+    /// </summary>
+    public MockCommandRegistry WithExecutor(string name, ICommandExecutor executor)
+    {
+        _executors[name] = executor;
+        _registeredCommands.Add(name);
+        return this;
+    }
+
+    /// <summary>
+    /// Configure a command that returns a stub executor.
+    /// </summary>
+    public MockCommandRegistry WithCommand(string name, int returnCode = 0)
+    {
+        return WithExecutor(name, new StubExecutor(returnCode));
+    }
+
+    public void Register<TCommand, TOptions>(
+        string name,
+        Func<TCommand> commandFactory,
+        Func<CliOptions, TOptions> optionsConverter)
+        where TCommand : ICommand<TOptions>
+    {
+        _registeredCommands.Add(name);
+    }
+
+    public ICommandExecutor? GetExecutor(string name)
+    {
+        GetExecutorCalls.Add(name);
+        return _executors.TryGetValue(name, out var executor) ? executor : null;
+    }
+
+    public IEnumerable<string> RegisteredCommands => _registeredCommands;
+
+    private class StubExecutor : ICommandExecutor
+    {
+        private readonly int _returnCode;
+
+        public StubExecutor(int returnCode) => _returnCode = returnCode;
+
+        public Task<int> ExecuteAsync(CliOptions options, CancellationToken cancellationToken)
+            => Task.FromResult(_returnCode);
+    }
+}

--- a/tests/DraftSpec.Tests/Infrastructure/Mocks/MockConfigApplier.cs
+++ b/tests/DraftSpec.Tests/Infrastructure/Mocks/MockConfigApplier.cs
@@ -1,0 +1,30 @@
+using DraftSpec.Cli;
+using DraftSpec.Cli.Pipeline;
+
+namespace DraftSpec.Tests.Infrastructure.Mocks;
+
+/// <summary>
+/// Mock implementation of IConfigApplier for testing.
+/// </summary>
+public class MockConfigApplier : IConfigApplier
+{
+    /// <summary>
+    /// Gets the list of options that were passed to ApplyConfig.
+    /// </summary>
+    public List<CliOptions> ApplyConfigCalls { get; } = [];
+
+    /// <summary>
+    /// Gets whether ApplyConfig was called.
+    /// </summary>
+    public bool ApplyCalled => ApplyConfigCalls.Count > 0;
+
+    /// <summary>
+    /// Gets the last options passed to ApplyConfig, or null if not called.
+    /// </summary>
+    public CliOptions? LastOptions => ApplyConfigCalls.Count > 0 ? ApplyConfigCalls[^1] : null;
+
+    public void ApplyConfig(CliOptions options)
+    {
+        ApplyConfigCalls.Add(options);
+    }
+}


### PR DESCRIPTION
## Summary

Addresses the design smell of CommandFactory's growing constructor (10 factory parameters). 
Extracts a CommandRegistry pattern that centralizes command registration.

- Add `ICommandRegistry` interface for command registration and lookup
- Add `CommandRegistry` implementation with case-insensitive matching
- Refactor `CommandFactory` to delegate to registry (77 → 28 lines, 10 → 1 params)
- Centralize all command registration in `ServiceCollectionExtensions`
- Add `MockCommandRegistry` and `MockConfigApplier` test doubles
- Add 24 comprehensive `CommandRegistryTests`
- Simplify `CommandFactoryTests` to test delegation pattern only

## Benefits

Adding a new command now requires updating only `ServiceCollectionExtensions.cs` instead of 
multiple files. The CommandFactory is now a thin wrapper that's trivial to test.

## Test plan

- [x] All 2958 unit tests pass
- [x] All 56 integration tests pass
- [x] Pre-commit hooks pass (format, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)