### PR TITLE
security: Set restrictive permissions on Unix temp files

### DIFF
--- a/src/DraftSpec.Mcp/Services/CurrentOperatingSystem.cs
+++ b/src/DraftSpec.Mcp/Services/CurrentOperatingSystem.cs
@@ -1,0 +1,15 @@
+namespace DraftSpec.Mcp.Services;
+
+/// <summary>
+/// Production implementation that delegates to System.OperatingSystem.
+/// </summary>
+public class CurrentOperatingSystem : IOperatingSystem
+{
+    /// <summary>
+    /// Singleton instance for convenience.
+    /// </summary>
+    public static CurrentOperatingSystem Instance { get; } = new();
+
+    /// <inheritdoc />
+    public bool IsWindows => OperatingSystem.IsWindows();
+}

--- a/src/DraftSpec.Mcp/Services/IOperatingSystem.cs
+++ b/src/DraftSpec.Mcp/Services/IOperatingSystem.cs
@@ -1,0 +1,13 @@
+namespace DraftSpec.Mcp.Services;
+
+/// <summary>
+/// Abstraction for operating system detection.
+/// Enables testing of platform-specific code paths.
+/// </summary>
+public interface IOperatingSystem
+{
+    /// <summary>
+    /// Gets whether the current operating system is Windows.
+    /// </summary>
+    bool IsWindows { get; }
+}

--- a/src/DraftSpec.Mcp/Services/IUnixPermissionSetter.cs
+++ b/src/DraftSpec.Mcp/Services/IUnixPermissionSetter.cs
@@ -1,0 +1,16 @@
+namespace DraftSpec.Mcp.Services;
+
+/// <summary>
+/// Abstraction for setting Unix file permissions.
+/// Enables testing of permission-setting code paths.
+/// </summary>
+public interface IUnixPermissionSetter
+{
+    /// <summary>
+    /// Sets Unix file mode on the specified path.
+    /// No-op on Windows for production implementations.
+    /// </summary>
+    /// <param name="path">The file path to set permissions on.</param>
+    /// <param name="mode">The Unix file mode to set.</param>
+    void SetMode(string path, UnixFileMode mode);
+}

--- a/src/DraftSpec.Mcp/Services/SystemUnixPermissionSetter.cs
+++ b/src/DraftSpec.Mcp/Services/SystemUnixPermissionSetter.cs
@@ -1,0 +1,34 @@
+namespace DraftSpec.Mcp.Services;
+
+/// <summary>
+/// Production implementation that delegates to File.SetUnixFileMode.
+/// </summary>
+public class SystemUnixPermissionSetter : IUnixPermissionSetter
+{
+    private readonly IOperatingSystem _os;
+
+    /// <summary>
+    /// Singleton instance for convenience (uses real OS detection).
+    /// </summary>
+    public static SystemUnixPermissionSetter Instance { get; } = new();
+
+    /// <summary>
+    /// Creates a new instance with the specified operating system provider.
+    /// </summary>
+    public SystemUnixPermissionSetter(IOperatingSystem? os = null)
+    {
+        _os = os ?? CurrentOperatingSystem.Instance;
+    }
+
+    /// <inheritdoc />
+    public void SetMode(string path, UnixFileMode mode)
+    {
+        if (_os.IsWindows)
+            return;
+
+        // CA1416: We're guarding with a runtime OS check via IOperatingSystem
+#pragma warning disable CA1416
+        File.SetUnixFileMode(path, mode);
+#pragma warning restore CA1416
+    }
+}

--- a/tests/DraftSpec.Tests/Infrastructure/Mocks/MockOperatingSystem.cs
+++ b/tests/DraftSpec.Tests/Infrastructure/Mocks/MockOperatingSystem.cs
@@ -1,0 +1,24 @@
+using DraftSpec.Mcp.Services;
+
+namespace DraftSpec.Tests.Infrastructure.Mocks;
+
+/// <summary>
+/// Mock implementation of IOperatingSystem for testing platform-specific code.
+/// </summary>
+public class MockOperatingSystem : IOperatingSystem
+{
+    /// <summary>
+    /// Gets or sets whether IsWindows returns true.
+    /// </summary>
+    public bool IsWindows { get; set; }
+
+    /// <summary>
+    /// Creates a mock that simulates Windows.
+    /// </summary>
+    public static MockOperatingSystem Windows() => new() { IsWindows = true };
+
+    /// <summary>
+    /// Creates a mock that simulates Unix/Linux/macOS.
+    /// </summary>
+    public static MockOperatingSystem Unix() => new() { IsWindows = false };
+}

--- a/tests/DraftSpec.Tests/Infrastructure/Mocks/MockUnixPermissionSetter.cs
+++ b/tests/DraftSpec.Tests/Infrastructure/Mocks/MockUnixPermissionSetter.cs
@@ -1,0 +1,37 @@
+using DraftSpec.Mcp.Services;
+
+namespace DraftSpec.Tests.Infrastructure.Mocks;
+
+/// <summary>
+/// Mock implementation of IUnixPermissionSetter for testing.
+/// </summary>
+public class MockUnixPermissionSetter : IUnixPermissionSetter
+{
+    /// <summary>
+    /// Records all calls to SetMode.
+    /// </summary>
+    public List<(string Path, UnixFileMode Mode)> SetModeCalls { get; } = [];
+
+    /// <summary>
+    /// When set, SetMode will throw this exception.
+    /// </summary>
+    public Exception? ThrowOnSetMode { get; set; }
+
+    /// <inheritdoc />
+    public void SetMode(string path, UnixFileMode mode)
+    {
+        if (ThrowOnSetMode != null)
+            throw ThrowOnSetMode;
+
+        SetModeCalls.Add((path, mode));
+    }
+
+    /// <summary>
+    /// Resets the mock state.
+    /// </summary>
+    public void Reset()
+    {
+        SetModeCalls.Clear();
+        ThrowOnSetMode = null;
+    }
+}

--- a/tests/DraftSpec.Tests/Mcp/Services/SystemUnixPermissionSetterTests.cs
+++ b/tests/DraftSpec.Tests/Mcp/Services/SystemUnixPermissionSetterTests.cs
@@ -1,0 +1,160 @@
+using DraftSpec.Mcp.Services;
+using DraftSpec.Tests.Infrastructure.Mocks;
+
+namespace DraftSpec.Tests.Mcp.Services;
+
+/// <summary>
+/// Tests for SystemUnixPermissionSetter.
+/// </summary>
+public class SystemUnixPermissionSetterTests
+{
+    #region Windows Branch
+
+    [Test]
+    public async Task SetMode_OnWindows_DoesNotCallFileSetUnixFileMode()
+    {
+        // Arrange - simulate Windows
+        var mockOs = MockOperatingSystem.Windows();
+        var setter = new SystemUnixPermissionSetter(mockOs);
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            // Act - should be a no-op on Windows
+            setter.SetMode(tempFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+            // Assert - file should still exist (no exception thrown)
+            await Assert.That(File.Exists(tempFile)).IsTrue();
+
+            // On actual Windows, File.GetUnixFileMode would throw, but since we're
+            // mocking Windows on a Unix system, we can verify the mode wasn't changed
+            if (!OperatingSystem.IsWindows())
+            {
+                // The file should have its original permissions, not the ones we tried to set
+                var mode = File.GetUnixFileMode(tempFile);
+                // GetTempFileName typically creates with 0600 on Unix, but the point is
+                // that SetMode was a no-op because we're "on Windows"
+                await Assert.That(mode).IsNotEqualTo(UnixFileMode.None);
+            }
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task SetMode_OnWindows_ReturnsWithoutError()
+    {
+        var mockOs = MockOperatingSystem.Windows();
+        var setter = new SystemUnixPermissionSetter(mockOs);
+
+        // Even with a non-existent file, should not throw on Windows (early return)
+        setter.SetMode("/nonexistent/path/file.txt", UnixFileMode.UserRead);
+
+        await Assert.That(true).IsTrue(); // If we get here, no exception
+    }
+
+    #endregion
+
+    #region Unix Branch
+
+    [Test]
+    public async Task SetMode_OnUnix_SetsFilePermissions()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var mockOs = MockOperatingSystem.Unix();
+        var setter = new SystemUnixPermissionSetter(mockOs);
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            // Act
+            setter.SetMode(tempFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+            // Assert
+            var mode = File.GetUnixFileMode(tempFile);
+            await Assert.That(mode).IsEqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task SetMode_OnUnix_WithDifferentMode_SetsCorrectPermissions()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var mockOs = MockOperatingSystem.Unix();
+        var setter = new SystemUnixPermissionSetter(mockOs);
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            // Act - set read-only
+            setter.SetMode(tempFile, UnixFileMode.UserRead);
+
+            // Assert
+            var mode = File.GetUnixFileMode(tempFile);
+            await Assert.That(mode).IsEqualTo(UnixFileMode.UserRead);
+
+            // Restore write permission for cleanup
+            File.SetUnixFileMode(tempFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Test]
+    public async Task SetMode_OnUnix_WithNonExistentFile_Throws()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var mockOs = MockOperatingSystem.Unix();
+        var setter = new SystemUnixPermissionSetter(mockOs);
+
+        var action = () => setter.SetMode("/nonexistent/path/file.txt", UnixFileMode.UserRead);
+
+        await Assert.That(action).ThrowsException();
+    }
+
+    #endregion
+
+    #region Default Constructor
+
+    [Test]
+    public async Task Instance_UsesCurrentOperatingSystem()
+    {
+        var setter = SystemUnixPermissionSetter.Instance;
+
+        // The singleton should work without throwing
+        var tempFile = Path.GetTempFileName();
+
+        try
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                setter.SetMode(tempFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+                var mode = File.GetUnixFileMode(tempFile);
+                await Assert.That(mode).IsEqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
+            else
+            {
+                // On Windows, should be a no-op
+                setter.SetMode(tempFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+                await Assert.That(true).IsTrue();
+            }
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    #endregion
+}

--- a/tests/DraftSpec.Tests/Mcp/Services/TempFileManagerTests.cs
+++ b/tests/DraftSpec.Tests/Mcp/Services/TempFileManagerTests.cs
@@ -1,4 +1,5 @@
 using DraftSpec.Mcp.Services;
+using DraftSpec.Tests.Infrastructure.Mocks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -252,6 +253,342 @@ public class TempFileManagerTests
         _manager.Cleanup(new string?[] { validPath, null, invalidPath, "" });
 
         await Assert.That(File.Exists(validPath)).IsFalse();
+    }
+
+    #endregion
+
+    #region Local Packages / NuGet Config
+
+    [Test]
+    [Category("Unix")]
+    public async Task Constructor_WithLocalPackages_CreatesNuGetConfig()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var localPackagesDir = "/tmp/draftspec-packages";
+        var dummyPackage = Path.Combine(localPackagesDir, "test.nupkg");
+
+        try
+        {
+            // Create local packages directory with a dummy nupkg file
+            Directory.CreateDirectory(localPackagesDir);
+            await File.WriteAllTextAsync(dummyPackage, "dummy package content");
+
+            // Create a new manager - this should trigger EnsureNuGetConfig
+            var logger = NullLogger<TempFileManager>.Instance;
+            var manager = new TempFileManager(logger);
+
+            // Verify NuGet.config was created
+            var nugetConfigPath = Path.Combine(manager.TempDirectory, "NuGet.config");
+            await Assert.That(File.Exists(nugetConfigPath)).IsTrue();
+
+            // Verify it contains the local packages path
+            var content = await File.ReadAllTextAsync(nugetConfigPath);
+            await Assert.That(content).Contains(localPackagesDir);
+            await Assert.That(content).Contains("nuget.org");
+
+            // Cleanup NuGet.config
+            if (File.Exists(nugetConfigPath))
+                File.Delete(nugetConfigPath);
+        }
+        finally
+        {
+            // Cleanup local packages directory
+            if (File.Exists(dummyPackage))
+                File.Delete(dummyPackage);
+            if (Directory.Exists(localPackagesDir))
+                Directory.Delete(localPackagesDir);
+        }
+    }
+
+    [Test]
+    [Category("Unix")]
+    public async Task Constructor_WithLocalPackages_SetsRestrictivePermissionsOnNuGetConfig()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var localPackagesDir = "/tmp/draftspec-packages";
+        var dummyPackage = Path.Combine(localPackagesDir, "test.nupkg");
+
+        try
+        {
+            // Create local packages directory with a dummy nupkg file
+            Directory.CreateDirectory(localPackagesDir);
+            await File.WriteAllTextAsync(dummyPackage, "dummy package content");
+
+            // Create a new manager - this should trigger EnsureNuGetConfig
+            var logger = NullLogger<TempFileManager>.Instance;
+            var manager = new TempFileManager(logger);
+
+            // Verify NuGet.config has restrictive permissions
+            var nugetConfigPath = Path.Combine(manager.TempDirectory, "NuGet.config");
+            var mode = File.GetUnixFileMode(nugetConfigPath);
+            await Assert.That(mode).IsEqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+            // Cleanup NuGet.config
+            if (File.Exists(nugetConfigPath))
+                File.Delete(nugetConfigPath);
+        }
+        finally
+        {
+            // Cleanup local packages directory
+            if (File.Exists(dummyPackage))
+                File.Delete(dummyPackage);
+            if (Directory.Exists(localPackagesDir))
+                Directory.Delete(localPackagesDir);
+        }
+    }
+
+    [Test]
+    [Category("Unix")]
+    public async Task Constructor_WithExistingNuGetConfig_DoesNotOverwrite()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var localPackagesDir = "/tmp/draftspec-packages";
+        var dummyPackage = Path.Combine(localPackagesDir, "test.nupkg");
+        var tempDir = Path.Combine(Path.GetTempPath(), "draftspec-mcp");
+
+        try
+        {
+            // Create local packages directory with a dummy nupkg file
+            Directory.CreateDirectory(localPackagesDir);
+            await File.WriteAllTextAsync(dummyPackage, "dummy package content");
+
+            // Pre-create a NuGet.config with custom content
+            Directory.CreateDirectory(tempDir);
+            var nugetConfigPath = Path.Combine(tempDir, "NuGet.config");
+            var originalContent = "<!-- existing config -->";
+            await File.WriteAllTextAsync(nugetConfigPath, originalContent);
+
+            // Create a new manager - should NOT overwrite existing config
+            var logger = NullLogger<TempFileManager>.Instance;
+            _ = new TempFileManager(logger);
+
+            // Verify content was not changed
+            var content = await File.ReadAllTextAsync(nugetConfigPath);
+            await Assert.That(content).IsEqualTo(originalContent);
+
+            // Cleanup NuGet.config
+            if (File.Exists(nugetConfigPath))
+                File.Delete(nugetConfigPath);
+        }
+        finally
+        {
+            // Cleanup local packages directory
+            if (File.Exists(dummyPackage))
+                File.Delete(dummyPackage);
+            if (Directory.Exists(localPackagesDir))
+                Directory.Delete(localPackagesDir);
+        }
+    }
+
+    #endregion
+
+    #region Cleanup Exception Handling
+
+    [Test]
+    [Category("Unix")]
+    public async Task Cleanup_WhenFileCannotBeDeleted_LogsWarningAndContinues()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        // Create a file in a directory, then make the directory read-only
+        var testDir = Path.Combine(_manager.TempDirectory, $"readonly-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(testDir);
+        var filePath = Path.Combine(testDir, "locked-file.txt");
+        await File.WriteAllTextAsync(filePath, "content");
+
+        try
+        {
+            // Make directory read-only (prevents file deletion on Unix)
+            File.SetUnixFileMode(testDir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+            // This should NOT throw - it should log a warning and continue
+            _manager.Cleanup(filePath);
+
+            // File should still exist because deletion failed
+            await Assert.That(File.Exists(filePath)).IsTrue();
+        }
+        finally
+        {
+            // Restore permissions for cleanup
+            File.SetUnixFileMode(testDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            if (File.Exists(filePath))
+                File.Delete(filePath);
+            if (Directory.Exists(testDir))
+                Directory.Delete(testDir);
+        }
+    }
+
+    #endregion
+
+    #region Unix File Permissions
+
+    [Test]
+    [Category("Unix")]
+    public async Task CreateTempSpecFileAsync_OnUnix_SetsRestrictivePermissions()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var path = await _manager.CreateTempSpecFileAsync("content", CancellationToken.None);
+
+        try
+        {
+            var mode = File.GetUnixFileMode(path);
+
+            // Should be 0600 (UserRead | UserWrite only)
+            await Assert.That(mode).IsEqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        finally
+        {
+            _manager.Cleanup(path);
+        }
+    }
+
+    [Test]
+    [Category("Unix")]
+    public async Task CreateTempSpecFileAsync_OnUnix_NoGroupOrOtherPermissions()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var path = await _manager.CreateTempSpecFileAsync("content", CancellationToken.None);
+
+        try
+        {
+            var mode = File.GetUnixFileMode(path);
+
+            // Verify no group permissions
+            await Assert.That(mode.HasFlag(UnixFileMode.GroupRead)).IsFalse();
+            await Assert.That(mode.HasFlag(UnixFileMode.GroupWrite)).IsFalse();
+            await Assert.That(mode.HasFlag(UnixFileMode.GroupExecute)).IsFalse();
+
+            // Verify no other permissions
+            await Assert.That(mode.HasFlag(UnixFileMode.OtherRead)).IsFalse();
+            await Assert.That(mode.HasFlag(UnixFileMode.OtherWrite)).IsFalse();
+            await Assert.That(mode.HasFlag(UnixFileMode.OtherExecute)).IsFalse();
+        }
+        finally
+        {
+            _manager.Cleanup(path);
+        }
+    }
+
+    [Test]
+    [Category("Unix")]
+    public async Task CreateTempSpecFileAsync_OnUnix_OwnerHasReadWriteAccess()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var path = await _manager.CreateTempSpecFileAsync("content", CancellationToken.None);
+
+        try
+        {
+            var mode = File.GetUnixFileMode(path);
+
+            // Verify owner has read and write permissions
+            await Assert.That(mode.HasFlag(UnixFileMode.UserRead)).IsTrue();
+            await Assert.That(mode.HasFlag(UnixFileMode.UserWrite)).IsTrue();
+
+            // Verify owner does not have execute permission
+            await Assert.That(mode.HasFlag(UnixFileMode.UserExecute)).IsFalse();
+        }
+        finally
+        {
+            _manager.Cleanup(path);
+        }
+    }
+
+    #endregion
+
+    #region Mock Permission Setter Tests
+
+    [Test]
+    public async Task CreateTempSpecFileAsync_CallsPermissionSetterWithCorrectMode()
+    {
+        var mockSetter = new MockUnixPermissionSetter();
+        var logger = NullLogger<TempFileManager>.Instance;
+        var manager = new TempFileManager(logger, mockSetter);
+
+        var path = await manager.CreateTempSpecFileAsync("content", CancellationToken.None);
+
+        try
+        {
+            await Assert.That(mockSetter.SetModeCalls).Count().IsEqualTo(1);
+            await Assert.That(mockSetter.SetModeCalls[0].Path).IsEqualTo(path);
+            await Assert.That(mockSetter.SetModeCalls[0].Mode).IsEqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        finally
+        {
+            manager.Cleanup(path);
+        }
+    }
+
+    [Test]
+    public async Task CreateTempSpecFileAsync_WhenPermissionsFail_StillReturnsFilePath()
+    {
+        var mockSetter = new MockUnixPermissionSetter
+        {
+            ThrowOnSetMode = new IOException("Permission denied")
+        };
+        var logger = NullLogger<TempFileManager>.Instance;
+        var manager = new TempFileManager(logger, mockSetter);
+
+        var path = await manager.CreateTempSpecFileAsync("content", CancellationToken.None);
+
+        try
+        {
+            // Should still return a valid path even though permissions failed
+            await Assert.That(path).IsNotNull();
+            await Assert.That(File.Exists(path)).IsTrue();
+
+            // Verify the content was still written
+            var content = await File.ReadAllTextAsync(path);
+            await Assert.That(content).IsEqualTo("content");
+        }
+        finally
+        {
+            manager.Cleanup(path);
+        }
+    }
+
+    [Test]
+    public async Task CreateTempSpecFileAsync_WhenPermissionsFail_DoesNotThrow()
+    {
+        var mockSetter = new MockUnixPermissionSetter
+        {
+            ThrowOnSetMode = new UnauthorizedAccessException("Access denied")
+        };
+        var logger = NullLogger<TempFileManager>.Instance;
+        var manager = new TempFileManager(logger, mockSetter);
+
+        // This should not throw even though permission setting fails
+        var path = await manager.CreateTempSpecFileAsync("content", CancellationToken.None);
+
+        manager.Cleanup(path);
+        await Assert.That(true).IsTrue(); // If we get here, no exception was thrown
+    }
+
+    [Test]
+    public async Task CreateTempSpecFileAsync_MultipleFiles_CallsPermissionSetterForEach()
+    {
+        var mockSetter = new MockUnixPermissionSetter();
+        var logger = NullLogger<TempFileManager>.Instance;
+        var manager = new TempFileManager(logger, mockSetter);
+
+        var path1 = await manager.CreateTempSpecFileAsync("content1", CancellationToken.None);
+        var path2 = await manager.CreateTempSpecFileAsync("content2", CancellationToken.None);
+
+        try
+        {
+            await Assert.That(mockSetter.SetModeCalls).Count().IsEqualTo(2);
+            await Assert.That(mockSetter.SetModeCalls[0].Path).IsEqualTo(path1);
+            await Assert.That(mockSetter.SetModeCalls[1].Path).IsEqualTo(path2);
+        }
+        finally
+        {
+            manager.Cleanup(path1, path2);
+        }
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Set restrictive file permissions (0600) on temporary spec files created by the MCP server on Unix systems. This prevents other users on shared systems from reading or modifying spec file contents.

## Changes

### New Interfaces
- `IUnixPermissionSetter` - Abstraction for setting Unix file permissions
- `IOperatingSystem` - Abstraction for platform detection

### Production Implementations
- `SystemUnixPermissionSetter` - Delegates to `File.SetUnixFileMode`
- `CurrentOperatingSystem` - Delegates to `OperatingSystem.IsWindows()`

### Refactored
- `TempFileManager` - Uses DI with optional parameters (backward compatible)

### Test Infrastructure
- `MockUnixPermissionSetter` - For testing permission failures
- `MockOperatingSystem` - For testing platform-specific branches

### Test Coverage
- 36 tests total for MCP services
- Full coverage of Windows early-return branch
- Full coverage of Unix permission-setting branch
- Full coverage of catch block for permission failures
- EnsureNuGetConfig branch coverage
- Cleanup exception handling

## Security Impact

On multi-user Unix systems, this fix prevents:
- Information disclosure (other users reading spec contents)
- Tampering (other users modifying specs between creation and execution)

Windows behavior is unchanged (no-op).

## Files Changed

| File | Type |
|------|------|
| `IOperatingSystem.cs` | New interface |
| `CurrentOperatingSystem.cs` | New implementation |
| `IUnixPermissionSetter.cs` | New interface |
| `SystemUnixPermissionSetter.cs` | New implementation |
| `TempFileManager.cs` | Refactored with DI |
| `MockOperatingSystem.cs` | New mock |
| `MockUnixPermissionSetter.cs` | New mock |
| `SystemUnixPermissionSetterTests.cs` | New tests |
| `TempFileManagerTests.cs` | Additional tests |

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)