### PR TITLE
perf: Eliminate redundant file hashing in compilation caches

### DIFF
--- a/src/DraftSpec.TestingPlatform/StaticParseResultCache.cs
+++ b/src/DraftSpec.TestingPlatform/StaticParseResultCache.cs
@@ -55,7 +55,10 @@ public sealed class StaticParseResultCache
     {
         try
         {
-            var cacheKey = ComputeCacheKey(sourcePath, sourceFiles);
+            // Compute file hashes once and reuse for both cache key and validation
+            var fileHashes = ComputeFileHashes(sourceFiles);
+
+            var cacheKey = ComputeCacheKeyFromHashes(sourcePath, fileHashes);
             var metadataPath = GetMetadataPath(cacheKey);
 
             if (!File.Exists(metadataPath))
@@ -65,8 +68,8 @@ public sealed class StaticParseResultCache
             if (metadata == null)
                 return (false, null);
 
-            // Validate cache
-            if (!IsCacheValid(metadata, sourceFiles))
+            // Validate cache using pre-computed hashes
+            if (!IsCacheValidWithHashes(metadata, fileHashes))
             {
                 // Remove stale cache files
                 DeleteCacheEntry(cacheKey);
@@ -192,21 +195,65 @@ public sealed class StaticParseResultCache
     }
 
     /// <summary>
+    /// Computes SHA256 hashes for all source files.
+    /// </summary>
+    private static Dictionary<string, string> ComputeFileHashes(IReadOnlyList<string> sourceFiles)
+    {
+        return sourceFiles
+            .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(f => f, ComputeFileHash, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Computes a cache key based on source path and dependencies.
     /// </summary>
     private string ComputeCacheKey(string sourcePath, IReadOnlyList<string> sourceFiles)
+    {
+        var fileHashes = ComputeFileHashes(sourceFiles);
+        return ComputeCacheKeyFromHashes(sourcePath, fileHashes);
+    }
+
+    /// <summary>
+    /// Computes a cache key using pre-computed file hashes.
+    /// </summary>
+    private string ComputeCacheKeyFromHashes(string sourcePath, Dictionary<string, string> fileHashes)
     {
         var keyBuilder = new StringBuilder();
         keyBuilder.AppendLine(_draftSpecVersion);
         keyBuilder.AppendLine(sourcePath);
 
         // Include all dependency file hashes in sorted order for determinism
-        foreach (var file in sourceFiles.OrderBy(f => f, StringComparer.OrdinalIgnoreCase))
+        foreach (var (file, hash) in fileHashes.OrderBy(kvp => kvp.Key, StringComparer.OrdinalIgnoreCase))
         {
-            keyBuilder.AppendLine($"{file}:{ComputeFileHash(file)}");
+            keyBuilder.AppendLine($"{file}:{hash}");
         }
 
         return ComputeHash(keyBuilder.ToString())[..16]; // Use first 16 chars of hash
+    }
+
+    /// <summary>
+    /// Validates that a cache entry is still valid using pre-computed hashes.
+    /// </summary>
+    internal bool IsCacheValidWithHashes(CacheMetadata metadata, Dictionary<string, string> currentFileHashes)
+    {
+        // Check DraftSpec version
+        if (metadata.DraftSpecVersion != _draftSpecVersion)
+            return false;
+
+        // Check that all source files match
+        if (metadata.SourceFiles.Count != currentFileHashes.Count)
+            return false;
+
+        foreach (var (file, currentHash) in currentFileHashes)
+        {
+            if (!metadata.SourceFileHashes.TryGetValue(file, out var cachedHash))
+                return false;
+
+            if (currentHash != cachedHash)
+                return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/tests/DraftSpec.Tests/Scripting/ScriptCompilationCacheTests.cs
+++ b/tests/DraftSpec.Tests/Scripting/ScriptCompilationCacheTests.cs
@@ -729,6 +729,136 @@ public class ScriptCompilationCacheTests
         await Assert.That(result).IsTrue();
     }
 
+    #region IsCacheValidWithHashes Tests
+
+    [Test]
+    public async Task IsCacheValidWithHashes_ReturnsTrue_WhenHashesMatch()
+    {
+        // Arrange - cache a real script to get valid metadata with correct hashes
+        var sourceFile = Path.Combine(_testDir, "hash-valid.csx");
+        var code = "var x = 1;";
+        await File.WriteAllTextAsync(sourceFile, code);
+
+        var script = CreateTestScript(code);
+        _cache.CacheScript(sourceFile, [sourceFile], code, script);
+
+        // Read the generated metadata
+        var cacheDir = Path.Combine(_testDir, ".draftspec", "cache", "scripts");
+        var metaFile = Directory.GetFiles(cacheDir, "*.meta.json").Single();
+        var metaJson = await File.ReadAllTextAsync(metaFile);
+        var metadata = System.Text.Json.JsonSerializer.Deserialize<ScriptCompilationCache.CacheMetadata>(
+            metaJson,
+            new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase });
+
+        // Use the same hashes from metadata (simulating pre-computed hashes)
+        var fileHashes = metadata!.SourceFileHashes;
+
+        // Act
+        var result = _cache.IsCacheValidWithHashes(metadata, fileHashes);
+
+        // Assert
+        await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task IsCacheValidWithHashes_ReturnsFalse_WhenVersionMismatch()
+    {
+        // Arrange
+        var sourceFile = Path.Combine(_testDir, "hash-version-test.csx");
+        await File.WriteAllTextAsync(sourceFile, "var x = 1;");
+
+        var metadata = new ScriptCompilationCache.CacheMetadata
+        {
+            DraftSpecVersion = "0.0.0-wrong-version",
+            SourceFiles = [sourceFile],
+            SourceFileHashes = new Dictionary<string, string> { [sourceFile] = "somehash" }
+        };
+
+        var fileHashes = new Dictionary<string, string> { [sourceFile] = "somehash" };
+
+        // Act
+        var result = _cache.IsCacheValidWithHashes(metadata, fileHashes);
+
+        // Assert
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task IsCacheValidWithHashes_ReturnsFalse_WhenFileCountMismatch()
+    {
+        // Arrange
+        var sourceFile1 = Path.Combine(_testDir, "hash-count1.csx");
+        var sourceFile2 = Path.Combine(_testDir, "hash-count2.csx");
+
+        var metadata = new ScriptCompilationCache.CacheMetadata
+        {
+            DraftSpecVersion = typeof(DraftSpec.Dsl).Assembly.GetName().Version?.ToString() ?? "0.0.0",
+            SourceFiles = [sourceFile1], // Only one file
+            SourceFileHashes = new Dictionary<string, string> { [sourceFile1] = "hash1" }
+        };
+
+        // Pass two files in hash dictionary
+        var fileHashes = new Dictionary<string, string>
+        {
+            [sourceFile1] = "hash1",
+            [sourceFile2] = "hash2"
+        };
+
+        // Act
+        var result = _cache.IsCacheValidWithHashes(metadata, fileHashes);
+
+        // Assert
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task IsCacheValidWithHashes_ReturnsFalse_WhenFileNotInCachedHashes()
+    {
+        // Arrange
+        var sourceFile1 = Path.Combine(_testDir, "hash-missing1.csx");
+        var sourceFile2 = Path.Combine(_testDir, "hash-missing2.csx");
+
+        var metadata = new ScriptCompilationCache.CacheMetadata
+        {
+            DraftSpecVersion = typeof(DraftSpec.Dsl).Assembly.GetName().Version?.ToString() ?? "0.0.0",
+            SourceFiles = [sourceFile1],
+            SourceFileHashes = new Dictionary<string, string> { [sourceFile1] = "hash1" } // Only has sourceFile1
+        };
+
+        // Current hashes has different file
+        var fileHashes = new Dictionary<string, string> { [sourceFile2] = "hash2" };
+
+        // Act
+        var result = _cache.IsCacheValidWithHashes(metadata, fileHashes);
+
+        // Assert
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task IsCacheValidWithHashes_ReturnsFalse_WhenHashesDiffer()
+    {
+        // Arrange
+        var sourceFile = Path.Combine(_testDir, "hash-differ.csx");
+
+        var metadata = new ScriptCompilationCache.CacheMetadata
+        {
+            DraftSpecVersion = typeof(DraftSpec.Dsl).Assembly.GetName().Version?.ToString() ?? "0.0.0",
+            SourceFiles = [sourceFile],
+            SourceFileHashes = new Dictionary<string, string> { [sourceFile] = "old-hash" }
+        };
+
+        var fileHashes = new Dictionary<string, string> { [sourceFile] = "new-hash" };
+
+        // Act
+        var result = _cache.IsCacheValidWithHashes(metadata, fileHashes);
+
+        // Assert
+        await Assert.That(result).IsFalse();
+    }
+
+    #endregion
+
     private static Script<object> CreateTestScript(string code)
     {
         var options = ScriptOptions.Default


### PR DESCRIPTION
## Summary

Both `ScriptCompilationCache` and `StaticParseResultCache` were hashing all source files twice on cache misses - once during cache key computation and again during cache validation. This doubled file I/O unnecessarily.

### Changes
- Add `ComputeFileHashes()` to compute all hashes once upfront
- Add `ComputeCacheKeyFromHashes()` to use pre-computed hashes
- Add `IsCacheValidWithHashes()` to validate using pre-computed hashes
- Update `TryExecuteCachedAsync`/`TryGetCachedAsync` to use new methods
- Add 10 comprehensive tests for `IsCacheValidWithHashes`

### Performance Impact

For a spec with 10 dependent files averaging 5KB each:
| Metric | Before | After |
|--------|--------|-------|
| File I/O | 100KB | 50KB |
| SHA256 ops | 2x per file | 1x per file |

This is especially impactful during startup with cold caches.

## Test Plan
- [x] All 3231 unit tests pass
- [x] Added tests for `IsCacheValidWithHashes` on both cache classes
- [x] Existing cache tests verify end-to-end behavior still works

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)