### PR TITLE
fix(ci): add fetch-depth to coverage-baseline job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          fetch-depth: 0  # Full history for git-dependent tests
 
       - name: Setup .NET
         uses: actions/setup-dotnet@2016bd2012dba4e32de620c46fe006a3ac9f0602 # v5


### PR DESCRIPTION
## Summary

Fixes coverage-baseline job failure due to shallow checkout. Git-dependent tests require full history to run `git diff HEAD~1` commands.

## Test plan

- [ ] coverage-baseline job passes on docs-only PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)