### PR TITLE
feat(mcp): Add input size limits for spec content

### DIFF
--- a/src/DraftSpec.Mcp/ErrorCategory.cs
+++ b/src/DraftSpec.Mcp/ErrorCategory.cs
@@ -33,5 +33,8 @@ public enum ErrorCategory
     Configuration,
 
     /// <summary>Request rejected due to rate limiting.</summary>
-    RateLimited
+    RateLimited,
+
+    /// <summary>Input validation failed (e.g., content size limit exceeded).</summary>
+    Validation
 }

--- a/src/DraftSpec.Mcp/McpOptions.cs
+++ b/src/DraftSpec.Mcp/McpOptions.cs
@@ -16,4 +16,10 @@ public class McpOptions
     /// Default: 60 (1 per second average).
     /// </summary>
     public int MaxExecutionsPerMinute { get; init; } = 60;
+
+    /// <summary>
+    /// Maximum size in bytes for spec content input.
+    /// Default: 1MB. Prevents memory exhaustion from very large inputs.
+    /// </summary>
+    public int MaxSpecContentSizeBytes { get; init; } = 1_000_000;
 }

--- a/src/DraftSpec.Mcp/Models/BatchSpecResult.cs
+++ b/src/DraftSpec.Mcp/Models/BatchSpecResult.cs
@@ -34,4 +34,9 @@ public class BatchSpecResult
     /// Individual results for each spec.
     /// </summary>
     public List<NamedSpecResult> Results { get; init; } = [];
+
+    /// <summary>
+    /// Error message if the batch failed before execution (e.g., validation error).
+    /// </summary>
+    public string? Error { get; init; }
 }


### PR DESCRIPTION
## Summary

Add `MaxSpecContentSizeBytes` option to McpOptions (default: 1MB) to prevent memory exhaustion from very large inputs.

- Add `Validation` error category for input validation failures
- Both `RunSpec` and `RunSpecsBatch` validate content size before execution
- Add null/empty content validation for `RunSpec`
- Refactor SpecToolsTests with helper methods for maintainability
- Add comprehensive tests for validation behavior

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)