### PR TITLE
test: Add integration tests for v0.7.0 CLI commands

### DIFF
--- a/tests/DraftSpec.Cli.IntegrationTests/Commands/CacheCommandIntegrationTests.cs
+++ b/tests/DraftSpec.Cli.IntegrationTests/Commands/CacheCommandIntegrationTests.cs
@@ -1,0 +1,182 @@
+using DraftSpec.Cli.IntegrationTests.Infrastructure;
+
+namespace DraftSpec.Cli.IntegrationTests.Commands;
+
+/// <summary>
+/// Integration tests for the cache command (stats and clear subcommands).
+/// Tests run the actual CLI as a subprocess.
+/// </summary>
+[NotInParallel("CacheCommand")]
+public class CacheCommandIntegrationTests : IntegrationTestBase
+{
+    #region Stats Subcommand
+
+    [Test]
+    public async Task Stats_EmptyCache_ShowsZeroCounts()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "cache", "stats");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Stats command should succeed");
+        await Assert.That(result.Output).Contains("Entries: 0")
+            .Because("Empty cache should show 0 entries");
+    }
+
+    [Test]
+    public async Task Stats_AfterRunningSpecs_ShowsCacheEntries()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        // First, run specs to populate the cache
+        await RunCliInDirectoryAsync(specDir, "run", ".");
+
+        // Then check cache stats
+        var result = await RunCliInDirectoryAsync(specDir, "cache", "stats");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Stats command should succeed");
+        await Assert.That(result.Output).Contains("Cache Statistics:")
+            .Because("Should show cache statistics header");
+        await Assert.That(result.Output).Contains(".draftspec")
+            .Because("Should show cache location");
+    }
+
+    [Test]
+    public async Task Stats_ShowsCacheLocation()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "cache", "stats");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Output).Contains("Location:")
+            .Because("Should display cache location");
+        await Assert.That(result.Output).Contains(".draftspec")
+            .Because("Cache location should include .draftspec directory");
+    }
+
+    [Test]
+    public async Task Stats_ShowsBothCacheTypes()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "cache", "stats");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Output).Contains("Script Compilation Cache:")
+            .Because("Should show script compilation cache section");
+        await Assert.That(result.Output).Contains("Parse Result Cache:")
+            .Because("Should show parse result cache section");
+    }
+
+    #endregion
+
+    #region Clear Subcommand
+
+    [Test]
+    public async Task Clear_EmptyCache_ShowsAlreadyEmpty()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "cache", "clear");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Clear command should succeed even on empty cache");
+        await Assert.That(result.Output).Contains("already empty")
+            .Because("Should indicate cache was already empty");
+    }
+
+    [Test]
+    public async Task Clear_WithEntries_ClearsAndShowsCount()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        // First, run specs to populate the cache
+        await RunCliInDirectoryAsync(specDir, "run", ".");
+
+        // Then clear the cache
+        var result = await RunCliInDirectoryAsync(specDir, "cache", "clear");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Clear command should succeed");
+        await Assert.That(result.Output).Contains("Cleared")
+            .Because("Should indicate entries were cleared");
+    }
+
+    [Test]
+    public async Task Clear_ActuallyDeletesFiles()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        // Run specs to populate cache
+        await RunCliInDirectoryAsync(specDir, "run", ".");
+
+        // Clear the cache
+        await RunCliInDirectoryAsync(specDir, "cache", "clear");
+
+        // Verify stats show empty
+        var result = await RunCliInDirectoryAsync(specDir, "cache", "stats");
+
+        await Assert.That(result.Output).Contains("Entries: 0")
+            .Because("Cache should be empty after clear");
+    }
+
+    #endregion
+
+    #region Error Handling
+
+    [Test]
+    public async Task UnknownSubcommand_ReturnsExitCodeOne()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "cache", "invalid");
+
+        await Assert.That(result.ExitCode).IsEqualTo(1)
+            .Because("Unknown subcommand should return exit code 1");
+        await Assert.That(result.Output).Contains("Unknown cache subcommand")
+            .Because("Should show error message for unknown subcommand");
+    }
+
+    [Test]
+    public async Task UnknownSubcommand_ShowsUsage()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "cache", "delete");
+
+        await Assert.That(result.ExitCode).IsEqualTo(1);
+        await Assert.That(result.Output).Contains("stats")
+            .Because("Should show available subcommands");
+        await Assert.That(result.Output).Contains("clear")
+            .Because("Should show available subcommands");
+    }
+
+    [Test]
+    public async Task Stats_CaseInsensitive_AcceptsUppercase()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "cache", "STATS");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Subcommand should be case-insensitive");
+        await Assert.That(result.Output).Contains("Cache Statistics:")
+            .Because("Should show cache statistics");
+    }
+
+    [Test]
+    public async Task Clear_CaseInsensitive_AcceptsUppercase()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "cache", "CLEAR");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Subcommand should be case-insensitive");
+    }
+
+    #endregion
+}

--- a/tests/DraftSpec.Cli.IntegrationTests/Commands/EstimateCommandIntegrationTests.cs
+++ b/tests/DraftSpec.Cli.IntegrationTests/Commands/EstimateCommandIntegrationTests.cs
@@ -1,0 +1,177 @@
+using DraftSpec.Cli.IntegrationTests.Infrastructure;
+
+namespace DraftSpec.Cli.IntegrationTests.Commands;
+
+/// <summary>
+/// Integration tests for the estimate command.
+/// Tests run the actual CLI as a subprocess.
+/// </summary>
+[NotInParallel("EstimateCommand")]
+public class EstimateCommandIntegrationTests : IntegrationTestBase
+{
+    #region No History
+
+    [Test]
+    public async Task NoHistory_ShowsRunSpecsMessage()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "estimate", ".");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Estimate should succeed even without history");
+        await Assert.That(result.Output).Contains("No test history found")
+            .Because("Should indicate no history exists");
+        await Assert.That(result.Output).Contains("draftspec run")
+            .Because("Should suggest running specs first");
+    }
+
+    #endregion
+
+    #region With History
+
+    [Test]
+    public async Task WithHistory_ShowsP50P95Max()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        // Create history with timing data
+        CreateHistoryFile(specDir)
+            .WithTimedSpec("spec-1", "Feature > calculates totals", 100, 120, 110, 105, 115)
+            .WithTimedSpec("spec-2", "Feature > validates input", 50, 55, 48, 52, 60)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "estimate", ".");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Estimate should succeed");
+        await Assert.That(result.Output).Contains("Runtime Estimate")
+            .Because("Should show estimate header");
+        await Assert.That(result.Output).Contains("P50")
+            .Because("Should show P50 median");
+        await Assert.That(result.Output).Contains("P95")
+            .Because("Should show P95");
+        await Assert.That(result.Output).Contains("Max observed")
+            .Because("Should show maximum observed time");
+    }
+
+    [Test]
+    public async Task WithHistory_ShowsSlowestSpecs()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        // Create history with varied timing data
+        CreateHistoryFile(specDir)
+            .WithTimedSpec("slow-spec", "Feature > slow operation", 500, 600, 550)
+            .WithTimedSpec("fast-spec", "Feature > fast operation", 10, 12, 11)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "estimate", ".");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Output).Contains("Slowest specs")
+            .Because("Should show slowest specs section");
+        await Assert.That(result.Output).Contains("slow operation")
+            .Because("Should list the slow spec");
+    }
+
+    [Test]
+    public async Task WithHistory_ShowsRecommendedTimeout()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        CreateHistoryFile(specDir)
+            .WithTimedSpec("spec-1", "Feature > test", 100, 150, 120)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "estimate", ".");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Output).Contains("Recommended CI timeout")
+            .Because("Should show recommended CI timeout");
+        await Assert.That(result.Output).Contains("2x P95")
+            .Because("Should explain timeout is 2x P95");
+    }
+
+    #endregion
+
+    #region Output Seconds
+
+    [Test]
+    public async Task OutputSeconds_ReturnsMachineReadableNumber()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        // Create history with known timing
+        CreateHistoryFile(specDir)
+            .WithTimedSpec("spec-1", "Feature > test", 1000, 1000, 1000) // 1 second each
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "estimate", ".", "--output-seconds");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        // Output should be a simple number (seconds as decimal)
+        var output = result.Output.Trim();
+        await Assert.That(double.TryParse(output, out _)).IsTrue()
+            .Because("Output should be a parseable number");
+    }
+
+    [Test]
+    public async Task OutputSeconds_NoExtraOutput()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        CreateHistoryFile(specDir)
+            .WithTimedSpec("spec-1", "Feature > test", 500)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "estimate", ".", "--output-seconds");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        // Should not contain human-readable labels
+        await Assert.That(result.Output).DoesNotContain("Runtime Estimate")
+            .Because("Machine-readable mode should not include headers");
+        await Assert.That(result.Output).DoesNotContain("P50")
+            .Because("Machine-readable mode should not include percentile labels");
+    }
+
+    #endregion
+
+    #region Custom Percentile
+
+    [Test]
+    public async Task CustomPercentile_UsesSpecifiedValue()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        CreateHistoryFile(specDir)
+            .WithTimedSpec("spec-1", "Feature > test", 100, 200, 300, 400, 500)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "estimate", ".", "--percentile", "75");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Output).Contains("P75")
+            .Because("Should show the custom percentile in slowest specs section");
+    }
+
+    #endregion
+
+    #region Error Handling
+
+    [Test]
+    public async Task InvalidDirectory_ReturnsExitCodeOne()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+        var nonExistentPath = Path.Combine(specDir, "does-not-exist");
+
+        var result = await RunCliInDirectoryAsync(specDir, "estimate", nonExistentPath);
+
+        await Assert.That(result.ExitCode).IsEqualTo(1)
+            .Because("Should fail for non-existent directory");
+        await Assert.That(result.Output).Contains("not found")
+            .Because("Should indicate directory was not found");
+    }
+
+    #endregion
+}

--- a/tests/DraftSpec.Cli.IntegrationTests/Commands/FlakyCommandIntegrationTests.cs
+++ b/tests/DraftSpec.Cli.IntegrationTests/Commands/FlakyCommandIntegrationTests.cs
@@ -1,0 +1,230 @@
+using DraftSpec.Cli.IntegrationTests.Infrastructure;
+
+namespace DraftSpec.Cli.IntegrationTests.Commands;
+
+/// <summary>
+/// Integration tests for the flaky command.
+/// Tests run the actual CLI as a subprocess.
+/// </summary>
+[NotInParallel("FlakyCommand")]
+public class FlakyCommandIntegrationTests : IntegrationTestBase
+{
+    #region No History
+
+    [Test]
+    public async Task NoHistory_ShowsRunSpecsMessage()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "flaky", ".");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Flaky should succeed even without history");
+        await Assert.That(result.Output).Contains("No test history found")
+            .Because("Should indicate no history exists");
+        await Assert.That(result.Output).Contains("draftspec run")
+            .Because("Should suggest running specs first");
+    }
+
+    #endregion
+
+    #region No Flaky Specs
+
+    [Test]
+    public async Task NoFlakySpecs_ShowsCleanMessage()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        // Create history with stable specs (no flakiness)
+        CreateHistoryFile(specDir)
+            .WithStableSpec("spec-1", "Feature > always passes", runCount: 10)
+            .WithStableSpec("spec-2", "Feature > consistently passes", runCount: 10)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "flaky", ".");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Output).Contains("No flaky specs detected")
+            .Because("Should indicate no flaky specs found");
+    }
+
+    [Test]
+    public async Task NoFlakySpecs_ShowsAnalyzedCount()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        CreateHistoryFile(specDir)
+            .WithStableSpec("spec-1", "Feature > test 1", runCount: 5)
+            .WithStableSpec("spec-2", "Feature > test 2", runCount: 5)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "flaky", ".");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Output).Contains("Analyzed")
+            .Because("Should show analysis info");
+        await Assert.That(result.Output).Contains("2 specs")
+            .Because("Should show number of specs analyzed");
+    }
+
+    #endregion
+
+    #region Flaky Specs Detected
+
+    [Test]
+    public async Task DetectsFlakySpecs_ShowsReport()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        // Create history with a flaky spec (alternating pass/fail)
+        CreateHistoryFile(specDir)
+            .WithFlakySpec("flaky-spec", "Feature > unstable test", statusChanges: 5)
+            .WithStableSpec("stable-spec", "Feature > stable test", runCount: 5)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "flaky", ".");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Output).Contains("Flaky Tests Detected")
+            .Because("Should show flaky tests header");
+        await Assert.That(result.Output).Contains("unstable test")
+            .Because("Should list the flaky spec");
+        await Assert.That(result.Output).Contains("pass rate")
+            .Because("Should show pass rate");
+    }
+
+    [Test]
+    public async Task DetectsFlakySpecs_ShowsSeverity()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        // Create history with high flakiness
+        CreateHistoryFile(specDir)
+            .WithFlakySpec("very-flaky", "Feature > very unstable", statusChanges: 8)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "flaky", ".");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Output).Contains("Flakiness:")
+            .Because("Should show flakiness severity");
+        await Assert.That(result.Output).Contains("status change")
+            .Because("Should show status change count");
+    }
+
+    [Test]
+    public async Task DetectsFlakySpecs_ShowsRecommendations()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        CreateHistoryFile(specDir)
+            .WithFlakySpec("flaky-spec", "Feature > unstable", statusChanges: 4)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "flaky", ".");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Output).Contains("Recommendations")
+            .Because("Should show recommendations section");
+        await Assert.That(result.Output).Contains("--quarantine")
+            .Because("Should suggest quarantine flag");
+    }
+
+    #endregion
+
+    #region Clear Subcommand
+
+    [Test]
+    public async Task Clear_ExistingSpec_ClearsHistory()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        // Create history with a spec
+        CreateHistoryFile(specDir)
+            .WithFlakySpec("spec-to-clear", "Feature > to be cleared", statusChanges: 3)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "flaky", ".", "--clear", "spec-to-clear");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Clear should succeed for existing spec");
+        await Assert.That(result.Output).Contains("Cleared history for")
+            .Because("Should confirm history was cleared");
+    }
+
+    [Test]
+    public async Task Clear_NonexistentSpec_ReturnsOne()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        // Create history but without the spec we'll try to clear
+        CreateHistoryFile(specDir)
+            .WithStableSpec("other-spec", "Feature > other test", runCount: 3)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "flaky", ".", "--clear", "nonexistent-spec");
+
+        await Assert.That(result.ExitCode).IsEqualTo(1)
+            .Because("Clear should fail for non-existent spec");
+        await Assert.That(result.Output).Contains("No history found for")
+            .Because("Should indicate spec was not found");
+    }
+
+    #endregion
+
+    #region Custom Options
+
+    [Test]
+    public async Task MinStatusChanges_FiltersResults()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        // Create spec with exactly 3 status changes
+        CreateHistoryFile(specDir)
+            .WithFlakySpec("borderline-flaky", "Feature > borderline", statusChanges: 3)
+            .Build();
+
+        // With high threshold, should not detect as flaky
+        var result = await RunCliInDirectoryAsync(specDir, "flaky", ".", "--min-changes", "5");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Output).Contains("No flaky specs detected")
+            .Because("Higher threshold should filter out borderline flaky spec");
+    }
+
+    [Test]
+    public async Task WindowSize_LimitsAnalysis()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        CreateHistoryFile(specDir)
+            .WithFlakySpec("flaky-spec", "Feature > flaky", statusChanges: 3)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "flaky", ".", "--window-size", "5");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Output).Contains("last 5 runs")
+            .Because("Should show the window size used");
+    }
+
+    #endregion
+
+    #region Error Handling
+
+    [Test]
+    public async Task InvalidDirectory_ReturnsExitCodeOne()
+    {
+        var specDir = CreateFixture().WithPassingSpec().Build();
+        var nonExistentPath = Path.Combine(specDir, "does-not-exist");
+
+        var result = await RunCliInDirectoryAsync(specDir, "flaky", nonExistentPath);
+
+        await Assert.That(result.ExitCode).IsEqualTo(1)
+            .Because("Should fail for non-existent directory");
+        await Assert.That(result.Output).Contains("not found")
+            .Because("Should indicate directory was not found");
+    }
+
+    #endregion
+}

--- a/tests/DraftSpec.Cli.IntegrationTests/Commands/RunCommandAffectedByTests.cs
+++ b/tests/DraftSpec.Cli.IntegrationTests/Commands/RunCommandAffectedByTests.cs
@@ -1,0 +1,210 @@
+using DraftSpec.Cli.IntegrationTests.Infrastructure;
+
+namespace DraftSpec.Cli.IntegrationTests.Commands;
+
+/// <summary>
+/// Integration tests for the run command's --affected-by option (test impact analysis).
+/// Tests run the actual CLI as a subprocess with real git repositories.
+/// </summary>
+[NotInParallel("RunAffectedBy")]
+public class RunCommandAffectedByTests : IntegrationTestBase
+{
+    private const string PassingSpec = """
+        #r "../../../src/DraftSpec/bin/Release/net10.0/DraftSpec.dll"
+        using static DraftSpec.Dsl;
+
+        describe("Feature", () =>
+        {
+            it("passes", () =>
+            {
+                expect(1).toBe(1);
+            });
+        });
+        """;
+
+    private const string SourceFile = """
+        namespace MyApp;
+
+        public class Calculator
+        {
+            public int Add(int a, int b) => a + b;
+        }
+        """;
+
+    private const string ModifiedSourceFile = """
+        namespace MyApp;
+
+        public class Calculator
+        {
+            public int Add(int a, int b) => a + b;
+            public int Subtract(int a, int b) => a - b;
+        }
+        """;
+
+    #region Staged Changes
+
+    [Test]
+    public async Task AffectedBy_Staged_ShowsImpactAnalysis()
+    {
+        var repoPath = CreateGitRepo()
+            .WithFile("src/Calculator.cs", SourceFile)
+            .WithFile("specs/Calculator.spec.csx", PassingSpec)
+            .WithCommit("Initial commit")
+            .WithStagedChange("src/Calculator.cs", ModifiedSourceFile)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(repoPath, "run", "specs", "--affected-by", "staged");
+
+        await Assert.That(result.Output).Contains("Analyzing impact of changes")
+            .Because("Should show impact analysis is running");
+        await Assert.That(result.Output).Contains("staged")
+            .Because("Should show the analysis target");
+    }
+
+    [Test]
+    public async Task AffectedBy_Staged_NoChanges_ShowsNoChangesMessage()
+    {
+        var repoPath = CreateGitRepo()
+            .WithFile("src/Calculator.cs", SourceFile)
+            .WithFile("specs/Calculator.spec.csx", PassingSpec)
+            .WithCommit("Initial commit")
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(repoPath, "run", "specs", "--affected-by", "staged");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Should succeed with no changes");
+        await Assert.That(result.Output).Contains("No changed files detected")
+            .Because("Should indicate no changes found");
+    }
+
+    #endregion
+
+    #region HEAD Comparisons
+
+    [Test]
+    public async Task AffectedBy_HeadTilde1_ShowsChangedFilesCount()
+    {
+        var repoPath = CreateGitRepo()
+            .WithFile("src/Calculator.cs", SourceFile)
+            .WithFile("specs/Calculator.spec.csx", PassingSpec)
+            .WithCommit("Initial commit")
+            .WithCommit("Second commit")
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(repoPath, "run", "specs", "--affected-by", "HEAD~1");
+
+        await Assert.That(result.Output).Contains("Changed files")
+            .Because("Should show changed files count");
+    }
+
+    #endregion
+
+    #region Dry Run
+
+    [Test]
+    public async Task AffectedBy_DryRun_ListsSpecsWithoutRunning()
+    {
+        var repoPath = CreateGitRepo()
+            .WithFile("src/Calculator.cs", SourceFile)
+            .WithFile("specs/Calculator.spec.csx", PassingSpec)
+            .WithCommit("Initial commit")
+            .WithStagedChange("src/Calculator.cs", ModifiedSourceFile)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(repoPath, "run", "specs", "--affected-by", "staged", "--dry-run");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Dry run should succeed");
+        await Assert.That(result.Output).Contains("dry run")
+            .Because("Should indicate dry run mode");
+    }
+
+    [Test]
+    public async Task AffectedBy_DryRun_DoesNotExecuteSpecs()
+    {
+        var repoPath = CreateGitRepo()
+            .WithFile("src/Calculator.cs", SourceFile)
+            .WithFile("specs/Calculator.spec.csx", PassingSpec)
+            .WithCommit("Initial commit")
+            .WithStagedChange("src/Calculator.cs", ModifiedSourceFile)
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(repoPath, "run", "specs", "--affected-by", "staged", "--dry-run");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        // Should not contain actual spec execution output
+        await Assert.That(result.Output).DoesNotContain("passed")
+            .Because("Dry run should not execute specs");
+        await Assert.That(result.Output).DoesNotContain("failed")
+            .Because("Dry run should not execute specs");
+    }
+
+    #endregion
+
+    #region No Affected Specs
+
+    [Test]
+    public async Task AffectedBy_NoAffectedSpecs_ShowsNoAffectedMessage()
+    {
+        // Create a repo with a source file change that doesn't affect any specs
+        var repoPath = CreateGitRepo()
+            .WithFile("src/Calculator.cs", SourceFile)
+            .WithFile("src/Unrelated.cs", "class Unrelated {}")
+            .WithFile("specs/Calculator.spec.csx", PassingSpec)
+            .WithCommit("Initial commit")
+            .WithStagedChange("src/Unrelated.cs", "class Unrelated { int x; }")
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(repoPath, "run", "specs", "--affected-by", "staged");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0)
+            .Because("Should succeed with no affected specs");
+        // Either no changed files or no affected specs
+        var hasExpectedMessage = result.Output.Contains("No affected specs") ||
+                                  result.Output.Contains("Affected specs: 0");
+        await Assert.That(hasExpectedMessage).IsTrue()
+            .Because("Should indicate no specs were affected");
+    }
+
+    #endregion
+
+    #region Not a Git Repository
+
+    [Test]
+    public async Task AffectedBy_NotGitRepo_ShowsError()
+    {
+        // Create a regular directory without git
+        var specDir = CreateFixture().WithPassingSpec().Build();
+
+        var result = await RunCliInDirectoryAsync(specDir, "run", ".", "--affected-by", "staged");
+
+        await Assert.That(result.ExitCode).IsEqualTo(1)
+            .Because("Should fail in non-git directory");
+        await Assert.That(result.Output).Contains("Failed to get changed files")
+            .Because("Should show git error message");
+    }
+
+    #endregion
+
+    #region Error Handling
+
+    [Test]
+    public async Task AffectedBy_InvalidRef_ReturnsExitCodeOne()
+    {
+        var repoPath = CreateGitRepo()
+            .WithFile("src/Calculator.cs", SourceFile)
+            .WithFile("specs/Calculator.spec.csx", PassingSpec)
+            .WithCommit("Initial commit")
+            .Build();
+
+        var result = await RunCliInDirectoryAsync(repoPath, "run", "specs", "--affected-by", "nonexistent-branch");
+
+        await Assert.That(result.ExitCode).IsEqualTo(1)
+            .Because("Should fail for invalid git ref");
+        await Assert.That(result.Output).Contains("Failed to get changed files")
+            .Because("Should show error message");
+    }
+
+    #endregion
+}

--- a/tests/DraftSpec.Cli.IntegrationTests/Infrastructure/GitRepositoryBuilder.cs
+++ b/tests/DraftSpec.Cli.IntegrationTests/Infrastructure/GitRepositoryBuilder.cs
@@ -1,0 +1,133 @@
+using DraftSpec.Cli;
+
+namespace DraftSpec.Cli.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Fluent builder for creating test git repositories.
+/// </summary>
+public class GitRepositoryBuilder
+{
+    private readonly string _directory;
+    private readonly List<(string Path, string Content)> _initialFiles = [];
+    private readonly List<string> _commitMessages = [];
+    private readonly List<(string Path, string Content)> _stagedChanges = [];
+    private readonly List<(string Path, string Content)> _unstagedChanges = [];
+
+    public GitRepositoryBuilder(string directory)
+    {
+        _directory = directory;
+    }
+
+    /// <summary>
+    /// Adds a file to the repository.
+    /// If called before first commit, file is included in initial commit.
+    /// </summary>
+    public GitRepositoryBuilder WithFile(string relativePath, string content)
+    {
+        _initialFiles.Add((relativePath, content));
+        return this;
+    }
+
+    /// <summary>
+    /// Creates a commit with all pending files.
+    /// </summary>
+    public GitRepositoryBuilder WithCommit(string message)
+    {
+        _commitMessages.Add(message);
+        return this;
+    }
+
+    /// <summary>
+    /// Stages a file change (for testing --affected-by staged).
+    /// </summary>
+    public GitRepositoryBuilder WithStagedChange(string relativePath, string content)
+    {
+        _stagedChanges.Add((relativePath, content));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an unstaged modification (for testing --affected-by HEAD).
+    /// </summary>
+    public GitRepositoryBuilder WithUnstagedChange(string relativePath, string content)
+    {
+        _unstagedChanges.Add((relativePath, content));
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the git repository and returns the path.
+    /// </summary>
+    public string Build()
+    {
+        Directory.CreateDirectory(_directory);
+
+        // Initialize git repo
+        RunGit("init");
+        RunGit("config", "user.email", "test@example.com");
+        RunGit("config", "user.name", "Test User");
+
+        // Write initial files
+        foreach (var (path, content) in _initialFiles)
+        {
+            var fullPath = Path.Combine(_directory, path);
+            var dir = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(fullPath, content);
+        }
+
+        // Stage and commit
+        if (_initialFiles.Count > 0 || _commitMessages.Count > 0)
+        {
+            RunGit("add", ".");
+
+            var commitMessage = _commitMessages.Count > 0 ? _commitMessages[0] : "Initial commit";
+            RunGit("commit", "-m", commitMessage);
+        }
+
+        // Handle additional commits if specified
+        for (var i = 1; i < _commitMessages.Count; i++)
+        {
+            // Create a dummy file change for each additional commit
+            var dummyFile = Path.Combine(_directory, $".commit{i}");
+            File.WriteAllText(dummyFile, $"Commit {i}");
+            RunGit("add", ".");
+            RunGit("commit", "-m", _commitMessages[i]);
+        }
+
+        // Apply staged changes
+        foreach (var (path, content) in _stagedChanges)
+        {
+            var fullPath = Path.Combine(_directory, path);
+            var dir = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(fullPath, content);
+            RunGit("add", path);
+        }
+
+        // Apply unstaged changes
+        foreach (var (path, content) in _unstagedChanges)
+        {
+            var fullPath = Path.Combine(_directory, path);
+            var dir = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(fullPath, content);
+        }
+
+        return _directory;
+    }
+
+    private ProcessResult RunGit(params string[] args)
+    {
+        var result = ProcessHelper.Run("git", args, _directory);
+        if (!result.Success)
+        {
+            throw new InvalidOperationException(
+                $"Git command failed: git {string.Join(" ", args)}\n{result.Error}");
+        }
+        return result;
+    }
+}

--- a/tests/DraftSpec.Cli.IntegrationTests/Infrastructure/HistoryFileBuilder.cs
+++ b/tests/DraftSpec.Cli.IntegrationTests/Infrastructure/HistoryFileBuilder.cs
@@ -1,0 +1,144 @@
+using System.Text.Json;
+
+namespace DraftSpec.Cli.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Fluent builder for creating .draftspec/history.json files for integration tests.
+/// </summary>
+public class HistoryFileBuilder
+{
+    private readonly string _projectDir;
+    private readonly Dictionary<string, SpecEntryData> _specs = new();
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public HistoryFileBuilder(string projectDir)
+    {
+        _projectDir = projectDir;
+    }
+
+    /// <summary>
+    /// Adds a spec with consistent passing history.
+    /// </summary>
+    public HistoryFileBuilder WithStableSpec(string specId, string displayName, int runCount = 5)
+    {
+        var runs = Enumerable.Range(0, runCount)
+            .Select(i => new RunData
+            {
+                Timestamp = DateTime.UtcNow.AddMinutes(-i),
+                Status = "passed",
+                DurationMs = 100.0 + i * 10
+            })
+            .ToList();
+
+        _specs[specId] = new SpecEntryData { DisplayName = displayName, Runs = runs };
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a spec with alternating pass/fail history (flaky pattern).
+    /// </summary>
+    public HistoryFileBuilder WithFlakySpec(string specId, string displayName, int statusChanges = 3)
+    {
+        // Create runs with alternating status to produce the specified number of changes
+        var runs = new List<RunData>();
+        var currentStatus = "passed";
+
+        for (var i = 0; i <= statusChanges + 2; i++)
+        {
+            runs.Add(new RunData
+            {
+                Timestamp = DateTime.UtcNow.AddMinutes(-i),
+                Status = currentStatus,
+                DurationMs = 100.0 + i * 10
+            });
+
+            // Toggle status to create a change
+            if (i < statusChanges)
+            {
+                currentStatus = currentStatus == "passed" ? "failed" : "passed";
+            }
+        }
+
+        _specs[specId] = new SpecEntryData { DisplayName = displayName, Runs = runs };
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a spec with custom run history (e.g., "passed", "failed", "passed").
+    /// </summary>
+    public HistoryFileBuilder WithSpec(string specId, string displayName, params string[] statuses)
+    {
+        var runs = statuses.Select((status, i) => new RunData
+        {
+            Timestamp = DateTime.UtcNow.AddMinutes(-i),
+            Status = status,
+            DurationMs = 100.0 + i * 10
+        }).ToList();
+
+        _specs[specId] = new SpecEntryData { DisplayName = displayName, Runs = runs };
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a spec with specific timing data for estimate tests.
+    /// </summary>
+    public HistoryFileBuilder WithTimedSpec(string specId, string displayName, params int[] durationsMs)
+    {
+        var runs = durationsMs.Select((duration, i) => new RunData
+        {
+            Timestamp = DateTime.UtcNow.AddMinutes(-i),
+            Status = "passed",
+            DurationMs = duration
+        }).ToList();
+
+        _specs[specId] = new SpecEntryData { DisplayName = displayName, Runs = runs };
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the history file and returns the project directory path.
+    /// </summary>
+    public string Build()
+    {
+        var draftspecDir = Path.Combine(_projectDir, ".draftspec");
+        Directory.CreateDirectory(draftspecDir);
+
+        var history = new HistoryData
+        {
+            Version = 1,
+            UpdatedAt = DateTime.UtcNow,
+            Specs = _specs
+        };
+
+        var json = JsonSerializer.Serialize(history, JsonOptions);
+        File.WriteAllText(Path.Combine(draftspecDir, "history.json"), json);
+
+        return _projectDir;
+    }
+
+    // Internal data classes matching the SpecHistory JSON schema
+    private sealed class HistoryData
+    {
+        public int Version { get; set; }
+        public DateTime UpdatedAt { get; set; }
+        public Dictionary<string, SpecEntryData> Specs { get; set; } = new();
+    }
+
+    private sealed class SpecEntryData
+    {
+        public string DisplayName { get; set; } = "";
+        public List<RunData> Runs { get; set; } = new();
+    }
+
+    private sealed class RunData
+    {
+        public DateTime Timestamp { get; set; }
+        public string Status { get; set; } = "";
+        public double DurationMs { get; set; }
+    }
+}

--- a/tests/DraftSpec.Cli.IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/tests/DraftSpec.Cli.IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -61,6 +61,18 @@ public abstract class IntegrationTestBase
         => new(Path.Combine(_tempDir, $"specs_{Guid.NewGuid():N}"));
 
     /// <summary>
+    /// Creates a history file builder for a project directory.
+    /// </summary>
+    protected HistoryFileBuilder CreateHistoryFile(string projectDir)
+        => new(projectDir);
+
+    /// <summary>
+    /// Creates a git repository builder for this test.
+    /// </summary>
+    protected GitRepositoryBuilder CreateGitRepo()
+        => new(Path.Combine(_tempDir, $"repo_{Guid.NewGuid():N}"));
+
+    /// <summary>
     /// Runs the CLI with the given arguments and returns the result.
     /// </summary>
     protected Task<ProcessResult> RunCliAsync(params string[] args)


### PR DESCRIPTION
## Summary

- Add end-to-end integration tests for `cache`, `estimate`, `flaky`, and `run --affected-by` commands
- Create infrastructure helpers for test fixture creation
- Tests run the actual CLI as a subprocess to verify real behavior

### New Infrastructure
- `HistoryFileBuilder`: Fluent builder for `.draftspec/history.json` test files with `WithStableSpec()`, `WithFlakySpec()`, `WithTimedSpec()` methods
- `GitRepositoryBuilder`: Fluent builder for test git repositories with `WithFile()`, `WithCommit()`, `WithStagedChange()` methods

### New Test Classes (38 tests)
| Test Class | Tests | Coverage |
|------------|-------|----------|
| CacheCommandIntegrationTests | 11 | stats/clear subcommands, error handling, case-insensitivity |
| EstimateCommandIntegrationTests | 8 | no history, P50/P95/Max, slowest specs, machine-readable output |
| FlakyCommandIntegrationTests | 11 | no history, no flaky specs, detection, clear, custom options |
| RunCommandAffectedByTests | 8 | staged changes, dry run, git errors, no affected specs |

## Test plan

- [x] All 94 integration tests pass (38 new + 56 existing)
- [x] Build succeeds with no warnings
- [x] Pre-commit hooks pass (dotnet-format, dotnet-build)

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)