### PR TITLE
fix(ci): Pass MinVer version override as MSBuild property

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          fetch-depth: 0  # Full history needed for git-based tests (HEAD~1)
+          fetch-depth: 0  # Full history needed for MinVer
+          fetch-tags: true  # Required for MinVer to find version tags
 
       - name: Determine version
         id: version
@@ -36,6 +37,13 @@ jobs:
           TAG="${{ github.event.release.tag_name }}"
           # Strip 'v' prefix (v0.1.0-alpha.3 -> 0.1.0-alpha.3)
           VERSION="${TAG#v}"
+
+          # Validate version is not empty
+          if [ -z "$VERSION" ]; then
+            echo "::error::No version tag found. Ensure this workflow was triggered by a release."
+            exit 1
+          fi
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Publishing version: $VERSION"
 
@@ -48,9 +56,7 @@ jobs:
         run: dotnet restore --locked-mode
 
       - name: Build
-        run: dotnet build --no-restore -c Release
-        env:
-          MinVerVersionOverride: ${{ steps.version.outputs.version }}
+        run: dotnet build --no-restore -c Release -p:MinVerVersionOverride=${{ steps.version.outputs.version }}
 
       - name: Run unit tests
         run: dotnet run --project tests/DraftSpec.Tests --no-build -c Release
@@ -59,9 +65,7 @@ jobs:
         run: dotnet run --project tests/DraftSpec.Cli.IntegrationTests --no-build -c Release
 
       - name: Pack
-        run: dotnet pack --no-build -c Release
-        env:
-          MinVerVersionOverride: ${{ steps.version.outputs.version }}
+        run: dotnet pack --no-build -c Release -p:MinVerVersionOverride=${{ steps.version.outputs.version }}
 
       - name: Display packages
         run: |


### PR DESCRIPTION
## Summary

Fixes package versioning issue where packages were built with `0.1.0-alpha.0.N` instead of the release tag version (e.g., `0.7.0-alpha.1`).

**Root cause:** The `MinVerVersionOverride` environment variable wasn't being applied correctly during the build/pack steps.

**Changes:**
- Use `-p:MinVerVersionOverride=...` MSBuild property instead of env var (more reliable)
- Add `fetch-tags: true` to checkout step to ensure MinVer can find version tags
- Add validation to fail fast if version tag is missing (prevents publishing with wrong version)

## Test Plan

After merging, re-release v0.7.0-alpha.1 (or create v0.7.0-alpha.2) and verify packages are built with correct version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)