### PR TITLE
fix(ci): Use full git history in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          fetch-depth: 0  # Full history needed for git-based tests (HEAD~1)
 
       - name: Determine version
         id: version


### PR DESCRIPTION
## Summary

Fixes the publish workflow failing on release because a git-based test (`GetChangedFilesAsync_WithCommitRef_RunsGitDiff`) requires access to `HEAD~1`, which doesn't exist in GitHub Actions' default shallow clone.

### Root Cause

GitHub Actions uses `fetch-depth: 1` by default, creating a shallow clone with only the HEAD commit. The test at `GitServiceTests.cs:240` calls `GetChangedFilesAsync("HEAD~1", ...)` which fails with:

```
fatal: ambiguous argument 'HEAD~1': unknown revision or path not in the working tree.
```

### Fix

Add `fetch-depth: 0` to the checkout step to get full git history.

## Test Plan

- [x] Verify workflow YAML is valid
- [ ] Re-trigger the v0.7.0-alpha.1 release to confirm fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)