### PR TITLE
test: Add comprehensive tests for CoverageToolDetector

### DIFF
--- a/src/DraftSpec.Cli/Coverage/CoverageToolDetector.cs
+++ b/src/DraftSpec.Cli/Coverage/CoverageToolDetector.cs
@@ -3,15 +3,25 @@ namespace DraftSpec.Cli.Coverage;
 /// <summary>
 /// Detects if dotnet-coverage tool is available.
 /// </summary>
-public static class CoverageToolDetector
+public class CoverageToolDetector
 {
-    private static bool? _isAvailable;
-    private static string? _version;
+    private readonly IProcessRunner _processRunner;
+    private bool? _isAvailable;
+    private string? _version;
+
+    /// <summary>
+    /// Creates a new CoverageToolDetector with an optional process runner.
+    /// </summary>
+    /// <param name="processRunner">Process runner for executing commands. Defaults to SystemProcessRunner.</param>
+    public CoverageToolDetector(IProcessRunner? processRunner = null)
+    {
+        _processRunner = processRunner ?? new SystemProcessRunner();
+    }
 
     /// <summary>
     /// Check if dotnet-coverage is installed and accessible.
     /// </summary>
-    public static bool IsAvailable
+    public bool IsAvailable
     {
         get
         {
@@ -26,7 +36,7 @@ public static class CoverageToolDetector
     /// <summary>
     /// Get the installed dotnet-coverage version, or null if not installed.
     /// </summary>
-    public static string? Version
+    public string? Version
     {
         get
         {
@@ -37,11 +47,11 @@ public static class CoverageToolDetector
         }
     }
 
-    private static void CheckAvailability()
+    private void CheckAvailability()
     {
         try
         {
-            var result = ProcessHelper.Run("dotnet-coverage", ["--version"]);
+            var result = _processRunner.Run("dotnet-coverage", ["--version"]);
             _isAvailable = result.Success;
             _version = result.Success ? result.Output.Trim() : null;
         }
@@ -50,14 +60,5 @@ public static class CoverageToolDetector
             _isAvailable = false;
             _version = null;
         }
-    }
-
-    /// <summary>
-    /// Reset the cached detection state. Used for testing.
-    /// </summary>
-    internal static void Reset()
-    {
-        _isAvailable = null;
-        _version = null;
     }
 }

--- a/tests/DraftSpec.Tests/Cli/Coverage/CoverageToolDetectorTests.cs
+++ b/tests/DraftSpec.Tests/Cli/Coverage/CoverageToolDetectorTests.cs
@@ -1,0 +1,201 @@
+using DraftSpec.Cli;
+using DraftSpec.Cli.Coverage;
+using DraftSpec.Tests.Infrastructure.Mocks;
+
+namespace DraftSpec.Tests.Cli.Coverage;
+
+public class CoverageToolDetectorTests
+{
+    [Test]
+    public async Task IsAvailable_WhenToolInstalled_ReturnsTrue()
+    {
+        // Arrange
+        var mockRunner = new MockProcessRunner();
+        mockRunner.AddResult(new ProcessResult("1.0.0", "", 0));
+        var detector = new CoverageToolDetector(mockRunner);
+
+        // Act
+        var result = detector.IsAvailable;
+
+        // Assert
+        await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task IsAvailable_WhenToolNotInstalled_ReturnsFalse()
+    {
+        // Arrange
+        var mockRunner = new MockProcessRunner();
+        mockRunner.AddResult(new ProcessResult("", "dotnet-coverage not found", 1));
+        var detector = new CoverageToolDetector(mockRunner);
+
+        // Act
+        var result = detector.IsAvailable;
+
+        // Assert
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task IsAvailable_WhenProcessThrows_ReturnsFalse()
+    {
+        // Arrange
+        var mockRunner = new MockProcessRunner { ThrowOnRun = true };
+        var detector = new CoverageToolDetector(mockRunner);
+
+        // Act
+        var result = detector.IsAvailable;
+
+        // Assert
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task IsAvailable_CachesResult_OnlyCallsProcessOnce()
+    {
+        // Arrange
+        var mockRunner = new MockProcessRunner();
+        mockRunner.AddResult(new ProcessResult("1.0.0", "", 0));
+        var detector = new CoverageToolDetector(mockRunner);
+
+        // Act
+        _ = detector.IsAvailable;
+        _ = detector.IsAvailable;
+        _ = detector.IsAvailable;
+
+        // Assert
+        await Assert.That(mockRunner.RunCalls).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task IsAvailable_CallsCorrectCommand()
+    {
+        // Arrange
+        var mockRunner = new MockProcessRunner();
+        mockRunner.AddResult(new ProcessResult("1.0.0", "", 0));
+        var detector = new CoverageToolDetector(mockRunner);
+
+        // Act
+        _ = detector.IsAvailable;
+
+        // Assert
+        await Assert.That(mockRunner.RunCalls).Count().IsEqualTo(1);
+        var (fileName, arguments) = mockRunner.RunCalls[0];
+        await Assert.That(fileName).IsEqualTo("dotnet-coverage");
+        await Assert.That(arguments).Contains("--version");
+    }
+
+    [Test]
+    public async Task Version_WhenToolInstalled_ReturnsTrimmedVersion()
+    {
+        // Arrange
+        var mockRunner = new MockProcessRunner();
+        mockRunner.AddResult(new ProcessResult("1.2.3\n", "", 0));
+        var detector = new CoverageToolDetector(mockRunner);
+
+        // Act
+        var result = detector.Version;
+
+        // Assert
+        await Assert.That(result).IsEqualTo("1.2.3");
+    }
+
+    [Test]
+    public async Task Version_WhenToolNotInstalled_ReturnsNull()
+    {
+        // Arrange
+        var mockRunner = new MockProcessRunner();
+        mockRunner.AddResult(new ProcessResult("", "not found", 1));
+        var detector = new CoverageToolDetector(mockRunner);
+
+        // Act
+        var result = detector.Version;
+
+        // Assert
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task Version_WithWhitespace_ReturnsTrimmedValue()
+    {
+        // Arrange
+        var mockRunner = new MockProcessRunner();
+        mockRunner.AddResult(new ProcessResult("  2.0.0  \r\n", "", 0));
+        var detector = new CoverageToolDetector(mockRunner);
+
+        // Act
+        var result = detector.Version;
+
+        // Assert
+        await Assert.That(result).IsEqualTo("2.0.0");
+    }
+
+    [Test]
+    public async Task Version_WhenProcessThrows_ReturnsNull()
+    {
+        // Arrange
+        var mockRunner = new MockProcessRunner { ThrowOnRun = true };
+        var detector = new CoverageToolDetector(mockRunner);
+
+        // Act
+        var result = detector.Version;
+
+        // Assert
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task Version_AccessBeforeIsAvailable_TriggersCheckAvailability()
+    {
+        // Arrange
+        var mockRunner = new MockProcessRunner();
+        mockRunner.AddResult(new ProcessResult("3.0.0", "", 0));
+        var detector = new CoverageToolDetector(mockRunner);
+
+        // Act - access Version first, before IsAvailable
+        var version = detector.Version;
+        var isAvailable = detector.IsAvailable;
+
+        // Assert
+        await Assert.That(mockRunner.RunCalls).Count().IsEqualTo(1);
+        await Assert.That(version).IsEqualTo("3.0.0");
+        await Assert.That(isAvailable).IsTrue();
+    }
+
+    [Test]
+    public async Task Version_AfterIsAvailableCall_DoesNotCallProcessAgain()
+    {
+        // Arrange
+        var mockRunner = new MockProcessRunner();
+        mockRunner.AddResult(new ProcessResult("1.5.0", "", 0));
+        var detector = new CoverageToolDetector(mockRunner);
+
+        // Act
+        _ = detector.IsAvailable;
+        var version = detector.Version;
+
+        // Assert
+        await Assert.That(mockRunner.RunCalls).Count().IsEqualTo(1);
+        await Assert.That(version).IsEqualTo("1.5.0");
+    }
+
+    [Test]
+    public async Task Constructor_WithNullProcessRunner_UsesDefaultRunner()
+    {
+        // Arrange & Act
+        var detector = new CoverageToolDetector(null);
+
+        // Assert - just verify it doesn't throw
+        await Assert.That(detector).IsNotNull();
+    }
+
+    [Test]
+    public async Task Constructor_WithDefaultParameter_CreatesSuccessfully()
+    {
+        // Arrange & Act
+        var detector = new CoverageToolDetector();
+
+        // Assert - just verify it doesn't throw
+        await Assert.That(detector).IsNotNull();
+    }
+}


### PR DESCRIPTION
## Summary

Refactor `CoverageToolDetector` from a static class to an instance-based class with `IProcessRunner` dependency injection to enable comprehensive unit testing.

## Changes

- **Refactored** `CoverageToolDetector` to accept `IProcessRunner` via constructor (optional, defaults to `SystemProcessRunner`)
- **Added** 13 comprehensive tests covering:
  - `IsAvailable` returning true/false based on tool availability
  - Version parsing with whitespace trimming
  - Caching behavior (process only called once)
  - Exception handling when process throws
  - Correct command execution (`dotnet-coverage --version`)
  - Constructor with null/default parameters

## Test plan

- [x] All 13 new tests pass
- [x] Full test suite passes (3,264 tests)
- [x] Husky pre-commit hooks pass (format, build)

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)