### PR TITLE
security: Add CodeQL static analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4
+        with:
+          languages: csharp
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@2016bd2012dba4e32de620c46fe006a3ac9f0602 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build
+        run: dotnet build -c Release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4
+        with:
+          category: "/language:csharp"


### PR DESCRIPTION
## Summary
Adds CodeQL SAST (Static Application Security Testing) to detect security vulnerabilities in C# code.

## Changes
- New `.github/workflows/codeql.yml` workflow
- Runs on push to main, PRs, and weekly (Monday 6am UTC)
- Uses explicit `dotnet build` instead of autobuild for reliability
- All actions pinned by SHA

## Test plan
- [ ] CI workflow passes
- [ ] CodeQL workflow runs successfully
- [ ] Results appear in GitHub Security tab

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)