### PR TITLE
security(ci): Fix injection vulnerabilities and reduce permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,10 +33,11 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
           # Strip 'v' prefix (v0.1.0-alpha.3 -> 0.1.0-alpha.3)
-          VERSION="${TAG#v}"
+          VERSION="${RELEASE_TAG#v}"
 
           # Validate version is not empty
           if [ -z "$VERSION" ]; then
@@ -56,7 +57,9 @@ jobs:
         run: dotnet restore --locked-mode
 
       - name: Build
-        run: dotnet build --no-restore -c Release -p:MinVerVersionOverride=${{ steps.version.outputs.version }}
+        env:
+          MINVER_VERSION: ${{ steps.version.outputs.version }}
+        run: dotnet build --no-restore -c Release -p:MinVerVersionOverride="$MINVER_VERSION"
 
       - name: Run unit tests
         run: dotnet run --project tests/DraftSpec.Tests --no-build -c Release
@@ -65,7 +68,9 @@ jobs:
         run: dotnet run --project tests/DraftSpec.Cli.IntegrationTests --no-build -c Release
 
       - name: Pack
-        run: dotnet pack --no-build -c Release -p:MinVerVersionOverride=${{ steps.version.outputs.version }}
+        env:
+          MINVER_VERSION: ${{ steps.version.outputs.version }}
+        run: dotnet pack --no-build -c Release -p:MinVerVersionOverride="$MINVER_VERSION"
 
       - name: Display packages
         run: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,7 +8,9 @@ on:
     - cron: '0 2 * * 1' # Weekly on Monday at 2am UTC
   workflow_dispatch:
 
-permissions: read-all
+# Minimal permissions - job-level permissions handle security-events and id-token
+permissions:
+  contents: read
 
 jobs:
   analysis:


### PR DESCRIPTION
## Summary

This PR addresses two high-priority security issues identified in the CI/CD review:

### 1. Fix injection vulnerability in publish.yml (#394)

**Before:** Version parameters were interpolated directly into shell commands:
```yaml
run: dotnet build ... -p:MinVerVersionOverride=${{ steps.version.outputs.version }}
```

**After:** Use environment variables to prevent potential command injection:
```yaml
env:
  MINVER_VERSION: ${{ steps.version.outputs.version }}
run: dotnet build ... -p:MinVerVersionOverride="$MINVER_VERSION"
```

### 2. Fix overly permissive permissions in scorecard.yml (#395)

**Before:** Top-level `permissions: read-all` granted more access than needed.

**After:** Minimal `permissions: contents: read` at top level - job-level permissions already handle `security-events: write` and `id-token: write`.

## Test Plan

- [ ] CI passes on all platforms
- [ ] Verify publish workflow syntax is valid (workflow_dispatch dry run if desired)

Closes #394
Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)