### PR TITLE
feat(plugins): Add optional plugin signing verification

### DIFF
--- a/src/DraftSpec.Cli/Configuration/PluginsConfig.cs
+++ b/src/DraftSpec.Cli/Configuration/PluginsConfig.cs
@@ -5,12 +5,55 @@ namespace DraftSpec.Cli.Configuration;
 /// <summary>
 /// Configuration for plugin loading and security.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Security Model</b>
+/// </para>
+/// <para>
+/// DraftSpec supports two methods for verifying plugin authenticity:
+/// </para>
+/// <list type="number">
+/// <item>
+/// <term>Public Key Tokens</term>
+/// <description>
+/// 8-byte (64-bit) hash of the strong name public key. Fast and simple,
+/// but provides weaker security guarantees. No revocation support.
+/// </description>
+/// </item>
+/// <item>
+/// <term>Certificate Thumbprints (Recommended)</term>
+/// <description>
+/// SHA256 hash of the Authenticode signing certificate. Provides stronger
+/// verification and can be revoked by removing from the trusted list.
+/// </description>
+/// </item>
+/// </list>
+/// <para>
+/// <b>Limitations</b>
+/// </para>
+/// <list type="bullet">
+/// <item>No automatic certificate revocation checking (CRL/OCSP)</item>
+/// <item>No certificate chain validation against system trust stores</item>
+/// <item>No timestamp verification for expired certificates</item>
+/// </list>
+/// <para>
+/// If a signing key is compromised, you must manually remove it from the
+/// trusted list and redeploy configuration to all affected systems.
+/// </para>
+/// </remarks>
 public class PluginsConfig
 {
     /// <summary>
-    /// When true, only load plugins that are signed with a trusted public key.
+    /// When true, only load plugins that are signed with a trusted key or certificate.
     /// Default: false (allow all plugins).
     /// </summary>
+    /// <remarks>
+    /// When enabled, plugins must have either:
+    /// <list type="bullet">
+    /// <item>A strong name with a public key token in <see cref="TrustedPublicKeyTokens"/>, OR</item>
+    /// <item>An Authenticode signature with a certificate in <see cref="TrustedCertificateThumbprints"/></item>
+    /// </list>
+    /// </remarks>
     [JsonPropertyName("requireSignedPlugins")]
     public bool RequireSignedPlugins { get; set; } = false;
 
@@ -18,6 +61,35 @@ public class PluginsConfig
     /// List of trusted public key tokens (hex strings, e.g., "b77a5c561934e089").
     /// Plugins must be signed with one of these keys when RequireSignedPlugins is true.
     /// </summary>
+    /// <remarks>
+    /// Public key tokens are 8 bytes (16 hex characters). They are derived from
+    /// the strong name public key and provide basic verification of assembly origin.
+    /// Consider using <see cref="TrustedCertificateThumbprints"/> for stronger security.
+    /// </remarks>
     [JsonPropertyName("trustedPublicKeyTokens")]
     public List<string>? TrustedPublicKeyTokens { get; set; }
+
+    /// <summary>
+    /// List of trusted certificate thumbprints (SHA256 hex strings).
+    /// Plugins signed with any of these certificates are trusted.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Certificate thumbprints are SHA256 hashes (64 hex characters) of the
+    /// Authenticode signing certificate. This provides stronger verification
+    /// than public key tokens.
+    /// </para>
+    /// <para>
+    /// To get a certificate thumbprint:
+    /// <code>
+    /// # Windows PowerShell
+    /// (Get-AuthenticodeSignature .\Plugin.dll).SignerCertificate.Thumbprint
+    ///
+    /// # .NET CLI
+    /// dotnet tool run sigcheck -a Plugin.dll
+    /// </code>
+    /// </para>
+    /// </remarks>
+    [JsonPropertyName("trustedCertificateThumbprints")]
+    public List<string>? TrustedCertificateThumbprints { get; set; }
 }

--- a/src/DraftSpec.Cli/DependencyInjection/IAssemblyLoader.cs
+++ b/src/DraftSpec.Cli/DependencyInjection/IAssemblyLoader.cs
@@ -30,4 +30,12 @@ public interface IAssemblyLoader
     /// <param name="path">Path to the assembly file.</param>
     /// <returns>Lowercase hex string of the public key token, or null if not signed.</returns>
     string? GetPublicKeyToken(string path);
+
+    /// <summary>
+    /// Gets the SHA256 thumbprint of the Authenticode signing certificate.
+    /// Returns null if the assembly is not Authenticode-signed or cannot be read.
+    /// </summary>
+    /// <param name="path">Path to the assembly file.</param>
+    /// <returns>Uppercase hex string of the certificate SHA256 thumbprint, or null if not signed.</returns>
+    string? GetCertificateThumbprint(string path);
 }

--- a/src/DraftSpec.Cli/IsolatedAssemblyLoader.cs
+++ b/src/DraftSpec.Cli/IsolatedAssemblyLoader.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 
 namespace DraftSpec.Cli.DependencyInjection;
 
@@ -34,5 +37,36 @@ public class IsolatedAssemblyLoader : IAssemblyLoader
         {
             return null;
         }
+    }
+
+    public string? GetCertificateThumbprint(string path)
+    {
+        try
+        {
+            return ExtractAuthenticodeThumbprint(path);
+        }
+        catch
+        {
+            // File is not Authenticode-signed, not found, or other error
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Extracts the SHA256 thumbprint from an Authenticode-signed file.
+    /// Excluded from coverage: requires Windows Authenticode-signed file to test.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    private static string ExtractAuthenticodeThumbprint(string path)
+    {
+        // Note: CreateFromSignedFile is marked obsolete (SYSLIB0057) but there's no
+        // direct replacement in X509CertificateLoader for extracting Authenticode
+        // signatures. The method still works and is the only cross-platform option.
+#pragma warning disable SYSLIB0057
+        using var cert = X509Certificate2.CreateFromSignedFile(path);
+#pragma warning restore SYSLIB0057
+
+        // Compute SHA256 thumbprint (more secure than default SHA1)
+        return cert.GetCertHashString(HashAlgorithmName.SHA256);
     }
 }

--- a/tests/DraftSpec.Tests/Cli/DependencyInjection/IsolatedAssemblyLoaderTests.cs
+++ b/tests/DraftSpec.Tests/Cli/DependencyInjection/IsolatedAssemblyLoaderTests.cs
@@ -73,4 +73,65 @@ public class IsolatedAssemblyLoaderTests
         // Verify it's lowercase hex (only contains 0-9 and a-f)
         await Assert.That(token!.All(c => char.IsAsciiDigit(c) || (c >= 'a' && c <= 'f'))).IsTrue();
     }
+
+    [Test]
+    public async Task GetCertificateThumbprint_NonExistentPath_ReturnsNull()
+    {
+        var loader = new IsolatedAssemblyLoader();
+
+        var thumbprint = loader.GetCertificateThumbprint("/non/existent/path.dll");
+
+        await Assert.That(thumbprint).IsNull();
+    }
+
+    [Test]
+    public async Task GetCertificateThumbprint_InvalidFile_ReturnsNull()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "not an assembly");
+            var loader = new IsolatedAssemblyLoader();
+
+            var thumbprint = loader.GetCertificateThumbprint(tempFile);
+
+            await Assert.That(thumbprint).IsNull();
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task GetCertificateThumbprint_UnsignedAssembly_ReturnsNull()
+    {
+        // DraftSpec.dll is not Authenticode-signed
+        var assemblyPath = typeof(DraftSpec.Dsl).Assembly.Location;
+        var loader = new IsolatedAssemblyLoader();
+
+        var thumbprint = loader.GetCertificateThumbprint(assemblyPath);
+
+        await Assert.That(thumbprint).IsNull();
+    }
+
+    [Test]
+    public async Task GetCertificateThumbprint_StrongNamedButNotAuthenticode_ReturnsNull()
+    {
+        // System.Text.Json is strong-named but not Authenticode-signed on non-Windows
+        // On Windows it may be Authenticode-signed, so we just verify the format if present
+        var assemblyPath = typeof(System.Text.Json.JsonSerializer).Assembly.Location;
+        var loader = new IsolatedAssemblyLoader();
+
+        var thumbprint = loader.GetCertificateThumbprint(assemblyPath);
+
+        // Either null (not Authenticode-signed) or valid SHA256 thumbprint format
+        if (thumbprint != null)
+        {
+            // SHA256 = 32 bytes = 64 hex characters
+            await Assert.That(thumbprint.Length).IsEqualTo(64);
+            // Verify it's uppercase hex (X509Certificate2.GetCertHashString returns uppercase)
+            await Assert.That(thumbprint.All(c => char.IsAsciiDigit(c) || (c >= 'A' && c <= 'F'))).IsTrue();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Add TrustedCertificateThumbprints configuration option as an alternative to public key tokens for plugin verification.

### Changes
- Add `TrustedCertificateThumbprints` property to `PluginsConfig` (SHA256 hex strings)
- Add comprehensive security model documentation with limitations (no CRL/OCSP, no chain validation, no timestamp verification)
- Add `GetCertificateThumbprint` method to `IAssemblyLoader` interface
- Implement Authenticode signature extraction in `IsolatedAssemblyLoader`
- Update `PluginLoader` to check cert thumbprints before public key tokens
- Add 5 tests for certificate thumbprint verification scenarios

### Verification Order
1. Check certificate thumbprint (stronger verification, recommended)
2. Fall back to public key token if no cert match
3. Reject if signed but not trusted (with warning message)
4. Reject if unsigned (with warning message)

### Security Model Limitations
As documented in `PluginsConfig.cs`:
- No automatic certificate revocation checking (CRL/OCSP)
- No certificate chain validation against system trust stores
- No timestamp verification for expired certificates

If a signing key is compromised, you must manually remove it from the trusted list and redeploy configuration to all affected systems.

## Test Plan
- [x] Unit tests pass (3236 tests)
- [x] Verify trusted cert thumbprint allows plugin loading
- [x] Verify untrusted cert thumbprint rejects plugin
- [x] Verify cert thumbprint takes precedence over public key token
- [x] Verify fallback to public key token when no cert match
- [x] Verify case-insensitive thumbprint matching

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)