### PR TITLE
security: Pin GitHub Actions by commit SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
-      - "github-actions"
+      - "ci-cd"
+      - "security"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           fetch-depth: 0  # Full history for MinVer
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@2016bd2012dba4e32de620c46fe006a3ac9f0602 # v5
         with:
           dotnet-version: '10.0.x'
 
@@ -70,7 +70,7 @@ jobs:
           echo "::notice::Coverage ${COVERAGE}% meets threshold ${THRESHOLD}%"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/coverage.cobertura.xml
@@ -79,14 +79,14 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/test-results.xml
           report_type: test_results
 
       - name: Upload coverage report artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: coverage-report
           path: ./coverage-report
@@ -96,7 +96,7 @@ jobs:
         run: dotnet pack --no-build -c Release
 
       - name: Upload packages
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: nuget-packages
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.release.target_commitish == 'main'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Determine version
         id: version
@@ -34,7 +34,7 @@ jobs:
           echo "Publishing version: $VERSION"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@2016bd2012dba4e32de620c46fe006a3ac9f0602 # v5
         with:
           dotnet-version: '10.0.x'
 
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload packages to Release
         if: github.event_name == 'release' && !inputs.dry_run
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,22 +19,22 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@v2.4.0
+      - uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@c37a8b7cd97e31de3fcbd9b84c401870edeb8d34 # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           # Issue settings
           days-before-stale: 60


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to their commit SHAs instead of version tags to prevent supply chain attacks. This addresses the OpenSSF Scorecard "Pinned-Dependencies" check (currently 0/10).

## Changes

**Pinned actions across all workflows:**

| Action | Version | SHA |
|--------|---------|-----|
| actions/checkout | v4, v6 | `34e1148...`, `8e8c483...` |
| actions/setup-dotnet | v5 | `2016bd2...` |
| actions/upload-artifact | v4, v6 | `ea165f8...`, `b7c566a...` |
| actions/stale | v9 | `5bef64f...` |
| codecov/codecov-action | v5 | `671740a...` |
| softprops/action-gh-release | v2 | `a06a81a...` |
| release-drafter/release-drafter | v6 | `b1476f6...` |
| ossf/scorecard-action | v2.4.0 | `ff5dd89...` |
| github/codeql-action | v3 | `c37a8b7...` |

**Dependabot updates:**
- Group all action updates into single PRs
- Add `security` and `ci-cd` labels

## Test plan

- [x] All workflow files updated with pinned SHAs
- [x] Version comments added for maintainability
- [x] Dependabot configured to update pinned actions

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)