### PR TITLE
fix(ci): Only run TruffleHog secrets scan on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
           echo "::notice::No known vulnerabilities found in NuGet dependencies"
 
       - name: Scan for secrets
-        if: matrix.os == 'ubuntu-latest'
+        # Only scan on PRs - on pushes to main, base and HEAD are the same commit
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
         uses: trufflesecurity/trufflehog@ef6e76c3c4023279497fab4721ffa071a722fd05 # v3.92.4
         with:
           path: ./

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -38,6 +38,7 @@ jobs:
             scripting
             formatters
             deps
+            ci
           # Require scope to be one of the listed values (if provided)
           requireScope: false
           # Allow breaking change indicator (!)


### PR DESCRIPTION
## Summary

TruffleHog secrets scanning fails on pushes to main because the base and HEAD commits are identical after a PR merge. This causes the CI to fail with:

> "BASE and HEAD commits are the same. TruffleHog won't scan anything."

The fix restricts secret scanning to only run on pull requests, where it's most useful anyway (scanning new code being introduced).

Fixes the failure in: https://github.com/juvistr/draftspec/actions/runs/20658924434/job/59323298310

🤖 Generated with [Claude Code](https://claude.com/claude-code)