### PR TITLE
security: Apply least-privilege token permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,11 +12,13 @@ on:
         type: boolean
 
 permissions:
-  contents: write  # Required for creating releases
+  contents: read
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for uploading assets to release
     environment: nuget  # Requires approval for production pushes
     # Only run for releases targeting main (or manual dispatch)
     if: github.event_name == 'workflow_dispatch' || github.event.release.target_commitish == 'main'


### PR DESCRIPTION
## Summary

Add explicit permissions to workflows to restrict GITHUB_TOKEN access, following the principle of least privilege. This addresses the OpenSSF Scorecard "Token-Permissions" check (currently 0/10).

## Changes

| Workflow | Before | After |
|----------|--------|-------|
| ci.yml | No permissions defined | `permissions: contents: read` |
| publish.yml | Top-level `contents: write` | Top-level `read`, job-level `write` |

**Already properly configured:**
- `scorecard.yml` - Uses `permissions: read-all` with job-level escalation
- `stale.yml` - Minimal `issues/pull-requests: write`
- `release-drafter.yml` - Top-level read with job-level write

## Test plan

- [x] CI workflow runs with read-only permissions
- [x] Publish workflow can still upload release assets (job-level write)

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)