### PR TITLE
perf(cli): Optimize RuntimeEstimator to avoid repeated LINQ iterations

### DIFF
--- a/src/DraftSpec.Cli/History/RuntimeEstimator.cs
+++ b/src/DraftSpec.Cli/History/RuntimeEstimator.cs
@@ -7,6 +7,14 @@ public class RuntimeEstimator : IRuntimeEstimator
 {
     private const int TopSlowestCount = 5;
 
+    /// <summary>
+    /// Cached spec data with pre-sorted durations for efficient percentile calculations.
+    /// </summary>
+    private readonly record struct SpecData(
+        string SpecId,
+        string DisplayName,
+        IReadOnlyList<double> SortedDurations);
+
     public RuntimeEstimate Calculate(SpecHistory history, int percentile = 50)
     {
         if (history.Specs.Count == 0)
@@ -24,33 +32,25 @@ public class RuntimeEstimator : IRuntimeEstimator
             };
         }
 
-        var specEstimates = new List<SpecEstimate>();
-        var allRunCounts = new List<int>();
+        // Pre-compute sorted durations once per spec
+        var specDataList = new List<SpecData>();
 
         foreach (var (specId, entry) in history.Specs)
         {
             if (entry.Runs.Count == 0) continue;
 
-            var durations = entry.Runs
+            var sortedDurations = entry.Runs
                 .Where(r => r.DurationMs > 0)
-                .Select(r => r.DurationMs)
+                .Select(r => (double)r.DurationMs)
+                .OrderBy(d => d)
                 .ToList();
 
-            if (durations.Count == 0) continue;
+            if (sortedDurations.Count == 0) continue;
 
-            var estimate = CalculatePercentile(durations, percentile);
-            allRunCounts.Add(durations.Count);
-
-            specEstimates.Add(new SpecEstimate
-            {
-                SpecId = specId,
-                DisplayName = entry.DisplayName,
-                EstimateMs = estimate,
-                RunCount = durations.Count
-            });
+            specDataList.Add(new SpecData(specId, entry.DisplayName, sortedDurations));
         }
 
-        if (specEstimates.Count == 0)
+        if (specDataList.Count == 0)
         {
             return new RuntimeEstimate
             {
@@ -65,31 +65,32 @@ public class RuntimeEstimator : IRuntimeEstimator
             };
         }
 
-        // Calculate totals by summing individual spec estimates
-        var allEstimates = specEstimates.Select(s => s.EstimateMs).ToList();
-        var totalAtPercentile = allEstimates.Sum();
+        // Calculate all metrics using pre-sorted durations (no re-sorting)
+        var specEstimates = new List<SpecEstimate>();
+        double p50Total = 0, p95Total = 0, maxTotal = 0, totalAtPercentile = 0;
+        var totalRunCount = 0;
 
-        // For P50 and P95, recalculate each spec's contribution
-        var p50Total = specEstimates.Sum(s =>
+        foreach (var spec in specDataList)
         {
-            var entry = history.Specs[s.SpecId];
-            var durations = entry.Runs.Where(r => r.DurationMs > 0).Select(r => r.DurationMs).ToList();
-            return durations.Count > 0 ? CalculatePercentile(durations, 50) : 0;
-        });
+            var estimate = CalculatePercentileFromSorted(spec.SortedDurations, percentile);
+            var p50 = CalculatePercentileFromSorted(spec.SortedDurations, 50);
+            var p95 = CalculatePercentileFromSorted(spec.SortedDurations, 95);
+            var max = spec.SortedDurations[^1]; // Last element is max in sorted list
 
-        var p95Total = specEstimates.Sum(s =>
-        {
-            var entry = history.Specs[s.SpecId];
-            var durations = entry.Runs.Where(r => r.DurationMs > 0).Select(r => r.DurationMs).ToList();
-            return durations.Count > 0 ? CalculatePercentile(durations, 95) : 0;
-        });
+            totalAtPercentile += estimate;
+            p50Total += p50;
+            p95Total += p95;
+            maxTotal += max;
+            totalRunCount += spec.SortedDurations.Count;
 
-        var maxTotal = specEstimates.Sum(s =>
-        {
-            var entry = history.Specs[s.SpecId];
-            var durations = entry.Runs.Where(r => r.DurationMs > 0).Select(r => r.DurationMs).ToList();
-            return durations.Count > 0 ? durations.Max() : 0;
-        });
+            specEstimates.Add(new SpecEstimate
+            {
+                SpecId = spec.SpecId,
+                DisplayName = spec.DisplayName,
+                EstimateMs = estimate,
+                RunCount = spec.SortedDurations.Count
+            });
+        }
 
         var slowestSpecs = specEstimates
             .OrderByDescending(s => s.EstimateMs)
@@ -103,7 +104,7 @@ public class RuntimeEstimator : IRuntimeEstimator
             MaxMs = maxTotal,
             TotalEstimateMs = totalAtPercentile,
             Percentile = percentile,
-            SampleSize = allRunCounts.Count > 0 ? (int)allRunCounts.Average() : 0,
+            SampleSize = totalRunCount / specDataList.Count,
             SpecCount = specEstimates.Count,
             SlowestSpecs = slowestSpecs
         };
@@ -115,7 +116,18 @@ public class RuntimeEstimator : IRuntimeEstimator
         if (values.Count == 1) return values[0];
 
         var sorted = values.OrderBy(v => v).ToList();
-        var index = (int)Math.Ceiling(percentile / 100.0 * sorted.Count) - 1;
-        return sorted[Math.Clamp(index, 0, sorted.Count - 1)];
+        return CalculatePercentileFromSorted(sorted, percentile);
+    }
+
+    /// <summary>
+    /// Calculates a percentile value from a pre-sorted list (no re-sorting).
+    /// </summary>
+    private static double CalculatePercentileFromSorted(IReadOnlyList<double> sortedValues, int percentile)
+    {
+        if (sortedValues.Count == 0) return 0;
+        if (sortedValues.Count == 1) return sortedValues[0];
+
+        var index = (int)Math.Ceiling(percentile / 100.0 * sortedValues.Count) - 1;
+        return sortedValues[Math.Clamp(index, 0, sortedValues.Count - 1)];
     }
 }


### PR DESCRIPTION
## Summary

Optimizes `RuntimeEstimator.Calculate()` to pre-compute sorted durations once per spec instead of repeatedly extracting and sorting the same data.

**Changes:**
- Pre-compute sorted durations once per spec at the start
- Add `CalculatePercentileFromSorted` for pre-sorted input (no re-sorting)
- Calculate P50, P95, Max in single pass using pre-sorted data

**Performance improvement for 100 specs with 50 runs each:**
- Before: 400 intermediate list allocations, 400 sorts
- After: 100 list allocations, 100 sorts (4x improvement)

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)