### PR TITLE
security: Add provenance attestation to releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for uploading assets to release
+      id-token: write  # Required for provenance attestation
+      attestations: write  # Required for provenance attestation
     environment: nuget  # Requires approval for production pushes
     # Only run for releases targeting main (or manual dispatch)
     if: github.event_name == 'workflow_dispatch' || github.event.release.target_commitish == 'main'
@@ -63,6 +65,12 @@ jobs:
         run: |
           echo "Packages to publish:"
           find src -name "*.nupkg" -type f | grep -v obj
+
+      - name: Generate provenance attestation
+        if: github.event_name == 'release' && !inputs.dry_run
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: 'src/*/bin/Release/*.nupkg'
 
       - name: Publish to NuGet
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
## Summary
Adds SLSA provenance attestation to NuGet package releases using `actions/attest-build-provenance`.

## Changes
- Added `id-token: write` and `attestations: write` permissions
- Added provenance attestation step after pack, before publish
- Action pinned by SHA (v2)

## What this enables
- Cryptographically signed attestation linking artifacts to source commit
- Attestation visible on GitHub releases page
- Users can verify packages were built from claimed source by expected CI

## Test plan
- [ ] CI workflow passes
- [ ] Next release will include provenance attestation

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)