### PR TITLE
fix(ci): Use correct commit SHA for codeql-action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -35,6 +35,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@c37a8b7cd97e31de3fcbd9b84c401870edeb8d34 # v3
+      - uses: github/codeql-action/upload-sarif@45c373516f557556c15d420e3f5e0aa3d64366bc # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
Fixes the broken scorecard workflow by using the correct commit SHA for `github/codeql-action`.

The previous SHA (`c37a8b7cd97e31de3fcbd9b84c401870edeb8d34`) was pointing to an annotated tag object, not the actual commit. GitHub Actions requires commit SHAs when pinning by SHA.

The correct commit SHA for v3 is `45c373516f557556c15d420e3f5e0aa3d64366bc`.

## Test plan
- [ ] Scorecard workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)