### PR TITLE
chore(ci): Upgrade codeql-action to v4 and pin NuGet tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Convert TRX to JUnit
         if: ${{ !cancelled() }}
         run: |
-          dotnet tool install -g trx2junit
+          dotnet tool install -g trx2junit --version 2.1.0
           trx2junit tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/test-results.trx --output tests/DraftSpec.Tests/bin/Release/net10.0/TestResults
 
       - name: Run CLI integration tests
@@ -49,7 +49,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          dotnet tool install -g dotnet-reportgenerator-globaltool
+          dotnet tool install -g dotnet-reportgenerator-globaltool --version 5.5.1
           reportgenerator -reports:tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/coverage.cobertura.xml -targetdir:./coverage-report -reporttypes:Html
 
       - name: Enforce coverage threshold

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -35,6 +35,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@45c373516f557556c15d420e3f5e0aa3d64366bc # v3
+      - uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Upgrade `github/codeql-action` from v3 to v4 (v3 will be deprecated in December 2026)
- Pin NuGet tool versions for supply chain security:
  - `trx2junit` → 2.1.0
  - `dotnet-reportgenerator-globaltool` → 5.5.1

This addresses the remaining Pinned-Dependencies warnings from the OpenSSF Scorecard.

## References
- https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/

## Test plan
- [ ] CI workflow passes
- [ ] Scorecard workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)