### PR TITLE
fix: Add thread-safe configuration initialization

### DIFF
--- a/src/DraftSpec/Configuration/DraftSpecConfiguration.cs
+++ b/src/DraftSpec/Configuration/DraftSpecConfiguration.cs
@@ -11,8 +11,8 @@ namespace DraftSpec.Configuration;
 public class DraftSpecConfiguration : IDraftSpecConfiguration, IDisposable
 {
     private readonly PluginContext _pluginContext;
-    private bool _initialized;
-    private bool _disposed;
+    private int _initialized;
+    private int _disposed;
 
     /// <summary>
     /// Create a new DraftSpec configuration instance.
@@ -134,8 +134,8 @@ public class DraftSpecConfiguration : IDraftSpecConfiguration, IDisposable
     /// </summary>
     internal void Initialize()
     {
-        if (_initialized) return;
-        _initialized = true;
+        if (Interlocked.CompareExchange(ref _initialized, 1, 0) != 0)
+            return;
 
         // Initialize all plugins
         foreach (var plugin in Plugins.All) plugin.Initialize(_pluginContext);
@@ -164,8 +164,8 @@ public class DraftSpecConfiguration : IDraftSpecConfiguration, IDisposable
     /// </summary>
     public void Dispose()
     {
-        if (_disposed) return;
-        _disposed = true;
+        if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0)
+            return;
         Plugins.Dispose();
         GC.SuppressFinalize(this);
     }


### PR DESCRIPTION
## Summary

- Use `Interlocked.CompareExchange` for atomic check-and-set in `Initialize()` and `Dispose()` methods
- Prevents race conditions when called concurrently from multiple threads
- Added concurrent initialization and disposal tests

## Changes

| File | Change |
|------|--------|
| `DraftSpecConfiguration.cs` | Changed `_initialized` and `_disposed` from `bool` to `int`, use `Interlocked.CompareExchange` |
| `ConfigurationTests.cs` | Added `CountingPlugin` and 2 concurrent test cases |

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)