### PR TITLE
fix(mcp): Correct CurrentConcurrentExecutions property logic

### DIFF
--- a/tests/DraftSpec.Tests/Mcp/Services/ExecutionRateLimiterTests.cs
+++ b/tests/DraftSpec.Tests/Mcp/Services/ExecutionRateLimiterTests.cs
@@ -1,0 +1,119 @@
+using DraftSpec.Mcp;
+using DraftSpec.Mcp.Services;
+
+namespace DraftSpec.Tests.Mcp.Services;
+
+public class ExecutionRateLimiterTests
+{
+    #region CurrentConcurrentExecutions
+
+    [Test]
+    public async Task CurrentConcurrentExecutions_Initially_ReturnsZero()
+    {
+        var options = new McpOptions { MaxConcurrentExecutions = 3 };
+        using var limiter = new ExecutionRateLimiter(options);
+
+        var result = limiter.CurrentConcurrentExecutions;
+
+        await Assert.That(result).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task CurrentConcurrentExecutions_AfterAcquire_ReturnsOne()
+    {
+        var options = new McpOptions { MaxConcurrentExecutions = 3 };
+        using var limiter = new ExecutionRateLimiter(options);
+
+        await limiter.TryAcquireAsync();
+
+        var result = limiter.CurrentConcurrentExecutions;
+
+        await Assert.That(result).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CurrentConcurrentExecutions_AfterMultipleAcquires_ReturnsCorrectCount()
+    {
+        var options = new McpOptions { MaxConcurrentExecutions = 5 };
+        using var limiter = new ExecutionRateLimiter(options);
+
+        await limiter.TryAcquireAsync();
+        await limiter.TryAcquireAsync();
+        await limiter.TryAcquireAsync();
+
+        var result = limiter.CurrentConcurrentExecutions;
+
+        await Assert.That(result).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task CurrentConcurrentExecutions_AfterRelease_Decrements()
+    {
+        var options = new McpOptions { MaxConcurrentExecutions = 3 };
+        using var limiter = new ExecutionRateLimiter(options);
+
+        await limiter.TryAcquireAsync();
+        await limiter.TryAcquireAsync();
+        limiter.Release();
+
+        var result = limiter.CurrentConcurrentExecutions;
+
+        await Assert.That(result).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task CurrentConcurrentExecutions_AtMaxCapacity_ReturnsMax()
+    {
+        var options = new McpOptions { MaxConcurrentExecutions = 2 };
+        using var limiter = new ExecutionRateLimiter(options);
+
+        await limiter.TryAcquireAsync();
+        await limiter.TryAcquireAsync();
+
+        var result = limiter.CurrentConcurrentExecutions;
+
+        await Assert.That(result).IsEqualTo(2);
+    }
+
+    #endregion
+
+    #region TryAcquireAsync
+
+    [Test]
+    public async Task TryAcquireAsync_UnderLimit_ReturnsTrue()
+    {
+        var options = new McpOptions { MaxConcurrentExecutions = 2 };
+        using var limiter = new ExecutionRateLimiter(options);
+
+        var result = await limiter.TryAcquireAsync();
+
+        await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task TryAcquireAsync_AtLimit_ReturnsFalse()
+    {
+        var options = new McpOptions { MaxConcurrentExecutions = 1 };
+        using var limiter = new ExecutionRateLimiter(options);
+
+        await limiter.TryAcquireAsync();
+        var result = await limiter.TryAcquireAsync();
+
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task TryAcquireAsync_AfterRelease_CanAcquireAgain()
+    {
+        var options = new McpOptions { MaxConcurrentExecutions = 1 };
+        using var limiter = new ExecutionRateLimiter(options);
+
+        await limiter.TryAcquireAsync();
+        limiter.Release();
+        var result = await limiter.TryAcquireAsync();
+
+        await Assert.That(result).IsTrue();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Fix incorrect `CurrentConcurrentExecutions` property logic in `ExecutionRateLimiter`.

### Problem
The property had two issues:
1. **Incorrect calculation**: Returned semaphore's `CurrentCount` (available slots) instead of active executions
2. **Redundant ternary**: The condition `CurrentCount == 0 ? 0 : CurrentCount` always returned the same value

### Solution
- Store `_maxConcurrency` field to calculate active executions
- Return `_maxConcurrency - CurrentCount` to get actual running executions

### Before
```csharp
public int CurrentConcurrentExecutions =>
    _concurrencySemaphore.CurrentCount == 0 ? 0 :
    ((SemaphoreSlim)_concurrencySemaphore).CurrentCount;
```

### After
```csharp
public int CurrentConcurrentExecutions => _maxConcurrency - _concurrencySemaphore.CurrentCount;
```

## Test plan

- [x] Add `ExecutionRateLimiterTests` with 8 tests covering property behavior
- [x] All tests pass

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)