### PR TITLE
feat(cli): add command pipeline infrastructure

### DIFF
--- a/src/DraftSpec.Cli/Pipeline/CommandContext.cs
+++ b/src/DraftSpec.Cli/Pipeline/CommandContext.cs
@@ -1,0 +1,51 @@
+namespace DraftSpec.Cli.Pipeline;
+
+/// <summary>
+/// Context passed through the command pipeline, providing access to
+/// input path, I/O abstractions, and phase-to-phase communication.
+/// </summary>
+/// <remarks>
+/// Uses composition over inheritance: a single flat context with an Items
+/// dictionary rather than a type hierarchy. This avoids fragile base class
+/// problems and keeps all phases using the same non-generic interface.
+/// </remarks>
+public class CommandContext
+{
+    /// <summary>
+    /// The input path provided to the command (file or directory).
+    /// </summary>
+    public required string Path { get; init; }
+
+    /// <summary>
+    /// Console abstraction for output.
+    /// </summary>
+    public required IConsole Console { get; init; }
+
+    /// <summary>
+    /// File system abstraction for I/O operations.
+    /// </summary>
+    public required IFileSystem FileSystem { get; init; }
+
+    /// <summary>
+    /// Dictionary for phase-to-phase communication.
+    /// Use <see cref="Get{T}"/> and <see cref="Set{T}"/> for type-safe access,
+    /// or <see cref="ContextKeys"/> for well-known keys.
+    /// </summary>
+    public IDictionary<string, object?> Items { get; } = new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Get a typed value from the Items dictionary.
+    /// </summary>
+    /// <typeparam name="T">Expected type of the value.</typeparam>
+    /// <param name="key">The key to look up.</param>
+    /// <returns>The value cast to T, or default if not found.</returns>
+    public T? Get<T>(string key) => Items.TryGetValue(key, out var v) ? (T?)v : default;
+
+    /// <summary>
+    /// Set a typed value in the Items dictionary.
+    /// </summary>
+    /// <typeparam name="T">Type of the value.</typeparam>
+    /// <param name="key">The key to store under.</param>
+    /// <param name="value">The value to store.</param>
+    public void Set<T>(string key, T value) => Items[key] = value;
+}

--- a/src/DraftSpec.Cli/Pipeline/CommandPipelineBuilder.cs
+++ b/src/DraftSpec.Cli/Pipeline/CommandPipelineBuilder.cs
@@ -1,0 +1,74 @@
+namespace DraftSpec.Cli.Pipeline;
+
+/// <summary>
+/// Fluent builder for composing command phases into an executable pipeline delegate.
+/// </summary>
+/// <remarks>
+/// Mirrors the middleware pattern from <c>SpecRunner</c>. Phases execute in
+/// registration order: first added executes first, last added executes last.
+/// </remarks>
+/// <example>
+/// <code>
+/// var pipeline = new CommandPipelineBuilder()
+///     .Use(pathResolutionPhase)
+///     .Use(specDiscoveryPhase)
+///     .UseWhen(ctx => ctx.Get&lt;bool&gt;(ContextKeys.Quarantine), quarantinePhase)
+///     .Use(specExecutionPhase)
+///     .Build();
+///
+/// var exitCode = await pipeline(context, cancellationToken);
+/// </code>
+/// </example>
+public class CommandPipelineBuilder
+{
+    private readonly List<ICommandPhase> _phases = [];
+
+    /// <summary>
+    /// Add a phase to the pipeline.
+    /// </summary>
+    /// <param name="phase">The phase to add.</param>
+    /// <returns>This builder for method chaining.</returns>
+    public CommandPipelineBuilder Use(ICommandPhase phase)
+    {
+        ArgumentNullException.ThrowIfNull(phase);
+        _phases.Add(phase);
+        return this;
+    }
+
+    /// <summary>
+    /// Add a phase that only executes when the predicate returns true.
+    /// </summary>
+    /// <param name="predicate">Condition to evaluate against the context.</param>
+    /// <param name="phase">The phase to conditionally execute.</param>
+    /// <returns>This builder for method chaining.</returns>
+    public CommandPipelineBuilder UseWhen(Func<CommandContext, bool> predicate, ICommandPhase phase)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(phase);
+        _phases.Add(new ConditionalPhase(predicate, phase));
+        return this;
+    }
+
+    /// <summary>
+    /// Build the pipeline into an executable delegate.
+    /// </summary>
+    /// <returns>
+    /// A delegate that accepts a <see cref="CommandContext"/> and <see cref="CancellationToken"/>,
+    /// executes all phases in order, and returns an exit code.
+    /// </returns>
+    public Func<CommandContext, CancellationToken, Task<int>> Build()
+    {
+        // Terminal handler returns success (exit code 0)
+        Func<CommandContext, CancellationToken, Task<int>> pipeline =
+            (_, _) => Task.FromResult(0);
+
+        // Wrap phases in reverse order so first-added executes first
+        foreach (var phase in ((IEnumerable<ICommandPhase>)_phases).Reverse())
+        {
+            var current = pipeline;
+            pipeline = (ctx, ct) => phase.ExecuteAsync(ctx, current, ct);
+        }
+
+        return pipeline;
+    }
+}

--- a/src/DraftSpec.Cli/Pipeline/ConditionalPhase.cs
+++ b/src/DraftSpec.Cli/Pipeline/ConditionalPhase.cs
@@ -1,0 +1,40 @@
+namespace DraftSpec.Cli.Pipeline;
+
+/// <summary>
+/// Wrapper phase that conditionally executes an inner phase based on a predicate.
+/// </summary>
+/// <remarks>
+/// Used internally by <see cref="CommandPipelineBuilder.UseWhen"/> to implement
+/// conditional phase execution. If the predicate returns false, the inner phase
+/// is skipped and the next phase in the pipeline is called directly.
+/// </remarks>
+internal class ConditionalPhase : ICommandPhase
+{
+    private readonly Func<CommandContext, bool> _predicate;
+    private readonly ICommandPhase _inner;
+
+    /// <summary>
+    /// Create a conditional phase wrapper.
+    /// </summary>
+    /// <param name="predicate">Condition to evaluate. If true, inner phase executes.</param>
+    /// <param name="inner">The phase to conditionally execute.</param>
+    public ConditionalPhase(Func<CommandContext, bool> predicate, ICommandPhase inner)
+    {
+        _predicate = predicate;
+        _inner = inner;
+    }
+
+    /// <inheritdoc />
+    public Task<int> ExecuteAsync(
+        CommandContext context,
+        Func<CommandContext, CancellationToken, Task<int>> pipeline,
+        CancellationToken ct)
+    {
+        if (_predicate(context))
+        {
+            return _inner.ExecuteAsync(context, pipeline, ct);
+        }
+
+        return pipeline(context, ct);
+    }
+}

--- a/src/DraftSpec.Cli/Pipeline/ContextKeys.cs
+++ b/src/DraftSpec.Cli/Pipeline/ContextKeys.cs
@@ -1,0 +1,48 @@
+namespace DraftSpec.Cli.Pipeline;
+
+/// <summary>
+/// Well-known keys for <see cref="CommandContext.Items"/> dictionary.
+/// Use these constants for phase-to-phase communication to ensure consistency.
+/// </summary>
+/// <remarks>
+/// Each phase documents which keys it requires and produces. See individual
+/// phase documentation for the expected types and semantics of each key.
+/// </remarks>
+public static class ContextKeys
+{
+    /// <summary>
+    /// Resolved absolute path to the project/spec directory.
+    /// Type: <see cref="string"/>
+    /// </summary>
+    public const string ProjectPath = nameof(ProjectPath);
+
+    /// <summary>
+    /// List of discovered spec file paths.
+    /// Type: <c>IReadOnlyList&lt;string&gt;</c>
+    /// </summary>
+    public const string SpecFiles = nameof(SpecFiles);
+
+    /// <summary>
+    /// Parsed spec definitions from spec files.
+    /// Type: <c>IReadOnlyList&lt;ParsedSpec&gt;</c>
+    /// </summary>
+    public const string ParsedSpecs = nameof(ParsedSpecs);
+
+    /// <summary>
+    /// Whether quarantine mode is enabled.
+    /// Type: <see cref="bool"/>
+    /// </summary>
+    public const string Quarantine = nameof(Quarantine);
+
+    /// <summary>
+    /// Active filter options for spec selection.
+    /// Type: <c>FilterOptions</c>
+    /// </summary>
+    public const string Filter = nameof(Filter);
+
+    /// <summary>
+    /// Results from spec execution.
+    /// Type: <c>IReadOnlyList&lt;SpecResult&gt;</c>
+    /// </summary>
+    public const string RunResults = nameof(RunResults);
+}

--- a/src/DraftSpec.Cli/Pipeline/ICommandPhase.cs
+++ b/src/DraftSpec.Cli/Pipeline/ICommandPhase.cs
@@ -1,0 +1,44 @@
+namespace DraftSpec.Cli.Pipeline;
+
+/// <summary>
+/// A phase in the command execution pipeline.
+/// </summary>
+/// <remarks>
+/// Follows the middleware pattern, mirroring <c>ISpecMiddleware</c>. Phases can:
+/// <list type="bullet">
+/// <item><description>Run code before calling next (e.g., validation, setup)</description></item>
+/// <item><description>Run code after calling next (e.g., cleanup, output)</description></item>
+/// <item><description>Modify the context Items for downstream phases</description></item>
+/// <item><description>Short-circuit by returning without calling next</description></item>
+/// </list>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class PathResolutionPhase : ICommandPhase
+/// {
+///     public async Task&lt;int&gt; ExecuteAsync(
+///         CommandContext context,
+///         Func&lt;CommandContext, CancellationToken, Task&lt;int&gt;&gt; pipeline,
+///         CancellationToken ct)
+///     {
+///         var resolved = Path.GetFullPath(context.Path);
+///         context.Set&lt;string&gt;(ContextKeys.ProjectPath, resolved);
+///         return await pipeline(context, ct);
+///     }
+/// }
+/// </code>
+/// </example>
+public interface ICommandPhase
+{
+    /// <summary>
+    /// Execute the phase asynchronously, optionally calling the next phase.
+    /// </summary>
+    /// <param name="context">Command context with path, console, file system, and Items dictionary.</param>
+    /// <param name="pipeline">Delegate to invoke the next phase in the pipeline.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Exit code (0 for success, non-zero for failure).</returns>
+    Task<int> ExecuteAsync(
+        CommandContext context,
+        Func<CommandContext, CancellationToken, Task<int>> pipeline,
+        CancellationToken ct);
+}

--- a/tests/DraftSpec.Tests/Cli/Pipeline/CommandPipelineBuilderTests.cs
+++ b/tests/DraftSpec.Tests/Cli/Pipeline/CommandPipelineBuilderTests.cs
@@ -1,0 +1,388 @@
+using DraftSpec.Cli.Pipeline;
+using DraftSpec.Tests.Infrastructure.Mocks;
+
+namespace DraftSpec.Tests.Cli.Pipeline;
+
+/// <summary>
+/// Tests for <see cref="CommandPipelineBuilder"/>.
+/// </summary>
+public class CommandPipelineBuilderTests
+{
+    #region Build Tests
+
+    [Test]
+    public async Task Build_NoPhases_ReturnsZero()
+    {
+        var pipeline = new CommandPipelineBuilder().Build();
+        var context = CreateContext();
+
+        var result = await pipeline(context, CancellationToken.None);
+
+        await Assert.That(result).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Build_SinglePhase_ExecutesPhase()
+    {
+        var executed = false;
+        var phase = new TestPhase(() => executed = true);
+        var pipeline = new CommandPipelineBuilder()
+            .Use(phase)
+            .Build();
+        var context = CreateContext();
+
+        await pipeline(context, CancellationToken.None);
+
+        await Assert.That(executed).IsTrue();
+    }
+
+    [Test]
+    public async Task Build_MultiplePhases_ExecutesInOrder()
+    {
+        var order = new List<int>();
+        var pipeline = new CommandPipelineBuilder()
+            .Use(new TestPhase(() => order.Add(1)))
+            .Use(new TestPhase(() => order.Add(2)))
+            .Use(new TestPhase(() => order.Add(3)))
+            .Build();
+        var context = CreateContext();
+
+        await pipeline(context, CancellationToken.None);
+
+        await Assert.That(order).IsEquivalentTo([1, 2, 3]);
+    }
+
+    [Test]
+    public async Task Build_ReturnsPhaseExitCode()
+    {
+        var pipeline = new CommandPipelineBuilder()
+            .Use(new ExitCodePhase(42))
+            .Build();
+        var context = CreateContext();
+
+        var result = await pipeline(context, CancellationToken.None);
+
+        await Assert.That(result).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Build_LastPhaseExitCode_Propagates()
+    {
+        var pipeline = new CommandPipelineBuilder()
+            .Use(new TestPhase(() => { }))  // passes through
+            .Use(new ExitCodePhase(99))
+            .Build();
+        var context = CreateContext();
+
+        var result = await pipeline(context, CancellationToken.None);
+
+        await Assert.That(result).IsEqualTo(99);
+    }
+
+    #endregion
+
+    #region UseWhen Tests
+
+    [Test]
+    public async Task UseWhen_PredicateTrue_ExecutesPhase()
+    {
+        var executed = false;
+        var pipeline = new CommandPipelineBuilder()
+            .UseWhen(_ => true, new TestPhase(() => executed = true))
+            .Build();
+        var context = CreateContext();
+
+        await pipeline(context, CancellationToken.None);
+
+        await Assert.That(executed).IsTrue();
+    }
+
+    [Test]
+    public async Task UseWhen_PredicateFalse_SkipsPhase()
+    {
+        var executed = false;
+        var pipeline = new CommandPipelineBuilder()
+            .UseWhen(_ => false, new TestPhase(() => executed = true))
+            .Build();
+        var context = CreateContext();
+
+        await pipeline(context, CancellationToken.None);
+
+        await Assert.That(executed).IsFalse();
+    }
+
+    [Test]
+    public async Task UseWhen_PredicateFalse_ContinuesToNextPhase()
+    {
+        var order = new List<int>();
+        var pipeline = new CommandPipelineBuilder()
+            .Use(new TestPhase(() => order.Add(1)))
+            .UseWhen(_ => false, new TestPhase(() => order.Add(2)))
+            .Use(new TestPhase(() => order.Add(3)))
+            .Build();
+        var context = CreateContext();
+
+        await pipeline(context, CancellationToken.None);
+
+        await Assert.That(order).IsEquivalentTo([1, 3]);
+    }
+
+    [Test]
+    public async Task UseWhen_PredicateReadsContext_Works()
+    {
+        var executed = false;
+        var pipeline = new CommandPipelineBuilder()
+            .UseWhen(ctx => ctx.Get<bool>("flag"), new TestPhase(() => executed = true))
+            .Build();
+        var context = CreateContext();
+        context.Set("flag", true);
+
+        await pipeline(context, CancellationToken.None);
+
+        await Assert.That(executed).IsTrue();
+    }
+
+    #endregion
+
+    #region Short-Circuit Tests
+
+    [Test]
+    public async Task Phase_DoesNotCallNext_ShortCircuits()
+    {
+        var secondExecuted = false;
+        var pipeline = new CommandPipelineBuilder()
+            .Use(new ShortCircuitPhase(1))
+            .Use(new TestPhase(() => secondExecuted = true))
+            .Build();
+        var context = CreateContext();
+
+        var result = await pipeline(context, CancellationToken.None);
+
+        await Assert.That(secondExecuted).IsFalse();
+        await Assert.That(result).IsEqualTo(1);
+    }
+
+    #endregion
+
+    #region Context Sharing Tests
+
+    [Test]
+    public async Task Phase_CanModifyContext_NextPhaseSeesChanges()
+    {
+        string? capturedValue = null;
+        var pipeline = new CommandPipelineBuilder()
+            .Use(new ContextWriterPhase("key", "value"))
+            .Use(new ContextReaderPhase("key", v => capturedValue = v))
+            .Build();
+        var context = CreateContext();
+
+        await pipeline(context, CancellationToken.None);
+
+        await Assert.That(capturedValue).IsEqualTo("value");
+    }
+
+    [Test]
+    public async Task Phase_ContextChanges_VisibleAfterPipeline()
+    {
+        var pipeline = new CommandPipelineBuilder()
+            .Use(new ContextWriterPhase(ContextKeys.ProjectPath, "/resolved/path"))
+            .Build();
+        var context = CreateContext();
+
+        await pipeline(context, CancellationToken.None);
+
+        await Assert.That(context.Get<string>(ContextKeys.ProjectPath)).IsEqualTo("/resolved/path");
+    }
+
+    [Test]
+    public async Task Context_Get_MissingKey_ReturnsDefault()
+    {
+        var context = CreateContext();
+
+        var result = context.Get<string>("nonexistent-key");
+
+        await Assert.That(result).IsNull();
+    }
+
+    #endregion
+
+    #region Cancellation Tests
+
+    [Test]
+    public async Task Phase_ReceivesCancellationToken()
+    {
+        using var cts = new CancellationTokenSource();
+        CancellationToken? capturedToken = null;
+        var phase = new TokenCapturingPhase(t => capturedToken = t);
+        var pipeline = new CommandPipelineBuilder()
+            .Use(phase)
+            .Build();
+        var context = CreateContext();
+
+        await pipeline(context, cts.Token);
+
+        await Assert.That(capturedToken).IsEqualTo(cts.Token);
+    }
+
+    #endregion
+
+    #region Argument Validation Tests
+
+    [Test]
+    public void Use_NullPhase_ThrowsArgumentNullException()
+    {
+        var builder = new CommandPipelineBuilder();
+
+        Assert.Throws<ArgumentNullException>(() => builder.Use(null!));
+    }
+
+    [Test]
+    public void UseWhen_NullPredicate_ThrowsArgumentNullException()
+    {
+        var builder = new CommandPipelineBuilder();
+
+        Assert.Throws<ArgumentNullException>(() => builder.UseWhen(null!, new TestPhase(() => { })));
+    }
+
+    [Test]
+    public void UseWhen_NullPhase_ThrowsArgumentNullException()
+    {
+        var builder = new CommandPipelineBuilder();
+
+        Assert.Throws<ArgumentNullException>(() => builder.UseWhen(_ => true, null!));
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static CommandContext CreateContext() => new()
+    {
+        Path = "/test/path",
+        Console = new MockConsole(),
+        FileSystem = new MockFileSystem()
+    };
+
+    #endregion
+
+    #region Helper Classes
+
+    private class TestPhase : ICommandPhase
+    {
+        private readonly Action _onExecute;
+
+        public TestPhase(Action onExecute)
+        {
+            _onExecute = onExecute;
+        }
+
+        public async Task<int> ExecuteAsync(
+            CommandContext context,
+            Func<CommandContext, CancellationToken, Task<int>> pipeline,
+            CancellationToken ct)
+        {
+            _onExecute();
+            return await pipeline(context, ct);
+        }
+    }
+
+    private class ExitCodePhase : ICommandPhase
+    {
+        private readonly int _exitCode;
+
+        public ExitCodePhase(int exitCode)
+        {
+            _exitCode = exitCode;
+        }
+
+        public Task<int> ExecuteAsync(
+            CommandContext context,
+            Func<CommandContext, CancellationToken, Task<int>> pipeline,
+            CancellationToken ct)
+        {
+            return Task.FromResult(_exitCode);
+        }
+    }
+
+    private class ShortCircuitPhase : ICommandPhase
+    {
+        private readonly int _exitCode;
+
+        public ShortCircuitPhase(int exitCode)
+        {
+            _exitCode = exitCode;
+        }
+
+        public Task<int> ExecuteAsync(
+            CommandContext context,
+            Func<CommandContext, CancellationToken, Task<int>> pipeline,
+            CancellationToken ct)
+        {
+            // Don't call pipeline - short circuit
+            return Task.FromResult(_exitCode);
+        }
+    }
+
+    private class ContextWriterPhase : ICommandPhase
+    {
+        private readonly string _key;
+        private readonly object _value;
+
+        public ContextWriterPhase(string key, object value)
+        {
+            _key = key;
+            _value = value;
+        }
+
+        public async Task<int> ExecuteAsync(
+            CommandContext context,
+            Func<CommandContext, CancellationToken, Task<int>> pipeline,
+            CancellationToken ct)
+        {
+            context.Items[_key] = _value;
+            return await pipeline(context, ct);
+        }
+    }
+
+    private class ContextReaderPhase : ICommandPhase
+    {
+        private readonly string _key;
+        private readonly Action<string?> _onRead;
+
+        public ContextReaderPhase(string key, Action<string?> onRead)
+        {
+            _key = key;
+            _onRead = onRead;
+        }
+
+        public async Task<int> ExecuteAsync(
+            CommandContext context,
+            Func<CommandContext, CancellationToken, Task<int>> pipeline,
+            CancellationToken ct)
+        {
+            _onRead(context.Get<string>(_key));
+            return await pipeline(context, ct);
+        }
+    }
+
+    private class TokenCapturingPhase : ICommandPhase
+    {
+        private readonly Action<CancellationToken> _onCapture;
+
+        public TokenCapturingPhase(Action<CancellationToken> onCapture)
+        {
+            _onCapture = onCapture;
+        }
+
+        public async Task<int> ExecuteAsync(
+            CommandContext context,
+            Func<CommandContext, CancellationToken, Task<int>> pipeline,
+            CancellationToken ct)
+        {
+            _onCapture(ct);
+            return await pipeline(context, ct);
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Add core pipeline infrastructure for the unified command architecture (ADR-008):

- `ICommandPhase`: middleware-style interface mirroring `ISpecMiddleware`
- `CommandContext`: flat context with Path, Console, FileSystem, and Items dictionary
- `ContextKeys`: well-known keys for phase-to-phase communication
- `CommandPipelineBuilder`: fluent API with `Use()` and `UseWhen()`
- `ConditionalPhase`: internal wrapper for conditional phase execution

This is the foundational piece that enables all subsequent command migrations in the v0.8.1 milestone.

## Test plan

- [x] 17 unit tests covering execution order, short-circuit, context sharing (including missing key path), cancellation, and argument validation
- [x] All 3821 existing tests still pass

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)