### PR TITLE
feat(mcp): Add option to disable stack traces in error responses

### DIFF
--- a/src/DraftSpec.Mcp/McpOptions.cs
+++ b/src/DraftSpec.Mcp/McpOptions.cs
@@ -22,4 +22,11 @@ public class McpOptions
     /// Default: 1MB. Prevents memory exhaustion from very large inputs.
     /// </summary>
     public int MaxSpecContentSizeBytes { get; init; } = 1_000_000;
+
+    /// <summary>
+    /// Whether to include stack traces in error responses.
+    /// Default: false to prevent information disclosure.
+    /// Set to true for debugging during development.
+    /// </summary>
+    public bool IncludeStackTracesInErrors { get; init; }
 }

--- a/src/DraftSpec.Mcp/Services/SpecExecutionService.cs
+++ b/src/DraftSpec.Mcp/Services/SpecExecutionService.cs
@@ -15,6 +15,7 @@ public partial class SpecExecutionService : ISpecExecutionService
     private readonly TempFileManager _tempFileManager;
     private readonly IAsyncProcessRunner _processRunner;
     private readonly ExecutionRateLimiter _rateLimiter;
+    private readonly McpOptions _options;
     private readonly ILogger<SpecExecutionService> _logger;
 
     /// <summary>
@@ -47,11 +48,13 @@ public partial class SpecExecutionService : ISpecExecutionService
         TempFileManager tempFileManager,
         IAsyncProcessRunner processRunner,
         ExecutionRateLimiter rateLimiter,
+        McpOptions options,
         ILogger<SpecExecutionService> logger)
     {
         _tempFileManager = tempFileManager;
         _processRunner = processRunner;
         _rateLimiter = rateLimiter;
+        _options = options;
         _logger = logger;
     }
 
@@ -204,7 +207,7 @@ public partial class SpecExecutionService : ISpecExecutionService
                 {
                     Category = ErrorCategory.Runtime,
                     Message = $"Execution failed: {ex.Message}",
-                    StackTrace = ex.StackTrace
+                    StackTrace = _options.IncludeStackTracesInErrors ? ex.StackTrace : null
                 },
                 ErrorOutput = $"Execution failed: {ex.Message}",
                 DurationMs = stopwatch.Elapsed.TotalMilliseconds


### PR DESCRIPTION
## Summary

Add `IncludeStackTracesInErrors` option to `McpOptions` to control whether stack traces are included in error responses. This prevents information disclosure of internal file paths and method names.

### Changes
- Add `IncludeStackTracesInErrors` property to `McpOptions` (default: `false`)
- Update `SpecExecutionService` to conditionally include stack traces based on option
- Add unit tests for both enabled and disabled behavior

### Default Behavior

Stack traces are **disabled by default** to prevent information disclosure. Set `IncludeStackTracesInErrors = true` for debugging during development.

```csharp
services.AddDraftSpecMcp(new McpOptions
{
    IncludeStackTracesInErrors = true // Enable for debugging
});
```

## Test plan

- [x] Add tests for stack trace filtering behavior
- [x] All 32 SpecExecutionService tests pass

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)