### PR TITLE
fix(ci): Use recursive glob for nested package paths

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,7 +107,7 @@ jobs:
         if: github.event_name == 'push' && !inputs.dry_run
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-path: 'packages/*.nupkg'
+          subject-path: 'packages/**/*.nupkg'
 
       - name: Publish to NuGet
         if: ${{ !inputs.dry_run }}
@@ -126,4 +126,4 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           files: |
-            packages/*.nupkg
+            packages/**/*.nupkg


### PR DESCRIPTION
## Summary
- Changed `packages/*.nupkg` to `packages/**/*.nupkg` for attestation and release upload steps
- The artifact upload preserves directory structure, so packages end up at `packages/*/bin/Release/*.nupkg`

This was causing the v0.8.0-alpha.1 publish to fail at the attestation step.

Fixes publish workflow for nested package paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)