### PR TITLE
security(ci): Refine workflow permissions for least privilege

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,15 +15,13 @@ permissions:
   contents: read
 
 jobs:
-  publish:
+  build-test-pack:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write  # Required for uploading assets to release
-      id-token: write  # Required for provenance attestation
-      attestations: write  # Required for provenance attestation
-    environment: nuget  # Requires approval for production pushes
     # Only run for releases targeting main (or manual dispatch)
     if: github.event_name == 'workflow_dispatch' || github.event.release.target_commitish == 'main'
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -77,16 +75,45 @@ jobs:
           echo "Packages to publish:"
           find src -name "*.nupkg" -type f | grep -v obj
 
+      - name: Upload packages as artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nuget-packages
+          path: src/*/bin/Release/*.nupkg
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: build-test-pack
+    permissions:
+      contents: write  # Required for uploading assets to release
+      id-token: write  # Required for provenance attestation
+      attestations: write  # Required for provenance attestation
+    environment: nuget  # Requires approval for production pushes
+
+    steps:
+      - name: Download packages
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: nuget-packages
+          path: packages
+
+      - name: Display downloaded packages
+        run: |
+          echo "Downloaded packages:"
+          find packages -name "*.nupkg" -type f
+
       - name: Generate provenance attestation
         if: github.event_name == 'release' && !inputs.dry_run
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-path: 'src/*/bin/Release/*.nupkg'
+          subject-path: 'packages/*.nupkg'
 
       - name: Publish to NuGet
         if: ${{ !inputs.dry_run }}
         run: |
-          for pkg in $(find src -name "*.nupkg" -type f | grep -v obj); do
+          for pkg in $(find packages -name "*.nupkg" -type f); do
             echo "Publishing $pkg"
             dotnet nuget push "$pkg" \
               --api-key ${{ secrets.NUGET_API_KEY }} \
@@ -100,4 +127,4 @@ jobs:
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |
-            src/*/bin/Release/*.nupkg
+            packages/*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,13 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+*'  # Matches v1.0.0, v1.0.0-alpha.1, etc.
 
 permissions:
-  contents: write  # Required to create releases
+  contents: read
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to create releases
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6


### PR DESCRIPTION
## Summary

Addresses OpenSSF Security Scorecard Token Permissions warnings by refining workflow permissions to follow the principle of least privilege.

### Changes

**release.yml**
- Move `contents: write` from top-level to job-level permissions

**publish.yml** 
- Split single job into two jobs:
  - `build-test-pack`: Read-only permissions (checkout, build, test, pack, upload artifacts)
  - `publish-release`: Write permissions only where needed (attestation, NuGet publish, release upload)
- Uses artifact upload/download to pass packages between jobs

### Security Improvements

| Workflow | Before | After |
|----------|--------|-------|
| release.yml | Top-level `contents: write` | Job-level `contents: write` |
| publish.yml | Single job with write permissions for all steps | Build job (read-only) → Publish job (write) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)