### PR TITLE
chore(ci): Improve CI reliability and performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
         run: dotnet format --no-restore --verify-no-changes --verbosity diagnostic
 
       - name: Run tests with coverage
+        timeout-minutes: 15
         run: |
           dotnet run --project tests/DraftSpec.Tests -c Release -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --report-trx --report-trx-filename test-results.trx
 
@@ -81,8 +82,20 @@ jobs:
           trx2junit tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/test-results.trx --output tests/DraftSpec.Tests/bin/Release/net10.0/TestResults
 
       - name: Run CLI integration tests
+        timeout-minutes: 10
         run: |
           dotnet run --project tests/DraftSpec.Cli.IntegrationTests -c Release
+
+      - name: Upload test results on failure
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: test-results-${{ matrix.os }}
+          path: |
+            tests/**/TestResults/*.trx
+            tests/**/TestResults/*.xml
+          retention-days: 14
+          if-no-files-found: ignore
 
       - name: Generate coverage report
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,14 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Cache NuGet packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Restore dependencies
         run: dotnet restore --locked-mode
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Dependency Review
         uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4


### PR DESCRIPTION
## Summary

This PR implements 4 CI improvements identified in the CI/CD review:

### 1. Standardize checkout action SHA (#396)
- Updated `dependency-review.yml` from v4 SHA to v6 SHA
- All workflows now use the same checkout version: `@8e8c483db84b4bee98b60c0593521ed34d9990e8`

### 2. Add test execution timeouts (#397)
- Unit tests: 15 minute timeout
- Integration tests: 10 minute timeout
- Prevents CI from hanging indefinitely if a test gets stuck

### 3. Upload test results on failure (#398)
- New artifact upload step with `if: always()`
- Uploads TRX and XML test results for all platforms
- 14-day retention for debugging failed runs
- Uses `if-no-files-found: ignore` to handle cases where tests don't run

### 4. Add NuGet cache to CodeQL (#399)
- Added NuGet package caching to `codeql.yml`
- Uses same cache configuration as `ci.yml`
- Improves CodeQL build performance

## Test Plan

- [ ] CI passes on all platforms
- [ ] CodeQL workflow completes faster with cache hits
- [ ] Test results artifact is created (check Actions artifacts)

Closes #396
Closes #397
Closes #398
Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)