### PR TITLE
chore(ci): skip codecov checks for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,10 +186,48 @@ jobs:
             src/*/bin/Release/*.snupkg
           retention-days: 7
 
+  # Lean coverage job for docs-only PRs - just enough to satisfy codecov requirement
+  coverage-baseline:
+    needs: changes
+    if: needs.changes.outputs.code != 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@2016bd2012dba4e32de620c46fe006a3ac9f0602 # v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore and build
+        run: |
+          dotnet restore --locked-mode
+          dotnet build -c Release --no-restore
+
+      - name: Run tests with coverage
+        run: |
+          dotnet run --project tests/DraftSpec.Tests -c Release --no-build -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: tests/DraftSpec.Tests/bin/Release/net10.0/TestResults/coverage.cobertura.xml
+          fail_ci_if_error: false  # Don't fail docs PRs on coverage issues
+
   # Summary job for branch protection - provides single "build-summary" status
   build-summary:
     if: always()
-    needs: [changes, build]
+    needs: [changes, build, coverage-baseline]
     runs-on: ubuntu-latest
     steps:
       - name: Check build matrix status

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,11 +10,20 @@ coverage:
         if_ci_failed: error
         # Post success if no base report exists (new repo/branch)
         if_not_found: success
+        # Post success if no coverage uploads (docs-only PRs skip build)
+        if_no_uploads: success
     patch:
       default:
         target: 90%
         threshold: 2%
         if_not_found: success
+        # Post success if no coverage uploads (docs-only PRs skip build)
+        if_no_uploads: success
+
+# Only track coverage for source code files
+paths:
+  - "src/**"
+  - "tests/**"
 
 # Explicitly enable GitHub Checks (default, but being explicit)
 github_checks: true


### PR DESCRIPTION
## Summary

Add a lean `coverage-baseline` job for docs-only PRs to satisfy the required `codecov/patch` status check.

## Problem

When docs-only PRs skip the full build matrix, no coverage is uploaded to codecov. Since `codecov/patch` is a required status check, it remains in "expected - waiting" state and blocks merging.

## Solution

Add a `coverage-baseline` job that runs **only** when code files aren't changed:

| Aspect | Full Build | Coverage Baseline |
|--------|-----------|-------------------|
| Runners | 3 (ubuntu, windows, macos) | 1 (ubuntu only) |
| Tests | Unit + Integration | Unit only |
| Checks | Format, audit, secrets, etc. | None |
| Artifacts | Packages, reports | None |
| Purpose | Full validation | Satisfy codecov |

This ensures codecov always receives coverage data and can post a status.

## Changes

**`.github/workflows/ci.yml`**:
```yaml
coverage-baseline:
  needs: changes
  if: needs.changes.outputs.code != 'true'  # Only for docs-only PRs
  runs-on: ubuntu-latest
  steps:
    - # checkout, setup .NET, restore, build
    - # Run unit tests with coverage
    - # Upload to codecov
```

**`codecov.yml`**:
- Add `if_no_uploads: success` as fallback
- Add paths filter for `src/**` and `tests/**`

## Test Plan

- [ ] This PR triggers full build (workflow file changed)
- [ ] After merge, verify docs PR #429 runs `coverage-baseline` and codecov posts status
- [ ] Verify docs-only PRs can be merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)